### PR TITLE
Bar flicker fix

### DIFF
--- a/ClassModules/DeathKnight.lua
+++ b/ClassModules/DeathKnight.lua
@@ -313,8 +313,6 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	-- TRB.Functions.Bar:HideResourceBar() -- This is the generic one, but we are supposed to call Class:HideResourceBar?
-    -- Actually, we should probably just call TriggerResourceBarUpdates which calls HideResourceBar(true) if needed.
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 

--- a/ClassModules/DeathKnight.lua
+++ b/ClassModules/DeathKnight.lua
@@ -313,7 +313,8 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	TRB.Functions.Bar:HideResourceBar()
+	-- TRB.Functions.Bar:HideResourceBar() -- This is the generic one, but we are supposed to call Class:HideResourceBar?
+    -- Actually, we should probably just call TriggerResourceBarUpdates which calls HideResourceBar(true) if needed.
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -1090,6 +1091,11 @@ function targetsTimerFrame:onUpdate(sinceLastUpdate)
 end
 
 local function SwitchSpec()
+	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+		TRB.Functions.Bar:HideResourceBar(true)
+	end
 	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 	
@@ -1173,7 +1179,6 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				ConstructResourceBar(specCache[TRB.Data.barConstructedForSpec].settings)
 				TRB.Functions.Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
 				TRB.Functions.Character:UpdateHealthValues()
@@ -1295,6 +1300,11 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 			end
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
+				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+					TRB.Functions.Bar:HideResourceBar(true)
+				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
 						SwitchSpec()
@@ -1619,6 +1629,11 @@ function TRB.Functions.Class:GetBarTextFrame(relativeToFrame)
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
+		TRB.Functions.Bar:HideResourceBar(true)
+		return
+	end
+
 	if not TRB.Data.specSupported or talents == nil then
 		return
 	end

--- a/ClassModules/DemonHunter.lua
+++ b/ClassModules/DemonHunter.lua
@@ -289,7 +289,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	TRB.Functions.Bar:HideResourceBar()
+	-- TRB.Functions.Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -1238,6 +1238,11 @@ function targetsTimerFrame:onUpdate(sinceLastUpdate)
 end
 
 local function SwitchSpec()
+	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+		TRB.Functions.Bar:HideResourceBar(true)
+	end
 	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 	soulFragmentsFrame:UnregisterEvent("SPELL_UPDATE_USES")
@@ -1359,7 +1364,6 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				ConstructResourceBar(specCache[TRB.Data.barConstructedForSpec].settings)
 				TRB.Functions.Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
 				TRB.Functions.Character:UpdateHealthValues()
@@ -1481,6 +1485,11 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 			end
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
+				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+					TRB.Functions.Bar:HideResourceBar(true)
+				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
 						SwitchSpec()
@@ -1861,6 +1870,11 @@ function TRB.Functions.Class:RecreateThresholds(settings, barGroups)
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
+		TRB.Functions.Bar:HideResourceBar(true)
+		return
+	end
+
 	if not TRB.Data.specSupported or talents == nil then
 		return
 	end

--- a/ClassModules/Druid.lua
+++ b/ClassModules/Druid.lua
@@ -554,7 +554,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	TRB.Functions.Bar:HideResourceBar()
+	-- TRB.Functions.Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -2467,6 +2467,11 @@ function targetsTimerFrame:onUpdate(sinceLastUpdate)
 end
 
 local function SwitchSpec()
+	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+		TRB.Functions.Bar:HideResourceBar(true)
+	end
 	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 	
@@ -2640,7 +2645,6 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				ConstructResourceBar(specCache[TRB.Data.barConstructedForSpec].settings)
 				TRB.Functions.Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
 				TRB.Functions.Character:UpdateHealthValues()
@@ -2784,6 +2788,11 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 			end
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
+				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+					TRB.Functions.Bar:HideResourceBar(true)
+				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
 						SwitchSpec()
@@ -3389,6 +3398,11 @@ function TRB.Functions.Class:GetBarTextFrame(relativeToFrame)
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
+		TRB.Functions.Bar:HideResourceBar(true)
+		return
+	end
+
 	if not TRB.Data.specSupported or talents == nil then
 		return
 	end

--- a/ClassModules/Evoker.lua
+++ b/ClassModules/Evoker.lua
@@ -248,7 +248,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	TRB.Functions.Bar:HideResourceBar()
+	-- TRB.Functions.Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -931,6 +931,11 @@ function targetsTimerFrame:onUpdate(sinceLastUpdate)
 end
 
 local function SwitchSpec()
+	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+		TRB.Functions.Bar:HideResourceBar(true)
+	end
 	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 	if TRB.Data.character.specId == 1 then
