### PR TITLE
Restore 6-node Soul Fragments bar for Vengeance Demon Hunter + Fix bar text deletion bug

### DIFF
--- a/ClassModules/Classes/DemonHunterClasses.lua
+++ b/ClassModules/Classes/DemonHunterClasses.lua
@@ -460,12 +460,12 @@ function TRB.Classes.DemonHunter.BarGroupsFactory:CreateForSpec(specId, parentFr
             true -- isPrimary
         )
 
-        -- Soul Fragments (single bar with 5 threshold dividers creating 6 segments)
-        -- Uses C_Spell.GetSpellCastCount(spiritBomb.id) to get fragment count (0-5)
+        -- Soul Fragments (6 nodes, one per fragment, using stepped min/max ranges)
+        -- Uses C_Spell.GetSpellCastCount(spiritBomb.id) to get fragment count (0-6)
         barGroups.secondary = TRB.Classes.BarGroup:New(
             UIParent,
             "TwintopResourceBarFrame_ComboPoint",
-            1,
+            6,
             false -- not primary
         )
 
@@ -530,11 +530,9 @@ function TRB.Classes.DemonHunter.BarGroupsFactory:GetSpecConfiguration(specId)
                 isPrimary = true
             },
             secondary = {
-                maxNodes = 1,
+                maxNodes = 6,
                 isPrimary = false,
-                resourceType = "SoulFragments",
-                thresholdCount = 5, -- 5 dividers create 6 segments (0-5 Soul Fragments)
-                fillType = "discrete" -- Fills left-to-right based on fragment count
+                resourceType = "SoulFragments"
             },
             health = {
                 maxNodes = 1,

--- a/ClassModules/DemonHunter.lua
+++ b/ClassModules/DemonHunter.lua
@@ -252,20 +252,43 @@ local function ConstructResourceBar(settings)
 		if barGroups and barGroups.secondary then
 			barGroups.secondary:Hide()
 		end
-	elseif TRB.Data.character.specId == 2 then -- Vengeance - Soul Fragments bar with threshold dividers
+	elseif TRB.Data.character.specId == 2 then -- Vengeance - Soul Fragments (6 independent nodes)
 		if barGroups and barGroups.secondary then
-			-- Set up the secondary bar structure with 1 node
-			barGroups.secondary:SetNodeCount(1)
-			local sfNode = barGroups.secondary:GetNode(1)
-			if sfNode then
-				sfNode:SetMinMax(0, 6) -- 0-6 Soul Fragments
-				
-				-- Create 5 threshold dividers to create 6 segments
-				sfNode:ClearThresholds()
-				for thresholdId = 1, 5 do
-					local thresholdFrame = CreateFrame("Frame", nil, sfNode:GetFrame())
-					TRB.Functions.Threshold:ResetThresholdLineComboPoint(thresholdFrame, settings)
-					sfNode:RegisterThreshold(thresholdFrame)
+			local maxSoulFragments = 6
+
+			barGroups.secondary:SetMaxNodes(maxSoulFragments)
+			barGroups.secondary:SetNodeCount(maxSoulFragments)
+			barGroups.secondary:SetLayout(settings.comboPoints.spacing, TRB.Functions.Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
+			barGroups.secondary:Show()
+
+			local effectiveWidth, cdmForced = TRB.Functions.Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
+			if cdmForced then
+				barGroups.secondary.fullWidth = true
+			end
+
+			barGroups.secondary:ApplyLayout(
+				effectiveWidth,
+				settings.comboPoints.width,
+				settings.comboPoints.height,
+				settings.comboPoints.border
+			)
+
+			local frameLevels = TRB.Data.constants.frameLevels
+			for i = 1, maxSoulFragments do
+				local node = barGroups.secondary:GetNode(i)
+				if node then
+					node:SetTextures(
+						settings.textures.comboPointsBar,
+						settings.textures.comboPointsBorder,
+						settings.textures.comboPointsBackground
+					)
+					-- Stepped min/max: node 1 = 0,1; node 2 = 1,2; ... node 6 = 5,6
+					-- All nodes receive the same raw secret value; StatusBar clamping handles fill
+					node:SetMinMax(i - 1, i)
+					node:SetBorderColor(settings.colors.comboPoints.border.color)
+					node:SetBackgroundColorFromString(settings.colors.comboPoints.background.color)
+					node:SetColor(settings.colors.comboPoints.base.color)
+					node:SetFrameLevel(frameLevels.comboPoint)
 				end
 			end
 		end
@@ -715,9 +738,6 @@ local function UpdateSnapshot_Vengeance()
 	
 	local spells = TRB.Data.spellsData.spells --[[@as TRB.Classes.DemonHunter.VengeanceSpells]]
 	local snapshotData = TRB.Data.snapshotData --[[@as TRB.Classes.SnapshotData]]
-	
-	-- Vengeance Soul Fragments max is 6
-	TRB.Data.character.maxResource2Value = 6
 end
 
 local function UpdateSnapshot_Devourer()
@@ -1024,35 +1044,32 @@ local function UpdateResourceBar()
 			if specSettings.displayBar.secondary.visibility ~= "never" then
 				refreshText = true
 				local spells = TRB.Data.spellsData.spells --[[@as TRB.Classes.DemonHunter.VengeanceSpells]]
-				-- Soul Fragments bar (Vengeance, 0-5 fragments)
-				local current = snapshotData.attributes.resource2 or 0
-				local max = TRB.Data.character.maxResource2Value or 6
+				-- Soul Fragments bar (Vengeance, 0-6 fragments, 6 independent nodes)
+				local soulFragments = snapshotData.attributes.resource2 or 0
+				local maxSoulFragments = TRB.Data.character.maxResource2 or 6
 				
 				local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
 				local cpBorderColor = specSettings.colors.comboPoints.border.color
-				local cpColor = specSettings.colors.comboPoints.base.color
 
-				-- Update secondary bar (Soul Fragments with threshold dividers)
+				-- Update all 6 Soul Fragment nodes with positional coloring
 				if barGroups.secondary then
-					local sfNode = barGroups.secondary:GetNode(1)
-					if sfNode then
-						TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "secondary", sfNode, current, max)
-						sfNode:SetBorderColor(cpBorderColor)
-						sfNode:SetColor(cpColor)
-						sfNode:SetBackgroundColor(cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha)
-						
-						-- Position 5 threshold dividers at 1, 2, 3, 4, 5 to create 6 segments
-						local thresholds = sfNode:GetThresholds()
-						local sfContainerFrame = sfNode:GetFrame()
-						
-						-- Get threshold line color from comboPoints border
-						local thresholdColor = specSettings.colors.comboPoints.border.color
-						
-						for thresholdId = 1, 5 do
-							if thresholds[thresholdId] then
-								TRB.Functions.Color:SetThresholdColor(thresholds[thresholdId], thresholdColor, true)
-								TRB.Functions.Threshold:RepositionThresholdComboPoint(specCacheSettings, "soulFragment" .. thresholdId, thresholds[thresholdId], true, sfContainerFrame, thresholdId, max)
+					for x = 1, maxSoulFragments do
+						local cpNode = barGroups.secondary:GetNode(x)
+						if cpNode then
+							-- All nodes get the same raw secret value; each node's stepped
+							-- SetMinMax(x-1, x) handles fill via StatusBar clamping
+							TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "soulFragment" .. x, cpNode, soulFragments)
+							cpNode:SetBorderColor(cpBorderColor)
+							cpNode:SetBackgroundColor(cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha)
+
+							-- Positional coloring: base for 1-4, penultimate for 5, final for 6
+							local cpColor = specSettings.colors.comboPoints.base.color
+							if x == maxSoulFragments then
+								cpColor = specSettings.colors.comboPoints.final.color
+							elseif x == (maxSoulFragments - 1) then
+								cpColor = specSettings.colors.comboPoints.penultimate.color
 							end
