### PR TITLE
Fix color text while being at or above overcap threshold

### DIFF
--- a/ClassModules/Rogue.lua
+++ b/ClassModules/Rogue.lua
@@ -694,7 +694,7 @@ local function RefreshLookupData_Assassination()
 		if sharedSettings.colors.text.overThreshold.enabled then
 			local _overThreshold = false
 			for _, spell --[[@as TRB.Classes.SpellThreshold]] in ipairs(TRB.Data.cache.thresholdSpells) do
-				if spell ~= nil and spell.primaryResourceType ~= nil and (spell.baseline or talents.talents[spell.id]:IsActive()) and spell:GetPrimaryResourceCost() >= snapshotData.attributes.resource then
+				if spell ~= nil and spell.resource and (spell.baseline or talents.talents[spell.id]:IsActive()) and spell:GetPrimaryResourceCost() >= snapshotData.attributes.resource then
 					_overThreshold = true
 					break
 				end
@@ -2230,9 +2230,6 @@ function TRB.Functions.Class:CheckCharacter()
 			end
 			-- Rebuild secondary bar layout when combo point count changes
 			if barGroups and barGroups.secondary then
-				-- Clear cached node count so ApplyBarGroupsLayout uses the new maxResource2
-				barGroups.secondary.lastRebuildNodeCount = nil
-				
 				barGroups.secondary:SetMaxNodes(maxComboPoints)
 				barGroups.secondary:SetNodeCount(maxComboPoints)
 				barGroups.secondary:SetLayout(sharedSettings.comboPoints.spacing, sharedSettings.comboPoints.fullWidth, "HORIZONTAL")

--- a/ClassModules/Rogue.lua
+++ b/ClassModules/Rogue.lua
@@ -2230,6 +2230,9 @@ function TRB.Functions.Class:CheckCharacter()
 			end
 			-- Rebuild secondary bar layout when combo point count changes
 			if barGroups and barGroups.secondary then
+				-- Clear cached node count so ApplyBarGroupsLayout uses the new maxResource2
+				barGroups.secondary.lastRebuildNodeCount = nil
+				
 				barGroups.secondary:SetMaxNodes(maxComboPoints)
 				barGroups.secondary:SetNodeCount(maxComboPoints)
 				barGroups.secondary:SetLayout(sharedSettings.comboPoints.spacing, sharedSettings.comboPoints.fullWidth, "HORIZONTAL")


### PR DESCRIPTION
So this is weird but changing `spell.primaryResourceType ~= nil` to `spell.resource` fix the color text while being max energy for example _but_ color text for being over threshold line (f.e Garrote) is still not working and i can't figured it out 