@@ -1021,7 +1026,6 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				ConstructResourceBar(specCache[TRB.Data.barConstructedForSpec].settings)
 				TRB.Functions.Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
 				TRB.Functions.Character:UpdateHealthValues()
@@ -1143,6 +1147,11 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 			end
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
+				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+					TRB.Functions.Bar:HideResourceBar(true)
+				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
 						SwitchSpec()
@@ -1455,6 +1464,11 @@ function TRB.Functions.Class:GetBarTextFrame(relativeToFrame)
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
+		TRB.Functions.Bar:HideResourceBar(true)
+		return
+	end
+
 	if not TRB.Data.specSupported or talents == nil then
 		return
 	end

--- a/ClassModules/Hunter.lua
+++ b/ClassModules/Hunter.lua
@@ -261,7 +261,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	TRB.Functions.Bar:HideResourceBar()
+	-- TRB.Functions.Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -1169,6 +1169,11 @@ function targetsTimerFrame:onUpdate(sinceLastUpdate)
 end
 
 local function SwitchSpec()
+	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+		TRB.Functions.Bar:HideResourceBar(true)
+	end
 	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 
@@ -1287,7 +1292,6 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				ConstructResourceBar(specCache[TRB.Data.barConstructedForSpec].settings)
 				TRB.Functions.Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
 				TRB.Functions.Character:UpdateHealthValues()
@@ -1409,6 +1413,11 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 			end
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
+				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+					TRB.Functions.Bar:HideResourceBar(true)
+				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
 						SwitchSpec()
@@ -1647,6 +1656,11 @@ function TRB.Functions.Class:GetBarTextFrame(relativeToFrame)
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
+		TRB.Functions.Bar:HideResourceBar(true)
+		return
+	end
+
 	if not TRB.Data.specSupported or talents == nil then
 		return
 	end

--- a/ClassModules/Mage.lua
+++ b/ClassModules/Mage.lua
@@ -284,7 +284,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	TRB.Functions.Bar:HideResourceBar()
+	-- TRB.Functions.Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -700,6 +700,11 @@ function targetsTimerFrame:onUpdate(sinceLastUpdate)
 end
 
 local function SwitchSpec()
+	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+		TRB.Functions.Bar:HideResourceBar(true)
+	end
 	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 	
@@ -792,7 +797,6 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				ConstructResourceBar(specCache[TRB.Data.barConstructedForSpec].settings)
 				TRB.Functions.Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
 				TRB.Functions.Character:UpdateHealthValues()
@@ -914,6 +918,11 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 			end
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
+				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+					TRB.Functions.Bar:HideResourceBar(true)
+				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
 						SwitchSpec()
@@ -1205,6 +1214,11 @@ function TRB.Functions.Class:GetBarTextFrame(relativeToFrame)
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
+		TRB.Functions.Bar:HideResourceBar(true)
+		return
+	end
+
 	if not TRB.Data.specSupported or talents == nil then
 		return
 	end

--- a/ClassModules/Monk.lua
+++ b/ClassModules/Monk.lua
@@ -333,7 +333,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	TRB.Functions.Bar:HideResourceBar()
+	-- TRB.Functions.Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -1306,6 +1306,11 @@ function targetsTimerFrame:onUpdate(sinceLastUpdate)
 end
 
 local function SwitchSpec()
+	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+		TRB.Functions.Bar:HideResourceBar(true)
+	end
 	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 
@@ -1426,7 +1431,6 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				ConstructResourceBar(specCache[TRB.Data.barConstructedForSpec].settings)
 				TRB.Functions.Character:ResetCaches()
 				-- Reapply bar textures after spec switch to ensure health bar and other bar textures render correctly
 				if TRB.Frames.barGroups then
@@ -1549,6 +1553,11 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 			end
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
+				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+					TRB.Functions.Bar:HideResourceBar(true)
+				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
 						SwitchSpec()
@@ -2016,6 +2025,11 @@ function TRB.Functions.Class:RecreateThresholds(settings, barGroups)
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
+		TRB.Functions.Bar:HideResourceBar(true)
+		return
+	end
+
 	if not TRB.Data.specSupported or talents == nil then
 		return
 	end

--- a/ClassModules/Paladin.lua
+++ b/ClassModules/Paladin.lua
@@ -291,7 +291,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	TRB.Functions.Bar:HideResourceBar()
+	-- TRB.Functions.Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -815,6 +815,11 @@ function targetsTimerFrame:onUpdate(sinceLastUpdate)
 end
 
 local function SwitchSpec()
+	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+		TRB.Functions.Bar:HideResourceBar(true)
+	end
 	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 	