+							cpNode:SetColor(cpColor)
 						end
 					end
 				end
@@ -1566,8 +1583,8 @@ function TRB.Functions.Class:CheckCharacter()
 		TRB.Data.character.specName = "vengeance"
 		TRB.Data.character.compositeKey = "demonhunter_vengeance"
 		
-		-- Soul Fragments: 1 node with 5 thresholds, max 6 fragments
-		local maxComboPoints = 1
+		-- Soul Fragments: 6 nodes (one per fragment), max 6 fragments
+		local maxComboPoints = 6
 		TRB.Data.character.maxResource2Value = 6
 		local sharedSettings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 
@@ -1575,7 +1592,29 @@ function TRB.Functions.Class:CheckCharacter()
 			if maxComboPoints ~= TRB.Data.character.maxResource2 then
 				TRB.Data.character.maxResource2 = maxComboPoints
 				if TRB.Frames.barGroups ~= nil then
-					TRB.Functions.Bar:ApplyBarGroupsLayout(sharedSettings, TRB.Frames.barGroups)
+					local barGroups = TRB.Frames.barGroups
+					TRB.Functions.Bar:ApplyBarGroupsLayout(sharedSettings, barGroups)
+					-- Rebuild secondary nodes with stepped min/max
+					if barGroups.secondary then
+						barGroups.secondary:SetMaxNodes(maxComboPoints)
+						barGroups.secondary:SetNodeCount(maxComboPoints)
+						local frameLevels = TRB.Data.constants.frameLevels
+						for i = 1, maxComboPoints do
+							local node = barGroups.secondary:GetNode(i)
+							if node then
+								node:SetMinMax(i - 1, i)
+								node:SetTextures(
+									sharedSettings.textures.comboPointsBar,
+									sharedSettings.textures.comboPointsBorder,
+									sharedSettings.textures.comboPointsBackground
+								)
+								node:SetBorderColor(sharedSettings.colors.comboPoints.border.color)
+								node:SetBackgroundColorFromString(sharedSettings.colors.comboPoints.background.color)
+								node:SetColor(sharedSettings.colors.comboPoints.base.color)
+								node:SetFrameLevel(frameLevels.comboPoint)
+							end
+						end
+					end
 				end
 			end
 		end
