### PR TITLE
Fix threshold lines checkboxes

### DIFF
--- a/ClassModules/Options/RogueOptions.lua
+++ b/ClassModules/Options/RogueOptions.lua
@@ -968,7 +968,7 @@ local function AssassinationConstructThresholdPanel(parent)
 		spec.thresholds.thresholdDictionary.crimsonTempest.enabled = self:GetChecked()
 	end)
 
-	yCoord2 = yCoord2 - 25
+	yCoord = yCoord - 25
 	controls.checkBoxes.fanOfKnivesThresholdShow = CreateFrame("CheckButton", "TwintopResourceBar_Rogue_Assassination_Threshold_Option_fanOfKnives", parent, "ChatConfigCheckButtonTemplate")
 	f = controls.checkBoxes.fanOfKnivesThresholdShow
 	f:SetPoint("TOPLEFT", oUi.xCoord, yCoord)


### PR DESCRIPTION
Hey i was checking changes for Assassination Rogue for an alt to play later in the season and notice the `Fan of Knives` checkbox overlapping with `Crimson Tempest` checkbox 

<img width="433" height="122" alt="image" src="https://github.com/user-attachments/assets/8fd0c066-9a08-4b14-bca0-01b099754863" />
<img width="455" height="99" alt="image" src="https://github.com/user-attachments/assets/44c560b1-0bf2-4b7e-b4fc-2beb8b05fe1f" />