@@ -905,7 +910,6 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				ConstructResourceBar(specCache[TRB.Data.barConstructedForSpec].settings)
 				TRB.Functions.Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
 				TRB.Functions.Character:UpdateHealthValues()
@@ -1027,6 +1031,11 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 			end
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
+				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+					TRB.Functions.Bar:HideResourceBar(true)
+				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
 						SwitchSpec()
@@ -1314,6 +1323,11 @@ function TRB.Functions.Class:GetBarTextFrame(relativeToFrame)
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
+		TRB.Functions.Bar:HideResourceBar(true)
+		return
+	end
+
 	if not TRB.Data.specSupported or talents == nil then
 		return
 	end

--- a/ClassModules/Priest.lua
+++ b/ClassModules/Priest.lua
@@ -348,7 +348,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	TRB.Functions.Bar:HideResourceBar()
+	-- TRB.Functions.Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -1692,6 +1692,11 @@ function targetsTimerFrame:onUpdate(sinceLastUpdate)
 end
 
 local function SwitchSpec()
+	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+		TRB.Functions.Bar:HideResourceBar(true)
+	end
 	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization() or 0
 
@@ -1875,7 +1880,6 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				ConstructResourceBar(specCache[TRB.Data.barConstructedForSpec].settings)
 				TRB.Functions.Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
 				TRB.Functions.Character:UpdateHealthValues()
@@ -1994,6 +1998,11 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 			end
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
+				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+					TRB.Functions.Bar:HideResourceBar(true)
+				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
 						SwitchSpec()
@@ -2511,6 +2520,11 @@ function TRB.Functions.Class:GetBarTextFrame(relativeToFrame)
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
+		TRB.Functions.Bar:HideResourceBar(true)
+		return
+	end
+
 	if not TRB.Data.specSupported or talents == nil then
 		return
 	end

--- a/ClassModules/Rogue.lua
+++ b/ClassModules/Rogue.lua
@@ -460,7 +460,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	TRB.Functions.Bar:HideResourceBar()
+	-- TRB.Functions.Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -1781,6 +1781,11 @@ function targetsTimerFrame:onUpdate(sinceLastUpdate)
 end
 
 local function SwitchSpec()
+	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+		TRB.Functions.Bar:HideResourceBar(true)
+	end
 	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 	coupDeGraceFrame:UnregisterEvent("COOLDOWN_VIEWER_SPELL_OVERRIDE_UPDATED")
@@ -1921,7 +1926,6 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				ConstructResourceBar(specCache[TRB.Data.barConstructedForSpec].settings)
 				TRB.Functions.Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
 				TRB.Functions.Character:UpdateHealthValues()
@@ -2043,6 +2047,11 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 			end
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
+				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+					TRB.Functions.Bar:HideResourceBar(true)
+				end
 				SwitchSpec()
 			end
 		end
@@ -2430,6 +2439,11 @@ function TRB.Functions.Class:GetBarTextFrame(relativeToFrame)
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
+		TRB.Functions.Bar:HideResourceBar(true)
+		return
+	end
+
 	if not TRB.Data.specSupported or talents == nil then
 		return
 	end

--- a/ClassModules/Shaman.lua
+++ b/ClassModules/Shaman.lua
@@ -268,7 +268,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	TRB.Functions.Bar:HideResourceBar()
+	-- TRB.Functions.Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -1203,6 +1203,11 @@ function targetsTimerFrame:onUpdate(sinceLastUpdate)
 end
 
 local function SwitchSpec()
+	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+		TRB.Functions.Bar:HideResourceBar(true)
+	end
 	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 
@@ -1311,7 +1316,6 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				ConstructResourceBar(specCache[TRB.Data.barConstructedForSpec].settings)
 				TRB.Functions.Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
 				TRB.Functions.Character:UpdateHealthValues()
@@ -1432,6 +1436,11 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 			end
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
+				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+					TRB.Functions.Bar:HideResourceBar(true)
+				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
 						SwitchSpec()
@@ -1853,6 +1862,11 @@ function TRB.Functions.Class:GetBarTextFrame(relativeToFrame)
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
+		TRB.Functions.Bar:HideResourceBar(true)
+		return
+	end
+
 	if not TRB.Data.specSupported or talents == nil then
 		return
 	end

--- a/ClassModules/Warlock.lua
+++ b/ClassModules/Warlock.lua
@@ -285,7 +285,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	TRB.Functions.Bar:HideResourceBar()
+	-- TRB.Functions.Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -809,6 +809,11 @@ function targetsTimerFrame:onUpdate(sinceLastUpdate)
 end
 
 local function SwitchSpec()