@@ -1691,7 +1730,11 @@ function TRB.Functions.Class:HideResourceBar(force)
 			if barGroups and barGroups.secondary then
 				if showSecondary then
 					barGroups.secondary:Show()
-					barGroups.secondary:ShowNodes(1)
+					if TRB.Data.character.specId == 2 then
+						barGroups.secondary:ShowNodes(6)
+					else
+						barGroups.secondary:ShowNodes(1)
+					end
 				else
 					barGroups.secondary:Hide()
 				end
@@ -1833,21 +1876,25 @@ function TRB.Functions.Class:GetBarTextFrame(relativeToFrame)
 			end
 		end
 		return nil, true, false
-	elseif relativeToFrame == "HealthBar" then
-		if barGroups and barGroups.health then
-			local healthNode = barGroups.health:GetNode(1)
-			if healthNode then
-				local isVisible = barGroups.health.isVisible and healthNode.isVisible
-				return healthNode:GetFrame(), true, isVisible
+	elseif relativeToFrame ~= nil then
+		-- Handle secondary resources (ComboPoint1, ComboPoint2, etc.)
+		local comboPointIndex = string.match(relativeToFrame, "^ComboPoint(%d+)$")
+		if comboPointIndex ~= nil then
+			local index = tonumber(comboPointIndex)
+			if index ~= nil and barGroups and barGroups.secondary then
+				local secondaryNode = barGroups.secondary:GetNode(index)
+				if secondaryNode then
+					local isVisible = barGroups.secondary.isVisible and secondaryNode.isVisible
+					return secondaryNode:GetFrame(), true, isVisible
+				end
 			end
-		end
-		return nil, true, false
-	elseif relativeToFrame == "ComboPoint1" then
-		if barGroups and barGroups.secondary then
-			local secondaryNode = barGroups.secondary:GetNode(1)
-			if secondaryNode then
-				local isVisible = barGroups.secondary.isVisible and secondaryNode.isVisible
-				return secondaryNode:GetFrame(), true, isVisible
+		elseif relativeToFrame == "HealthBar" or relativeToFrame == "Health" then
+			if barGroups and barGroups.health then
+				local healthNode = barGroups.health:GetNode(1)
+				if healthNode then
+					local isVisible = barGroups.health.isVisible and healthNode.isVisible
+					return healthNode:GetFrame(), true, isVisible
+				end
 			end
 		end
 		return nil, true, false
