### PR TITLE
Clean up missed string references to Devouring Plague

### DIFF
--- a/Classes/Spell.lua
+++ b/Classes/Spell.lua
@@ -79,7 +79,7 @@ end
 ---@field public baseline boolean? # Is this spell a baseline ability?
 ---@field public isTalent boolean? # Is this spell available via a talent? Only used if we need to check if the talent is talented.
 ---@field public primaryResourceType Enum.PowerType? # Primary resource used in API calls, e.g. Enum.PowerType.Mana
----@field public primaryResourceTypeMod number? # Modifier applied to whatever the returned primary resource amount is, e.g. a second Devouring Plague cast cost
+---@field public primaryResourceTypeMod number? # Modifier applied to whatever the returned primary resource amount is, e.g. a second Shadow Word: Madness cast cost
 ---@field public primaryResourceTypeProperty string? # Which parameter to take from the return of the API call. Defaults to `cost` but can also be `minCost` or `costPerSec`.
 ---@field public primaryResourceTypePropertyValue number? # Custom override value that an ability will cost. Primarily used for spells that have a max range but the value isn't returned by the API, such as Execute.
 ---@field public resource number? # How much of the primary resource a spell will generate.

--- a/Functions/News.lua
+++ b/Functions/News.lua
@@ -24,6 +24,7 @@ local content = [====[
 ### Localization
 
 - [#623](#623) Updated translations for Simplified Chinese (zhCN) by M.O.S.S! Thank you so much for your help!
+- Clean up some old references to "Devouring Plague" to properly refer to "Shadow Word: Madness".
 
 ## Demon Hunter
 ### Havoc

--- a/Localization/enGB.lua
+++ b/Localization/enGB.lua
@@ -98,7 +98,7 @@ if locale == "enGB" then
     L["PriestShadowCheckboxMindFlayInsanityTooltip"] = "This will change the bar border colour when you are able to cast Mind Flay: Insanity"
     L["PriestShadowCheckboxMindDevourerTooltip"] = "This will change the bar border colour when you are able to cast Shadow Word: Madness for 0 Insanity cost via a Mind Devourer proc."
     L["PriestShadowTextColorsHeader"] = "Insanity Text Colours"
-    L["PriestShadowCheckboxThresholdOverTooltip"] = "This will change the Insanity text colour when you are able to cast Devouring Plague"
+    L["PriestShadowCheckboxThresholdOverTooltip"] = "This will change the Insanity text colour when you are able to cast Shadow Word: Madness"
     L["ShamanManaCheckboxAscendanceEnd"] = "Ascendance colour change when ending enabled"
     L["ShamanManaCheckboxAscendanceEndTooltip"] = "Changes the bar colour when Ascendance is ending in the next X GCDs or fixed length of time. Select which to use from the options below."
     L["ShamanElementalCheckboxAscendanceEnd"] = "Ascendance colour change when ending enabled"

--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -630,7 +630,6 @@ L["PriestShadowThresholdShadowWordMadness2xTooltip"] = "This will show the verti
 L["PriestShadowThresholdShadowWordMadness3x"] = "3x Shadow Word: Madness"
 L["PriestShadowThresholdShadowWordMadness3xTooltip"] = "This will show the vertical line on the bar denoting how much Insanity is required to cast three Shadow Word: Madnesses in a row."
 L["PriestShadowThresholdCheckboxOnlyCurrentNext"] = "Only show current + next threshold lines?"
-L["PriestShadowThresholdCheckboxOnlyCurrentNextTooltip"] = "This will only show Devouring Plague threshold lines if you already have enough Insanity to cast it, or, if it is the next threshold you're approaching. Only triggers the next after the previous threshold line has been reached, even if it is not checked above!"
 L["PriestShadowHeaderEndOfVoidformConfiguration"] = "End of Voidform Configuration"
 L["PriestShadowCheckboxVoidformGcds"] = "GCDs until Voidform ends"
 L["PriestShadowVoidformGcds"] = "Voidform GCDs - 0.75sec Floor"
@@ -639,12 +638,9 @@ L["PriestShadowVoidformTime"] = "Voidform Time Remaining (sec)"
 L["PriestShadowTextColorsHeader"] = "Insanity Text Colors"
 L["PriestShadowColorPickerTextCurrent"] = "Current Insanity"
 L["PriestShadowColorPickerTextCasting"] = "Insanity from hardcasting spells"
-L["PriestShadowColorPickerThresholdOver"] = "Have enough Insanity to cast Devouring Plague"
-L["PriestShadowCheckboxThresholdOverTooltip"] = "This will change the Insanity text color when you are able to cast Devouring Plague"
 L["PriestShadowAudioCheckboxShadowWordMadness"] = "Play audio cue when Shadow Word: Madness is usable"
 L["PriestShadowAudioCheckboxShadowWordMadnessTooltip"] = "Play an audio cue when Shadow Word: Madness can be cast."
 L["PriestShadowAudioCheckboxMindDevourer"] = "Play audio cue when a Mind Devourer proc occurs"
-L["PriestShadowAudioCheckboxMindDevourerTooltip"] = "Play an audio cue when a Mind Devourer proc occurs. This supercedes the regular Devouring Plague audio sound."
 
 -- ShamanOptions
 L["ResourceMaelstromWeapon"] = "Maelstrom Weapon"
@@ -1929,3 +1925,8 @@ L["BarTextVariablesPanelTitle"] = "Bar Text Variables"
 
 -- Wrapper Display Name (Edit Mode overlay)
 L["WrapperDisplayNameFormat"] = "%s - %s"
+
+L["PriestShadowThresholdCheckboxOnlyCurrentNextTooltip"] = "This will only show Shadow Word: Madness threshold lines if you already have enough Insanity to cast it, or, if it is the next threshold you're approaching. Only triggers the next after the previous threshold line has been reached, even if it is not checked above!"
+L["PriestShadowColorPickerThresholdOver"] = "Have enough Insanity to cast Shadow Word: Madness"
+L["PriestShadowCheckboxThresholdOverTooltip"] = "This will change the Insanity text color when you are able to cast Shadow Word: Madness"
+L["PriestShadowAudioCheckboxMindDevourerTooltip"] = "Play an audio cue when a Mind Devourer proc occurs. This supercedes the regular Shadow Word: Madness audio sound."


### PR DESCRIPTION
There were some missed updates to "Devouring Plague" becoming "Shadow Word: Madness". This fixes those and moves the localization strings in enUS.lua to the bottom for easier updating by localization authors.