+	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+		TRB.Functions.Bar:HideResourceBar(true)
+	end
 	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 
@@ -904,7 +909,6 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				ConstructResourceBar(specCache[TRB.Data.barConstructedForSpec].settings)
 				TRB.Functions.Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
 				TRB.Functions.Character:UpdateHealthValues()
@@ -1026,6 +1030,11 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 			end
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
+				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+					TRB.Functions.Bar:HideResourceBar(true)
+				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
 						SwitchSpec()
@@ -1320,6 +1329,11 @@ function TRB.Functions.Class:GetBarTextFrame(relativeToFrame)
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
+		TRB.Functions.Bar:HideResourceBar(true)
+		return
+	end
+
 	if not TRB.Data.specSupported or talents == nil then
 		return
 	end

--- a/ClassModules/Warrior.lua
+++ b/ClassModules/Warrior.lua
@@ -279,7 +279,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	TRB.Functions.Bar:HideResourceBar()
+	-- TRB.Functions.Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -1108,6 +1108,11 @@ function targetsTimerFrame:onUpdate(sinceLastUpdate)
 end
 
 local function SwitchSpec()
+	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+		TRB.Functions.Bar:HideResourceBar(true)
+	end
 	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 	
@@ -1215,7 +1220,6 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				ConstructResourceBar(specCache[TRB.Data.barConstructedForSpec].settings)
 				TRB.Functions.Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
 				TRB.Functions.Character:UpdateHealthValues()
@@ -1337,6 +1341,11 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 			end
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
+				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
+					TRB.Functions.Bar:HideResourceBar(true)
+				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
 						SwitchSpec()
@@ -1661,6 +1670,11 @@ function TRB.Functions.Class:GetBarTextFrame(relativeToFrame)
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
+		TRB.Functions.Bar:HideResourceBar(true)
+		return
+	end
+
 	if not TRB.Data.specSupported or talents == nil then
 		return
 	end

--- a/Classes/Bar.lua
+++ b/Classes/Bar.lua
@@ -270,8 +270,20 @@ function TRB.Classes.BarNode:SetFrameStrata(strata)
 	self.resourceFrame:SetFrameStrata(strata)
 end
 
+---Sets the node's alpha transparency
+---@param alpha number
+function TRB.Classes.BarNode:SetAlpha(alpha)
+	self.containerFrame:SetAlpha(alpha)
+end
+
 ---Shows the node
 function TRB.Classes.BarNode:Show()
+	if TRB.Functions and TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
+		self.containerFrame:SetAlpha(0)
+	else
+		self.containerFrame:SetAlpha(1)
+	end
+
 	self.containerFrame:Show()
 	self.resourceFrame:Show()
 	if self.border >= 1 then
@@ -504,6 +516,23 @@ function TRB.Classes.BarGroup:GetNodeCount()
 	return self.nodeCount
 end
 
+---Gets the container frame
+---@return Frame
+function TRB.Classes.BarGroup:GetContainerFrame()
+	return self.containerFrame
+end
+
+---Sets the alpha of the group container and all nodes
+---@param alpha number
+function TRB.Classes.BarGroup:SetAlpha(alpha)
+	self.containerFrame:SetAlpha(alpha)
+	for i = 1, self.maxNodes do
+		if self.nodes[i] then
+			self.nodes[i]:SetAlpha(alpha)
+		end
+	end
+end
+
 ---Gets all nodes
 ---@return TRB.Classes.BarNode[]
 function TRB.Classes.BarGroup:GetNodes()
@@ -676,6 +705,12 @@ end
 
 ---Shows the group container
 function TRB.Classes.BarGroup:Show()
+	if TRB.Functions and TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
+		self.containerFrame:SetAlpha(0)
+	else
+		self.containerFrame:SetAlpha(1)
+	end
+
 	self.containerFrame:Show()
 	self.isVisible = true
 end

--- a/Functions/Bar.lua
+++ b/Functions/Bar.lua
@@ -3,6 +3,78 @@ local _, TRB = ...
 TRB.Functions = TRB.Functions or {}
 TRB.Functions.Bar = {}
 