@@ -1877,20 +1924,25 @@ function TRB.Functions.Class:RecreateThresholds(settings, barGroups)
 		end
 	end
 
-	-- Vengeance: Soul Fragments bar with 5 threshold dividers (0-6 scale)
+	-- Vengeance: Soul Fragments bar with 6 independent nodes (stepped min/max)
 	if TRB.Data.character.specId == 2 and barGroups.secondary then
-		barGroups.secondary:SetNodeCount(1)
-		local sfNode = barGroups.secondary:GetNode(1)
-		if sfNode then
-			sfNode:SetMinMax(0, 6) -- 0-6 Soul Fragments
-			local existingThresholds = sfNode:GetThresholds()
-			if not existingThresholds or #existingThresholds ~= 5 then
-				sfNode:ClearThresholds()
-				for _ = 1, 5 do
-					local thresholdFrame = CreateFrame("Frame", nil, sfNode:GetFrame())
-					TRB.Functions.Threshold:ResetThresholdLineComboPoint(thresholdFrame, settings)
-					sfNode:RegisterThreshold(thresholdFrame)
-				end
+		local maxSoulFragments = 6
+		barGroups.secondary:SetMaxNodes(maxSoulFragments)
+		barGroups.secondary:SetNodeCount(maxSoulFragments)
+		local frameLevels = TRB.Data.constants.frameLevels
+		for i = 1, maxSoulFragments do
+			local node = barGroups.secondary:GetNode(i)
+			if node then
+				node:SetMinMax(i - 1, i)
+				node:SetTextures(
+					settings.textures.comboPointsBar,
+					settings.textures.comboPointsBorder,
+					settings.textures.comboPointsBackground
+				)
+				node:SetBorderColor(settings.colors.comboPoints.border.color)
+				node:SetBackgroundColorFromString(settings.colors.comboPoints.background.color)
+				node:SetColor(settings.colors.comboPoints.base.color)
+				node:SetFrameLevel(frameLevels.comboPoint)
 			end
 		end
 	end

--- a/ClassModules/Options/DemonHunterOptions.lua
+++ b/ClassModules/Options/DemonHunterOptions.lua
@@ -1222,7 +1222,7 @@ local function VengeanceConstructSoulFragmentsBarPanel(parent)
 	local yCoord = 5
 	local f = nil
 
-	yCoord = TRB.Functions.OptionsUi:GenerateComboPointDimensionsOptions(parent, controls, spec, 12, 2, yCoord, L["ResourceFury"], L["ResourceSoulFragments"], false)
+	yCoord = TRB.Functions.OptionsUi:GenerateComboPointDimensionsOptions(parent, controls, spec, 12, 2, yCoord, L["ResourceFury"], L["ResourceSoulFragments"])
 
 	yCoord = yCoord - 60
 	controls.comboPointColorsSection = TRB.Functions.OptionsUi:BuildSectionHeader(parent, L["DemonHunterVengeanceHeaderSoulFragmentColors"], oUi.xCoord, yCoord)
@@ -1243,7 +1243,6 @@ local function VengeanceConstructSoulFragmentsBarPanel(parent)
 	end)
 
 	yCoord = yCoord - 30