+local renderTransitionState = {
+	active = true,
+	token = 0,
+	reason = "init",
+	defaultDelay = 0.6
+}
+
+local function SetBarGroupsAlpha(alpha)
+	local barGroups = TRB.Frames.barGroups
+	if not barGroups then
+		return
+	end
+
+	for _, group in pairs(barGroups) do
+		if type(group) == "table" and group.SetAlpha then
+			group:SetAlpha(alpha)
+		elseif type(group) == "table" and group.GetContainerFrame then
+			local container = group:GetContainerFrame()
+			if container and container.SetAlpha then
+				container:SetAlpha(alpha)
+			end
+		end
+	end
+
+	-- Also handle legacy frames just in case
+	if TRB.Frames.barContainerFrame then
+		TRB.Frames.barContainerFrame:SetAlpha(alpha)
+	end
+	if TRB.Frames.resource2ContainerFrame then
+		TRB.Frames.resource2ContainerFrame:SetAlpha(alpha)
+	end
+end
+
+-- Initialize transition state early to prevent flash on load
+-- We'll clear this after a safe delay
+C_Timer.After(10, function()
+	if renderTransitionState.active and renderTransitionState.reason == "init" then
+		TRB.Functions.Bar:EndRenderTransition("init:timeout")
+	end
+end)
+
+local function HideAllBarGroupsAndBarText()
+	local barGroups = TRB.Frames.barGroups
+
+	if barGroups then
+		for _, group in pairs(barGroups) do
+			if type(group) == "table" and group.Hide then
+				group:Hide()
+			end
+		end
+	end
+
+	-- Brutally hide legacy frames
+	if TRB.Frames.barContainerFrame then
+		TRB.Frames.barContainerFrame:Hide()
+	end
+	if TRB.Frames.resource2ContainerFrame then
+		TRB.Frames.resource2ContainerFrame:Hide()
+	end
+
+	if TRB.Data.snapshotData and TRB.Data.snapshotData.attributes then
+		TRB.Data.snapshotData.attributes.isTracking = false
+	end
+
+	if TRB.Data.specCache and TRB.Data.character and TRB.Data.character.compositeKey and TRB.Functions.BarText and TRB.Functions.BarText.Hide then
+		local specCacheEntry = TRB.Data.specCache[TRB.Data.character.compositeKey]
+		if specCacheEntry and specCacheEntry.settings then
+			TRB.Functions.BarText:Hide(specCacheEntry.settings)
+		end
+	end
+end
+
 ---Computes the width of each Combo Point node
 ---@param settings TRB.Classes.Settings.SpecializationSettingsBase
 ---@return number
@@ -60,8 +132,80 @@ function TRB.Functions.Bar:ShowResourceBar()
 		TRB.Functions.Class:EventRegistration()
 	end
 
+	if self:IsRenderTransitionActive() then
+		return
+	end
+
 	TRB.Data.snapshotData.attributes.isTracking = true
 	TRB.Functions.Bar:HideResourceBar()
+end
+
+function TRB.Functions.Bar:IsRenderTransitionActive()
+	return renderTransitionState.active
+end
+
+function TRB.Functions.Bar:QueueRenderTransition(reason, delaySeconds)
+	local delay = delaySeconds or renderTransitionState.defaultDelay
+	if delay < 0 then
+		delay = 0
+	end
+
+	renderTransitionState.active = true
+	renderTransitionState.reason = reason
+	renderTransitionState.token = renderTransitionState.token + 1
+	local token = renderTransitionState.token
+	
+	-- Force immediate hide
+	HideAllBarGroupsAndBarText()
+	SetBarGroupsAlpha(0)
+
+	C_Timer.After(delay, function()
+		if renderTransitionState.active and renderTransitionState.token == token then
+			TRB.Functions.Bar:EndRenderTransition("timer")
+		end
+	end)
+end
+
+function TRB.Functions.Bar:TouchRenderTransition(delaySeconds)
+	if not renderTransitionState.active then
+		return
+	end
+
+	local delay = delaySeconds or renderTransitionState.defaultDelay
+	if delay < 0 then
+		delay = 0
+	end
+
+	renderTransitionState.token = renderTransitionState.token + 1
+	local token = renderTransitionState.token
+	
+	-- Re-enforce hide
+	HideAllBarGroupsAndBarText()
+	SetBarGroupsAlpha(0)
+
+	C_Timer.After(delay, function()
+		if renderTransitionState.active and renderTransitionState.token == token then
+			TRB.Functions.Bar:EndRenderTransition("activity")
+		end
+	end)
+end
+
+function TRB.Functions.Bar:EndRenderTransition(reason)
+	if not renderTransitionState.active then
+		return
+	end
+
+	renderTransitionState.active = false
+	renderTransitionState.reason = reason
+
+	TRB.Functions.Bar:HideResourceBar()
+	if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
+		TRB.Functions.Class:TriggerResourceBarUpdates()
+	end
+
+	-- Restore alpha only AFTER visibility logic has run
+	-- This prevents a single-frame flash where alpha becomes 1 while the bar is still technically "shown" but should be hidden
+	SetBarGroupsAlpha(1)
 end
 
 function TRB.Functions.Bar:HideResourceBar(force)
@@ -73,17 +217,12 @@ function TRB.Functions.Bar:HideResourceBar(force)
 
 	-- If spec is not supported (disabled), hide all bars immediately and skip all other logic
 	if not TRB.Data.specSupported then
-		local barGroups = TRB.Frames.barGroups
-		if barGroups then
-			for _, group in pairs(barGroups) do
-				if type(group) == "table" and group.Hide then
-					group:Hide()
-				end
-			end
-		end
-		if TRB.Data.snapshotData and TRB.Data.snapshotData.attributes then
-			TRB.Data.snapshotData.attributes.isTracking = false
-		end
+		HideAllBarGroupsAndBarText()
+		return
+	end
+
+	if self:IsRenderTransitionActive() then
+		HideAllBarGroupsAndBarText()
 		return
 	end
 
@@ -315,6 +454,13 @@ function TRB.Functions.Bar:ConstructBarGroups(settings, barGroups)
 		return
 	end
 
+	-- Pre-emptive hide before doing anything else
+	if self:IsRenderTransitionActive() then
+		SetBarGroupsAlpha(0)
+	end
+	
+	self:TouchRenderTransition(0.35)
+
 	-- Don't construct bars if spec is not supported (disabled in settings)
 	if not TRB.Data.specSupported then
 		return
@@ -341,6 +487,10 @@ function TRB.Functions.Bar:ConstructBarGroups(settings, barGroups)
 	TRB.Functions.BarText:CreateBarTextFrames()
 	TRB.Functions.BarText:Hide(settings)
 	TRB.Functions.Class:HideResourceBar()
+
+	if self:IsRenderTransitionActive() then
+		SetBarGroupsAlpha(0)
+	end
 end
 
 ---Applies size/position/layout updates to existing bar groups (OOP system only).
@@ -350,6 +500,13 @@ end
 function TRB.Functions.Bar:ApplyBarGroupsLayout(settings, barGroups)
 	if settings == nil or settings.bar == nil or barGroups == nil then
 		return
+	end
+
+	self:TouchRenderTransition(0.35)
+
+	-- If render transition is active, force alpha 0 to prevent flicker
+	if self:IsRenderTransitionActive() then
+		SetBarGroupsAlpha(0)
 	end
 
 	-- Don't apply layout if spec is not supported (disabled in settings)
@@ -494,6 +651,11 @@ function TRB.Functions.Bar:ApplyBarGroupsLayout(settings, barGroups)
 			-- Show the primary bar (now parented directly to UIParent)
 			primary:Show()
 			primaryNode:Show()
+
+			-- If render transition is active, keep it hidden (alpha 0) despite the Show() call
+			if self:IsRenderTransitionActive() then
+				SetBarGroupsAlpha(0)
+			end
 
 			-- Redraw thresholds to match new bar dimensions
 			local thresholds = primaryNode:GetThresholds()
@@ -731,6 +893,13 @@ end
 function TRB.Functions.Bar:ApplyBarGroupsAppearance(settings, barGroups)
 	if settings == nil or settings.bar == nil or barGroups == nil then
 		return
+	end
+
+	self:TouchRenderTransition(0.35)
+
+	-- If render transition is active, force alpha 0 to prevent flicker
+	if self:IsRenderTransitionActive() then
+		SetBarGroupsAlpha(0)
 	end
 
 	-- Clear color caches to ensure colors are re-applied after ApplyBackdrop resets frames