-	--[[
 	controls.colors.comboPoints.penultimate = TRB.Functions.OptionsUi:BuildColorPicker(parent, L["DemonHunterVengeanceColorPickerSoulFragmentPenultimate"], spec.colors.comboPoints.penultimate.color, oUi.colorPickerTextWidth, oUi.colorPickerFrameSize, oUi.xCoord, yCoord)
 	f = controls.colors.comboPoints.penultimate
 	f:SetScript("OnMouseDown", function(self, button, ...)
@@ -1257,16 +1256,6 @@ local function VengeanceConstructSoulFragmentsBarPanel(parent)
 	end)
 
 	yCoord = yCoord - 30
-	controls.checkBoxes.sameColorComboPoint = CreateFrame("CheckButton", "TwintopResourceBar_Rogue_Assassination_comboPointsSameColor", parent, "ChatConfigCheckButtonTemplate")
-	f = controls.checkBoxes.sameColorComboPoint
-	f:SetPoint("TOPLEFT", oUi.xCoord, yCoord)
-	getglobal(f:GetName() .. 'Text'):SetText(L["DemonHunterVengeanceCheckboxUseHighestSoulFragmentColorForAll"])
-	f.tooltip = L["DemonHunterVengeanceCheckboxUseHighestSoulFragmentColorForAllTooltip"]
-	f:SetChecked(spec.comboPoints.sameColor)
-	f:SetScript("OnClick", function(self, ...)
-		spec.comboPoints.sameColor = self:GetChecked()
-	end)]]
-
 	controls.colors.comboPoints.background = TRB.Functions.OptionsUi:BuildColorPicker(parent, L["DemonHunterVengeanceColorPickerUnfilledSoulFragmentBackground"], spec.colors.comboPoints.background.color, oUi.colorPickerTextWidth, oUi.colorPickerFrameSize, oUi.xCoord2, yCoord)
 	f = controls.colors.comboPoints.background
 	f:SetScript("OnMouseDown", function(self, button, ...)

--- a/Functions/Bar.lua
+++ b/Functions/Bar.lua
@@ -1222,8 +1222,10 @@ function TRB.Functions.Bar:ApplyBarGroupsAppearance(settings, barGroups)
 				-- not with layout (move/resize), to avoid clamping current values.
 				if isDevourer and i == 1 then
 					node:SetMinMax(0, TRB.Data.character.maxResource2Value or 50)
-				elseif isVengeance and i == 1 then
-					node:SetMinMax(0, 6) -- 0-6 Soul Fragments
+				elseif isVengeance then
+					-- Stepped min/max: node 1 = (0,1), node 2 = (1,2), ... node 6 = (5,6)
+					-- All nodes receive the same raw secret value; StatusBar clamping handles fill
+					node:SetMinMax(i - 1, i)
 				else
 					node:SetMinMax(0, 1)
 				end

--- a/Functions/BarText.lua
+++ b/Functions/BarText.lua
@@ -1183,14 +1183,13 @@ function TRB.Functions.BarText:CreateBarTextFrames(classId, specId)
 	local displayText = settings.displayText --[[@as TRB.Classes.Settings.DisplayText]]
 	
 	local entries = TRB.Functions.Table:Length(displayText.barText)
-	local frameCount = 0
+	local frameCount = 1
 	if entries > 0 then
 		if displayText.default.fontFace == nil or displayText.default.fontFace == "" or displayText.default.fontFaceName == nil or displayText.default.fontFaceName == "" then
 			displayText.default.fontFace = TRB.Data.constants.defaultSettings.fonts.fontFace
 			displayText.default.fontFaceName = TRB.Data.constants.defaultSettings.fonts.fontFaceName
 		end
 
-		frameCount = 1
 		for i = 1, entries do
 			local e = displayText.barText[i]
 
@@ -1270,8 +1269,8 @@ function TRB.Functions.BarText:CreateBarTextFrames(classId, specId)
 	
 	local textFramesEntries = TRB.Functions.Table:Length(textFrames)
 	-- We have extra frames we don't need now, probably because we changed talents/specs/deleted one in config. Hide extras.
-	if textFramesEntries > frameCount then
-		for i = frameCount+1, textFramesEntries do
+	if textFramesEntries >= frameCount then
+		for i = frameCount, textFramesEntries do
 			textFrames[i]:Hide()
 			---@diagnostic disable-next-line: undefined-field
 			textFrames[i].font:Hide()

--- a/Functions/News.lua
+++ b/Functions/News.lua
@@ -22,6 +22,11 @@ local content = [====[
 
 - [#632](#632) Updated translations for Simplified Chinese (zhCN) by M.O.S.S! Thank you so much for your help!
 
+## Demon Hunter
+### Vengeance
+
+- [#634](#634) Restore (almost all) original Soul Fragement functionality -- individual nodes instead of a single bar with thresholds, distinct colors for each node, and allow bar text areas to be placed in each.
+
 ---
 
 # 12.0.1.8-release (2026-02-21)

--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -1933,3 +1933,5 @@ L["PriestShadowAudioCheckboxMindDevourerTooltip"] = "Play an audio cue when a Mi
 
 -- Global Health Bar Colors
 L["CheckboxUseGlobalTooltip_HealthBarColors"] = "When checked, the global setting for health bar colors will be used instead of the specialization-specific setting."
+
+L["SoulFragment6"] = "Soul Fragment 6"

--- a/Options/OptionsUi.lua
+++ b/Options/OptionsUi.lua
@@ -6140,6 +6140,11 @@ StaticPopupDialogs["TwintopResourceBar_ConfirmDeleteBarText"] = {
 		d.btt:SetSelection()
 		table.remove(d.displayText.barText, d.row)
 		d.setTableValues(d.displayText, d.btt)
+		if d.classId == TRB.Data.character.classId and d.specId == TRB.Data.character.specId then
+			TRB.Data.cache.barText = {}
+			TRB.Data.cache.symbols = {}
+			TRB.Data.cache.barTextTree = {}
+		end
 		TRB.Functions.BarText:CreateBarTextFrames(d.classId, d.specId)
 		d.barTextOptionsFrame:Hide()
 	end,
@@ -6581,6 +6586,7 @@ function TRB.Functions.OptionsUi:GenerateBarTextEditor(parent, controls, spec, c
 		relativeToFrame[L["SoulFragment3"]] = "ComboPoint_3"
 		relativeToFrame[L["SoulFragment4"]] = "ComboPoint_4"
 		relativeToFrame[L["SoulFragment5"]] = "ComboPoint_5"
+		relativeToFrame[L["SoulFragment6"]] = "ComboPoint_6"
 		relativeToFrameList = {
 			L["MainResourceBar"],
 			L["SoulFragment1"],
@@ -6588,6 +6594,7 @@ function TRB.Functions.OptionsUi:GenerateBarTextEditor(parent, controls, spec, c
 			L["SoulFragment3"],
 			L["SoulFragment4"],
 			L["SoulFragment5"],
+			L["SoulFragment6"],
 			L["HealthBar"],
 			L["Screen"],
 		}


### PR DESCRIPTION
# Soul Fragments (Vengeance DH)

Replaces the single-node + 5-threshold-divider workaround for Soul Fragments with 6 independent BarNodes, one per fragment. Each node uses a stepped `SetMinMax` range — node 1 = (0,1), node 2 = (1,2), ... node 6 = (5,6) — so the raw secret value from `C_Spell.GetSpellCastCount()` can be passed directly to all nodes and WoW's native StatusBar clamping handles the fill/empty state per segment.

**Changes:**
- **DemonHunterClasses.lua**: Secondary BarGroup uses 6 nodes instead of 1
- **DemonHunter.lua**: `ConstructResourceBar`, `UpdateResourceBar`, `CheckCharacter`, `HideResourceBar`, `GetBarTextFrame`, and `RecreateThresholds` all updated for 6-node logic. Positional coloring (base → penultimate → final) replaces the removed `sameColor` feature, which was incompatible with secret values (`curve:Evaluate()` rejects them in tainted execution)
- **DemonHunterOptions.lua**: Removed `sameColor` checkbox; re-enabled penultimate/final color pickers and spacing slider
- **Bar.lua**: Fixed `ApplyBarGroupsAppearance` to apply stepped `SetMinMax(i-1, i)` to all Vengeance nodes instead of only setting node 1 to `(0, 6)`
- **OptionsUi.lua**: Added Soul Fragment 6 to bar text "Bound to Bar" anchor dropdown
- **enUS.lua**: Added `L["SoulFragment6"]`

# Bar text deletion bug fix

Deleting a bar text area left the previous text frame visible on screen.

- **BarText.lua**: Fixed off-by-one in `CreateBarTextFrames` — `frameCount` started at 0 then was set to 1 inside a conditional, causing the cleanup loop (`frameCount+1` start) to skip the first stale frame. Now initializes to 1 directly and the cleanup uses `>= frameCount` / starts at `frameCount`
- **OptionsUi.lua**: Delete confirmation handler now clears `barText`, `symbols`, and `barTextTree` caches (matching `ResetTableValues` behavior) to prevent stale cached text from rendering on remaining frames

Completes #634 