@@ -1154,6 +1323,11 @@ function TRB.Functions.Bar:ConstructAnchoredBarGroup(settings, anchorGroup, targ
 	if TRB.Data.specSupported then
 		targetGroup:Show()
 		targetGroup:ShowNodes(nodes)
+
+		-- If render transition is active, keep it hidden (alpha 0) despite the Show() call
+		if self:IsRenderTransitionActive() then
+			SetBarGroupsAlpha(0)
+		end
 	else
 		targetGroup:Hide()
 	end

--- a/Functions/BarText.lua
+++ b/Functions/BarText.lua
@@ -1247,13 +1247,19 @@ function TRB.Functions.BarText:CreateBarTextFrames(classId, specId)
 				font:SetTextColor(255/255, 255/255, 255/255, 1.0)
 				font:SetJustifyH(fontJustifyHorizontal)
 				font:SetFont(fontFace, fontSize, "OUTLINE")
-				font:Show()
 				font:ClearAllPoints()
 				font:SetPoint(relativeTo, relativeToFrame, relativeTo, e.position.xPos, e.position.yPos)
 				textFrames[frameCount]:SetParent(relativeToFrame)
 				textFrames[frameCount]:ClearAllPoints()
 				textFrames[frameCount]:SetAllPoints(font)
-				textFrames[frameCount]:Show()
+
+				if TRB.Functions.Bar:IsRenderTransitionActive() then
+					font:Hide()
+					textFrames[frameCount]:Hide()
+				else
+					font:Show()
+					textFrames[frameCount]:Show()
+				end
 			else
 				textFrames[frameCount]:Hide()
 				font:Hide()
@@ -1336,9 +1342,15 @@ function TRB.Functions.BarText:Show(settings)
 			end
 			
 			if e.enabled and isEnabled and isVisible and textFrames[i] ~= nil then
-				textFrames[i]:Show()
-				---@diagnostic disable-next-line: undefined-field
-				textFrames[i].font:Show()
+				if TRB.Functions.Bar:IsRenderTransitionActive() then
+					textFrames[i]:Hide()
+					---@diagnostic disable-next-line: undefined-field
+					textFrames[i].font:Hide()
+				else
+					textFrames[i]:Show()
+					---@diagnostic disable-next-line: undefined-field
+					textFrames[i].font:Show()
+				end
 			elseif textFrames[i] ~= nil then
 				textFrames[i]:Hide()
 				---@diagnostic disable-next-line: undefined-field

--- a/Functions/Character.lua
+++ b/Functions/Character.lua
@@ -244,6 +244,19 @@ end
 ---@param event string
 ---@param ... unknown
 local function CharacterChange(self, event, ...)
+	if event == "PLAYER_SPECIALIZATION_CHANGED" then
+		local unitTarget = ...
+		if unitTarget ~= "player" then
+			return
+		end
+	end
+
+	if event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED" then
+		if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+			TRB.Functions.Bar:QueueRenderTransition("characterChange:" .. event, 0.35)
+		end
+	end
+
 	if event == "UNIT_POWER_UPDATE" or event == "UNIT_POWER_FREQUENT" then
 		local unitTarget, powerType = ...
 		if unitTarget == "player" and (powerType == TRB.Data.resourceToken or powerType == TRB.Data.resource2Token) then
@@ -300,6 +313,8 @@ function TRB.Functions.Character:EnableCharacterChange()
 	characterChangeFrame:RegisterEvent("PET_BATTLE_OPENING_START")
 	characterChangeFrame:RegisterEvent("PET_BATTLE_CLOSE")
 	characterChangeFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+	characterChangeFrame:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
+	characterChangeFrame:RegisterEvent("TRAIT_CONFIG_UPDATED")
 end
 
 function TRB.Functions.Character:DisableCharacterChange()
@@ -315,6 +330,8 @@ function TRB.Functions.Character:DisableCharacterChange()
 	characterChangeFrame:UnregisterEvent("PET_BATTLE_OPENING_START")
 	characterChangeFrame:UnregisterEvent("PET_BATTLE_CLOSE")
 	characterChangeFrame:UnregisterEvent("PLAYER_ENTERING_WORLD")
+	characterChangeFrame:UnregisterEvent("PLAYER_SPECIALIZATION_CHANGED")
+	characterChangeFrame:UnregisterEvent("TRAIT_CONFIG_UPDATED")
 end
 
 ---Handles SPELL_RANGE_CHECK_UPDATE events

--- a/Init.lua
+++ b/Init.lua
@@ -359,6 +359,24 @@ TRB.Frames.combatFrame:SetScript("OnEvent", function(self, event, ...)
 	TRB.Functions.Bar:ShowResourceBar()
 end)
 
+TRB.Frames.renderTransitionFrame = CreateFrame("Frame")
+TRB.Frames.renderTransitionFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+TRB.Frames.renderTransitionFrame:RegisterEvent("ACTIVE_TALENT_GROUP_CHANGED")
+TRB.Frames.renderTransitionFrame:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
+TRB.Frames.renderTransitionFrame:RegisterEvent("PLAYER_TALENT_UPDATE")
+TRB.Frames.renderTransitionFrame:RegisterEvent("TRAIT_CONFIG_LIST_UPDATED")
+TRB.Frames.renderTransitionFrame:RegisterEvent("TRAIT_CONFIG_UPDATED")
+TRB.Frames.renderTransitionFrame:SetScript("OnEvent", function(self, event, arg1, ...)
+	if event == "PLAYER_SPECIALIZATION_CHANGED" and arg1 ~= "player" then
+		return
+	end
+
+	if TRB.Functions and TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
+		-- Increase initial transition time to cover the loading sequence delay
+		TRB.Functions.Bar:QueueRenderTransition("init:" .. event, 2.5)
+	end
+end)
+
 -- Settings placeholders
 TRB.Frames.interfaceSettingsFrameContainer = {}
 TRB.Frames.interfaceSettingsFrameContainer.controls = {}

--- a/Options/OptionsUi.lua
+++ b/Options/OptionsUi.lua
@@ -6555,7 +6555,9 @@ function TRB.Functions.OptionsUi:GenerateBarTextEditor(parent, controls, spec, c
 
 	local function ResetTableValues(barText)
 		spec.displayText.barText = barText
-		TRB.Data.specCache[compositeKey].settings.displayText.barText = barText
+		if TRB.Data.specCache[compositeKey] then
+			TRB.Data.specCache[compositeKey].settings.displayText.barText = barText
+		end
 		SetTableValues(spec.displayText, barTextTable)
 		_G["TwintopResourceBar_" .. namePrefix .. "_BarTextOptionsFrame"]:Hide()
 		


### PR DESCRIPTION
## Eliminate bar flicker on login and spec switch

### Problem

When logging in or switching specializations, resource bars would briefly flash on screen before being hidden and properly re-shown. This "appear → disappear → fade in" flicker was visually jarring and affected all 13 classes.

### Solution

Introduces a **render transition state machine** that suppresses all bar visibility until the addon's loading/switching sequence is fully complete.

### Changes

**New: Render Transition System (Bar.lua)**
- Added `renderTransitionState` (defaults to `active = true` on load) with token-based cancellation to prevent stale timer callbacks
- `QueueRenderTransition(reason, delay)` — activates suppression, forces all bar groups and bar text hidden at alpha 0
- `TouchRenderTransition(delay)` — resets the suppression timer when intermediate construction steps (layout, appearance) run during the transition window
- `EndRenderTransition(reason)` — deactivates suppression, runs `HideResourceBar` + `TriggerResourceBarUpdates` to apply correct visibility, then restores alpha to 1
- `IsRenderTransitionActive()` — query used throughout the codebase to gate Show() calls
- Refactored `HideResourceBar` to use centralized `HideAllBarGroupsAndBarText()` helper; now exits early when transition is active

**Bar frame suppression (Bar.lua)**
- `BarGroup:Show()` and `BarNode:Show()` force alpha 0 when render transition is active, preventing single-frame flashes even when Show() is called by construction logic
- Added `BarGroup:SetAlpha()` and `BarNode:SetAlpha()` to propagate alpha to container and all child nodes

**Bar text suppression (BarText.lua)**
- `BarText:CreateBarTextFrames()` — skips showing font/text frames during active transition
- `BarText:Show()` — hides instead of shows when transition is active

**Event-driven transition triggers**
- Init.lua — new `renderTransitionFrame` listens for `PLAYER_ENTERING_WORLD`, `ACTIVE_TALENT_GROUP_CHANGED`, `PLAYER_SPECIALIZATION_CHANGED`, `PLAYER_TALENT_UPDATE`, `TRAIT_CONFIG_LIST_UPDATED`, `TRAIT_CONFIG_UPDATED` and queues a 2.5s transition
- Character.lua — `CharacterChange` handler queues a 0.35s transition on `PLAYER_ENTERING_WORLD`, `PLAYER_SPECIALIZATION_CHANGED`, `TRAIT_CONFIG_UPDATED`; registers/unregisters the two new events

**All 13 class modules (`ClassModules/*.lua`)**
- `SwitchSpec()` — queues a 0.8s render transition at the top before any teardown
- `ConstructResourceBar()` — removed redundant `TRB.Functions.Bar:HideResourceBar()` call (TriggerResourceBarUpdates handles this correctly and respects the transition state)
- Event handler — queues a 0.8s transition before the delayed `SwitchSpec()` call on `PLAYER_ENTERING_WORLD` / `PLAYER_SPECIALIZATION_CHANGED` / `TRAIT_CONFIG_UPDATED`
- `TriggerResourceBarUpdates()` — early-returns with a force-hide when transition is active
- Removed duplicate `ConstructResourceBar` call from the post-SwitchSpec timer

**Bug fix (OptionsUi.lua)**
- Added nil guard on `TRB.Data.specCache[compositeKey]` in `ResetTableValues` to prevent errors when resetting bar text defaults

### Testing

- Login on any class — bar should not flash; it appears smoothly after the loading sequence completes
- `/reload` — same smooth appearance
- Switch specs — bar hides immediately, reappears after the new spec is fully loaded
- "Always show" / "Combat only" / "Never show" visibility settings still respected
- Edit Mode still shows bars correctly for repositioning
- Options panel bar text reset buttons work without errors