### PR TITLE
Restore Power Word Bars for Discipline Priest

### DIFF
--- a/ClassModules/Classes/PriestClasses.lua
+++ b/ClassModules/Classes/PriestClasses.lua
@@ -67,10 +67,10 @@ end
 
 
 ---@class TRB.Classes.Priest.DisciplineSpells : TRB.Classes.Priest.HealerSpells
---[[---@field public atonement TRB.Classes.SpellBase
----@field public evangelism TRB.Classes.SpellBase
 ---@field public powerWordRadiance TRB.Classes.SpellBase
 ---@field public lightsPromise TRB.Classes.SpellBase
+--[[---@field public atonement TRB.Classes.SpellBase
+---@field public evangelism TRB.Classes.SpellBase
 ---@field public shadowCovenant TRB.Classes.SpellBase
 ---@field public entropicRift TRB.Classes.SpellBase
 ---@field public depthOfShadows TRB.Classes.SpellBase]]
@@ -89,6 +89,16 @@ function TRB.Classes.Priest.DisciplineSpells:New()
 	-- Priest Talent Abilities
 
 	-- Discipline Talent Abilities
+	self.powerWordRadiance = TRB.Classes.SpellBase:New({
+		id = 194509,
+		isTalent = true,
+		hasCharges = true,
+		duration = 20
+	})
+	self.lightsPromise = TRB.Classes.SpellBase:New({
+		id = 322115,
+		isTalent = true
+	})
 	--[[self.atonement = TRB.Classes.SpellBase:New({
 		id = 194384,
 		isTalent = true,
@@ -100,15 +110,6 @@ function TRB.Classes.Priest.DisciplineSpells:New()
 	self.evangelism = TRB.Classes.SpellBase:New({
 		id = 472433,
 		atonementMod = 6
-	})
-	self.powerWordRadiance = TRB.Classes.SpellBase:New({
-		id = 194509,
-		isTalent = true,
-		hasCharges = true
-	})
-	self.lightsPromise = TRB.Classes.SpellBase:New({
-		id = 322115,
-		isTalent = true
 	})
 	self.shadowCovenant = TRB.Classes.SpellBase:New({
 		id = 322105,
@@ -142,10 +143,10 @@ function TRB.Classes.Priest.DisciplineSpells.FillBarTextVariables(specCacheEntry
 	local spells = specCacheEntry.spellsData.spells --[[@as TRB.Classes.Priest.DisciplineSpells]]
 
 	specCacheEntry.barTextVariables.icons = TRB.Functions.BarText:GetCommonIcons({
-		--[[{ variable = "#atonement", icon = spells.atonement.icon, description = spells.atonement.name, printInSettings = true },
-		{ variable = "#entropicRift", icon = spells.entropicRift.icon, description = spells.entropicRift.name, printInSettings = true },
 		{ variable = "#pwRadiance", icon = spells.powerWordRadiance.icon, description = spells.powerWordRadiance.name, printInSettings = true },
 		{ variable = "#powerWordRadiance", icon = spells.powerWordRadiance.icon, description = spells.powerWordRadiance.name, printInSettings = false },
+		--[[{ variable = "#atonement", icon = spells.atonement.icon, description = spells.atonement.name, printInSettings = true },
+		{ variable = "#entropicRift", icon = spells.entropicRift.icon, description = spells.entropicRift.name, printInSettings = true },
 		{ variable = "#sc", icon = spells.shadowCovenant.icon, description = spells.shadowCovenant.name, printInSettings = true },
 		{ variable = "#shadowCovenant", icon = spells.shadowCovenant.icon, description = spells.shadowCovenant.name, printInSettings = false },]]
 	})
@@ -157,17 +158,17 @@ function TRB.Classes.Priest.DisciplineSpells.FillBarTextVariables(specCacheEntry
 		{ variable = "$manaMax", description = L["PriestDisciplineBarTextVariable_manaMax"], printInSettings = true, color = false },
 		{ variable = "$resourceMax", description = "", printInSettings = false, color = false },
 		{ variable = "$casting", description = L["PriestDisciplineBarTextVariable_casting"], printInSettings = true, color = false },
-				
-		--[[{ variable = "$scTime", description = L["PriestDisciplineBarTextVariable_scTime"], printInSettings = true, color = false },
-		{ variable = "$shadowCovenantTime", description = "", printInSettings = false, color = false },
 
 		{ variable = "$pwRadianceTime", description = L["PriestDisciplineBarTextVariable_pwRadianceTime"], printInSettings = true, color = false },
 		{ variable = "$radianceTime", description = "", printInSettings = false, color = false },
 		{ variable = "$powerWordRadianceTime", description = "", printInSettings = false, color = false },
-		
+
 		{ variable = "$pwRadianceCharges", description = L["PriestDisciplineBarTextVariable_pwRadianceCharges"], printInSettings = true, color = false },
 		{ variable = "$radianceCharges", description = "", printInSettings = false, color = false },
-		{ variable = "$powerWordRadianceCharges", description = "", printInSettings = false, color = false },]]
+		{ variable = "$powerWordRadianceCharges", description = "", printInSettings = false, color = false },
+
+		--[[{ variable = "$scTime", description = L["PriestDisciplineBarTextVariable_scTime"], printInSettings = true, color = false },
+		{ variable = "$shadowCovenantTime", description = "", printInSettings = false, color = false },]]
 	})
 end
 
@@ -951,6 +952,14 @@ function TRB.Classes.Priest.BarGroupsFactory:CreateForSpec(specId, parentFrame)
             true -- isPrimary
         )
 
+        -- Secondary Power Words bar (up to 2 nodes: PWR 1 base + 1 from Light's Promise)
+        barGroups.secondary = TRB.Classes.BarGroup:New(
+            parentFrame or UIParent,
+            "TwintopResourceBarFrame_Secondary",
+            2,
+            false -- not primary
+        )
+
         -- Health bar (1 node)
         barGroups.health = TRB.Classes.BarGroup:New(
             parentFrame or UIParent,
@@ -1022,6 +1031,11 @@ function TRB.Classes.Priest.BarGroupsFactory:GetSpecConfiguration(specId)
             primary = {
                 maxNodes = 1,
                 isPrimary = true
+            },
+            secondary = {
+                maxNodes = 2,
+                isPrimary = false,
+                resourceType = "PowerWords"
             },
             health = {
                 maxNodes = 1,

--- a/ClassModules/Classes/PriestClasses.lua
+++ b/ClassModules/Classes/PriestClasses.lua
@@ -69,6 +69,7 @@ end
 ---@class TRB.Classes.Priest.DisciplineSpells : TRB.Classes.Priest.HealerSpells
 ---@field public powerWordRadiance TRB.Classes.SpellBase
 ---@field public lightsPromise TRB.Classes.SpellBase
+---@field public brightPupil TRB.Classes.SpellBase
 --[[---@field public atonement TRB.Classes.SpellBase
 ---@field public evangelism TRB.Classes.SpellBase
 ---@field public shadowCovenant TRB.Classes.SpellBase
@@ -93,11 +94,16 @@ function TRB.Classes.Priest.DisciplineSpells:New()
 		id = 194509,
 		isTalent = true,
 		hasCharges = true,
-		duration = 20
+		duration = 18
 	})
 	self.lightsPromise = TRB.Classes.SpellBase:New({
 		id = 322115,
 		isTalent = true
+	})
+	self.brightPupil = TRB.Classes.SpellBase:New({
+		id = 390684,
+		isTalent = true,
+		durationMod = -3
 	})
 	--[[self.atonement = TRB.Classes.SpellBase:New({
 		id = 194384,

--- a/ClassModules/Options/PriestOptions.lua
+++ b/ClassModules/Options/PriestOptions.lua
@@ -13,7 +13,7 @@ TRB.Options.Priest.Shadow = {}
 local SHADOW_MAX_INSANITY = 150
 
 
----Loads only the Holy Word bar text entries (no global mana text)
+---Loads only the Power Word bar text entries (no global mana text)
 ---@return TRB.Classes.Settings.DisplayTextEntry[]
 local function DisciplineLoadPowerWordBarTextSettings()
 	---@type TRB.Classes.Settings.DisplayTextEntry[]

--- a/ClassModules/Options/PriestOptions.lua
+++ b/ClassModules/Options/PriestOptions.lua
@@ -61,6 +61,7 @@ local function DisciplineLoadDefaultSettings(includeBarText, classic)
 			dragonriding = true
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
+		comboPoints = TRB.Functions.Settings:DefaultComboPointsDimensions(classic),
 		healthBar = TRB.Functions.Settings:DefaultHealthDimensions(classic),
 		colors={
 			text = {
@@ -753,9 +754,23 @@ local function DisciplineConstructManaBarPanel(parent)
 	f:SetScript("OnClick", function(self, ...)
 		spec.colors.bar.surgeOfLight.enabled = self:GetChecked()
 	end)
+end
 
-	--[[
-	yCoord = yCoord - 40
+local function DisciplineConstructPowerWordsPanel(parent)
+	if parent == nil then
+		return
+	end
+
+	local interfaceSettingsFrame = TRB.Frames.interfaceSettingsFrameContainer
+	local controls = interfaceSettingsFrame.controls.priest_discipline
+	local yCoord = 5
+	local f = nil
+
+	local spec = TRB.Data.settings.priest.discipline
+
+	yCoord = TRB.Functions.OptionsUi:GenerateComboPointDimensionsOptions(parent, controls, spec, 5, 1, yCoord, L["ResourceMana"], L["PriestDisciplinePowerWords"])
+
+	yCoord = yCoord - 60
 	controls.comboPointColorsSection = TRB.Functions.OptionsUi:BuildSectionHeader(parent, L["PriestDisciplinePowerWordColorsHeader"], oUi.xCoord, yCoord)
 	controls.colors.comboPoints = {}
 
@@ -771,29 +786,33 @@ local function DisciplineConstructManaBarPanel(parent)
 		if TRB.Data.character.classId == 5 and TRB.Data.character.specId == 1 then
 			TRB.Functions.Character:ResetCaches()
 			TRB.Functions.Class:CheckCharacter()
-			TRB.Functions.Bar:Construct(TRB.Data.specCache.priest_discipline.settings)
+			if TRB.Frames.barGroups ~= nil then
+				TRB.Functions.Bar:ApplyBarGroupsLayout(spec, TRB.Frames.barGroups)
+				TRB.Functions.Bar:ApplyBarGroupsAppearance(spec, TRB.Frames.barGroups)
+				TRB.Functions.Class:TriggerResourceBarUpdates()
+			end
 		end
 	end)
 
-	controls.colors.comboPoints.powerWordRadiance = TRB.Functions.OptionsUi:BuildColorPicker(parent, L["PriestDisciplineColorPowerWordRadiance"], spec.colors.comboPoints.powerWordRadiance, oUi.colorPickerTextWidth, oUi.colorPickerFrameSize, oUi.xCoord2, yCoord)
+	controls.colors.comboPoints.powerWordRadiance = TRB.Functions.OptionsUi:BuildColorPicker(parent, L["PriestDisciplineColorPowerWordRadiance"], spec.colors.comboPoints.powerWordRadiance.color, oUi.colorPickerTextWidth, oUi.colorPickerFrameSize, oUi.xCoord2, yCoord)
 	f = controls.colors.comboPoints.powerWordRadiance
 	f:SetScript("OnMouseDown", function(self, button, ...)
 		TRB.Functions.OptionsUi:ColorOnMouseDown(button, spec.colors.comboPoints, controls.colors.comboPoints, "powerWordRadiance")
 	end)
 
 	yCoord = yCoord - 30
-	controls.colors.comboPoints.border = TRB.Functions.OptionsUi:BuildColorPicker(parent, L["PriestDisciplineColorPowerWordBorder"], spec.colors.comboPoints.border, oUi.colorPickerTextWidth, oUi.colorPickerFrameSize, oUi.xCoord2, yCoord)
+	controls.colors.comboPoints.border = TRB.Functions.OptionsUi:BuildColorPicker(parent, L["PriestDisciplineColorPowerWordBorder"], spec.colors.comboPoints.border.color, oUi.colorPickerTextWidth, oUi.colorPickerFrameSize, oUi.xCoord2, yCoord)
 	f = controls.colors.comboPoints.border
 	f:SetScript("OnMouseDown", function(self, button, ...)
 		TRB.Functions.OptionsUi:ColorOnMouseDown(button, spec.colors.comboPoints, controls.colors.comboPoints, "border")
 	end)
 
 	yCoord = yCoord - 30
-	controls.colors.comboPoints.background = TRB.Functions.OptionsUi:BuildColorPicker(parent, L["PriestDisciplineColorPowerWordUnfilled"], spec.colors.comboPoints.background, oUi.colorPickerTextWidth, oUi.colorPickerFrameSize, oUi.xCoord2, yCoord)
+	controls.colors.comboPoints.background = TRB.Functions.OptionsUi:BuildColorPicker(parent, L["PriestDisciplineColorPowerWordUnfilled"], spec.colors.comboPoints.background.color, oUi.colorPickerTextWidth, oUi.colorPickerFrameSize, oUi.xCoord2, yCoord)
 	f = controls.colors.comboPoints.background
 	f:SetScript("OnMouseDown", function(self, button, ...)
 		TRB.Functions.OptionsUi:ColorOnMouseDown(button, spec.colors.comboPoints, controls.colors.comboPoints, "background", "backdrop", TRB.Functions.OptionsUi:GetSecondaryBackdropFrames())
-	end)]]
+	end)
 end
 
 local function DisciplineConstructHealthBarPanel(parent)
@@ -824,7 +843,7 @@ local function DisciplineConstructBarTexturesPanel(parent)
 
 	local spec = TRB.Data.settings.priest.discipline
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarTexturesOptions(parent, controls, spec, 5, 1, yCoord)--, true, L["PriestDisciplinePowerWords"])
+	yCoord = TRB.Functions.OptionsUi:GenerateBarTexturesOptions(parent, controls, spec, 5, 1, yCoord, true, L["PriestDisciplinePowerWords"])
 end
 
 local function DisciplineConstructBarVisibilityPanel(parent)
@@ -838,7 +857,7 @@ local function DisciplineConstructBarVisibilityPanel(parent)
 
 	local spec = TRB.Data.settings.priest.discipline
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 5, 1, yCoord, L["ResourceMana"], "notFull", false, nil, nil, false, nil, true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 5, 1, yCoord, L["ResourceMana"], "notFull", false, nil, nil, true, L["PriestDisciplinePowerWords"], true)
 end
 
 local function DisciplineConstructThresholdPanel(parent)
@@ -983,6 +1002,7 @@ local function DisciplineConstructOptionsPanel(cache)
 
 	yCoord = TRB.Functions.OptionsUi:BuildTabGroup(parent, namePrefix, {
 		{ key = "manaBar", label = L["TabMana"], width = oUi.tabWidth.small, constructor = DisciplineConstructManaBarPanel },
+		{ key = "powerWordsBar", label = L["TabPowerWords"], width = oUi.tabWidth.medium, constructor = DisciplineConstructPowerWordsPanel },
 		{ key = "healthBar", label = L["TabHealth"], width = oUi.tabWidth.small, constructor = DisciplineConstructHealthBarPanel },
 		{ key = "barTextures", label = L["TabTextures"], width = oUi.tabWidth.small, constructor = DisciplineConstructBarTexturesPanel },
 		{ key = "barVisibility", label = L["TabVisibility"], width = oUi.tabWidth.small, constructor = DisciplineConstructBarVisibilityPanel },

--- a/ClassModules/Options/PriestOptions.lua
+++ b/ClassModules/Options/PriestOptions.lua
@@ -12,14 +12,70 @@ TRB.Options.Priest.Shadow = {}
 
 local SHADOW_MAX_INSANITY = 150
 
+
+---Loads only the Holy Word bar text entries (no global mana text)
+---@return TRB.Classes.Settings.DisplayTextEntry[]
+local function DisciplineLoadPowerWordBarTextSettings()
+	---@type TRB.Classes.Settings.DisplayTextEntry[]
+	local textSettings = {
+		{
+			useDefaultFontColor = false,
+			useDefaultFontFace = false,
+			useDefaultFontSize = false,
+			enabled = true,
+			name = L["PriestDisciplineBarTextNamePWRadiance1"],
+			guid = TRB.Functions.String:Guid(),
+			text = "{$pwRadianceTime&$pwRadianceCharges=0}[$pwRadianceTime]",
+			fontFace = "Fonts\\FRIZQT__.TTF",
+			fontFaceName = "Friz Quadrata TT",
+			fontJustifyHorizontal = "LEFT",
+			fontJustifyHorizontalName = L["PositionLeft"],
+			fontSize = 14,
+			color = { color = "FFFFFFFF" },
+			position = {
+				xPos = 0,
+				yPos = 0,
+				relativeTo = "CENTER",
+				relativeToName = L["PositionCenter"],
+				relativeToFrame = "PowerWord_Radiance_1",
+				relativeToFrameName = L["PowerWordRadianceCharge1"],
+			},
+		},
+		{
+			useDefaultFontColor = false,
+			useDefaultFontFace = false,
+			useDefaultFontSize = false,
+			enabled = true,
+			name = L["PriestDisciplineBarTextNamePWRadiance2"],
+			guid = TRB.Functions.String:Guid(),
+			text = "{$pwRadianceTime&$pwRadianceCharges=1}[$pwRadianceTime]",
+			fontFace = "Fonts\\FRIZQT__.TTF",
+			fontFaceName = "Friz Quadrata TT",
+			fontJustifyHorizontal = "LEFT",
+			fontJustifyHorizontalName = L["PositionLeft"],
+			fontSize = 14,
+			color = { color = "FFFFFFFF" },
+			position = {
+				xPos = 0,
+				yPos = 0,
+				relativeTo = "CENTER",
+				relativeToName = L["PositionCenter"],
+				relativeToFrame = "PowerWord_Radiance_2",
+				relativeToFrameName = L["PowerWordRadianceCharge2"],
+			},
+		},
+	}
+
+	return textSettings
+end
+TRB.Options.Priest.DisciplineLoadPowerWordBarTextSettings = DisciplineLoadPowerWordBarTextSettings
+
 ---Loads extra default bar text settings for Discipline
 ---@param classic boolean?
 ---@return TRB.Classes.Settings.DisplayTextEntry[]
 local function DisciplineLoadExtraBarTextSettings(classic)
 	---@type TRB.Classes.Settings.DisplayTextEntry[]
-	local textSettings = {
-	}
-
+	local textSettings = DisciplineLoadPowerWordBarTextSettings()
 	local globalTextSettings = TRB.Functions.Settings:GlobalLoadDefaultBarTextSettings("mana", classic)
 	for k,v in pairs(globalTextSettings) do table.insert(textSettings, v) end
 	return textSettings
@@ -56,7 +112,7 @@ local function DisciplineLoadDefaultSettings(includeBarText, classic)
 		},
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
-			secondary = { visibility = "always", smooth = false },
+			secondary = { visibility = "always", smooth = true },
 			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
@@ -141,6 +197,7 @@ local function DisciplineLoadDefaultSettings(includeBarText, classic)
 
 	if includeBarText then
 		settings.displayText.barText = DisciplineLoadDefaultBarTextSettings(classic)
+		settings.displayText.migrations = { powerWordBarTextSeeded = true }
 	end
 
 	return settings
@@ -317,7 +374,7 @@ local function HolyLoadDefaultSettings(includeBarText, classic)
 		},
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
-			secondary = { visibility = "always", smooth = false },
+			secondary = { visibility = "always", smooth = true },
 			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
@@ -739,6 +796,8 @@ local function DisciplineConstructResetDefaultsPanel(parent)
 		button2 = L["No"],
 		OnAccept = function()
 			spec.displayText.barText = DisciplineLoadDefaultBarTextSettings()
+			spec.displayText.migrations = spec.displayText.migrations or {}
+			spec.displayText.migrations.powerWordBarTextSeeded = true
 			controls.barTextFields.ResetTableValues(spec.displayText.barText)
 		end,
 		timeout = 0,
@@ -765,6 +824,8 @@ local function DisciplineConstructResetDefaultsPanel(parent)
 		button2 = L["No"],
 		OnAccept = function()
 			spec.displayText.barText = DisciplineLoadDefaultBarTextSettings()
+			spec.displayText.migrations = spec.displayText.migrations or {}
+			spec.displayText.migrations.powerWordBarTextSeeded = true
 			controls.barTextFields.ResetTableValues(spec.displayText.barText)
 		end,
 		timeout = 0,
@@ -778,6 +839,8 @@ local function DisciplineConstructResetDefaultsPanel(parent)
 		button2 = L["No"],
 		OnAccept = function()
 			spec.displayText.barText = DisciplineLoadDefaultBarTextSettings(true)
+			spec.displayText.migrations = spec.displayText.migrations or {}
+			spec.displayText.migrations.powerWordBarTextSeeded = true
 			controls.barTextFields.ResetTableValues(spec.displayText.barText)
 		end,
 		timeout = 0,

--- a/ClassModules/Priest.lua
+++ b/ClassModules/Priest.lua
@@ -1005,7 +1005,11 @@ function TRB.Functions.Class:SpellCast(event, spellId)
 			UpdateCastingResourceFinal_Discipline()
 		elseif event == "UNIT_SPELLCAST_SUCCEEDED" then
 			if spellId == spells.powerWordRadiance.id then
-				snapshots[spells.powerWordRadiance.id].cooldown:SpendCharge(spells.powerWordRadiance.duration)
+				local duration = spells.powerWordRadiance.duration
+				if talents:IsTalentActive(spells.brightPupil) then
+					duration = duration + spells.brightPupil.attributes.durationMod
+				end
+				snapshots[spells.powerWordRadiance.id].cooldown:SpendCharge(duration)
 			end
 		end
 	elseif TRB.Data.character.specId == 2 then
@@ -2245,6 +2249,9 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 						-- Mark Holy Word bar text as seeded since HolyLoadDefaultBarTextSettings includes them
 						TRB.Data.settings.priest.holy.displayText.migrations = TRB.Data.settings.priest.holy.displayText.migrations or {}
 						TRB.Data.settings.priest.holy.displayText.migrations.holyWordBarTextSeeded = true
+						-- Mark Power Word bar text as seeded since DisciplineLoadDefaultBarTextSettings includes them
+						TRB.Data.settings.priest.discipline.displayText.migrations = TRB.Data.settings.priest.discipline.displayText.migrations or {}
+						TRB.Data.settings.priest.discipline.displayText.migrations.powerWordBarTextSeeded = true
 					end
 
 					-- Seed Holy Word bar text entries for existing users who don't have them yet
@@ -2255,6 +2262,16 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 							table.insert(TRB.Data.settings.priest.holy.displayText.barText, v)
 						end
 						TRB.Data.settings.priest.holy.displayText.migrations.holyWordBarTextSeeded = true
+					end
+
+					-- Seed Power Word bar text entries for existing users who don't have them yet
+					TRB.Data.settings.priest.discipline.displayText.migrations = TRB.Data.settings.priest.discipline.displayText.migrations or {}
+					if TRB.Data.settings.priest.discipline.displayText.migrations.powerWordBarTextSeeded ~= true then
+						local extraEntries = TRB.Options.Priest.DisciplineLoadPowerWordBarTextSettings()
+						for _, v in ipairs(extraEntries) do
+							table.insert(TRB.Data.settings.priest.discipline.displayText.barText, v)
+						end
+						TRB.Data.settings.priest.discipline.displayText.migrations.powerWordBarTextSeeded = true
 					end
 				else
 					local settings = TRB.Options.Priest.LoadDefaultSettings(true)

--- a/ClassModules/Priest.lua
+++ b/ClassModules/Priest.lua
@@ -127,9 +127,9 @@ local function FillSpecializationCache()
 		innervateCue = false,
 		surgeOfLightPlayed = false
 	}
-	--[[---@type TRB.Classes.Snapshot
-	specCache.priest_discipline.snapshotData.snapshots[spells.powerWordRadiance.id] = TRB.Classes.Snapshot:New(spells.powerWordRadiance)
 	---@type TRB.Classes.Snapshot
+	specCache.priest_discipline.snapshotData.snapshots[spells.powerWordRadiance.id] = TRB.Classes.Snapshot:New(spells.powerWordRadiance)
+	--[[---@type TRB.Classes.Snapshot
 	specCache.priest_discipline.snapshotData.snapshots[spells.shadowCovenant.id] = TRB.Classes.Snapshot:New(spells.shadowCovenant)
 	---@type TRB.Classes.Snapshot
 	specCache.priest_discipline.snapshotData.snapshots[spells.entropicRift.id] = TRB.Classes.Snapshot:New(spells.entropicRift, {
@@ -344,6 +344,49 @@ local function ConstructResourceBar(settings)
 		TRB.Functions.Bar:ConstructBarGroups(settings, barGroups)
 	end
 
+	-- Power Words secondary bar (Discipline only)
+	if TRB.Data.character.specId == 1 and barGroups and barGroups.secondary then
+		local maxPowerWordNodes = TRB.Data.character.maxResource2 or 0
+
+		if maxPowerWordNodes == 0 then
+			barGroups.secondary:Hide()
+		else
+			barGroups.secondary:SetMaxNodes(maxPowerWordNodes)
+			barGroups.secondary:SetNodeCount(maxPowerWordNodes)
+			barGroups.secondary:SetLayout(settings.comboPoints.spacing, TRB.Functions.Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
+			barGroups.secondary:Show()
+
+			local effectiveWidth, cdmForced = TRB.Functions.Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
+			if cdmForced then
+				barGroups.secondary.fullWidth = true
+			end
+
+			barGroups.secondary:ApplyLayout(
+				effectiveWidth,
+				settings.comboPoints.width,
+				settings.comboPoints.height,
+				settings.comboPoints.border
+			)
+
+			local frameLevels = TRB.Data.constants.frameLevels
+			for i = 1, maxPowerWordNodes do
+				local node = barGroups.secondary:GetNode(i)
+				if node then
+					node:SetTextures(
+						settings.textures.comboPointsBar,
+						settings.textures.comboPointsBorder,
+						settings.textures.comboPointsBackground
+					)
+					node:SetMinMax(0, 1)
+					node:SetBorderColor(settings.colors.comboPoints.border.color)
+					node:SetBackgroundColorFromString(settings.colors.comboPoints.background.color)
+					node:SetColor(settings.colors.comboPoints.powerWordRadiance.color)
+					node:SetFrameLevel(frameLevels.comboPoint)
+				end
+			end
+		end
+	end
+
 	-- Holy Words secondary bar (Holy only)
 	if TRB.Data.character.specId == 2 and barGroups and barGroups.secondary then
 		local maxHolyWordNodes = TRB.Data.character.maxResource2 or 0
@@ -464,18 +507,18 @@ local function RefreshLookupData_Discipline()
 	local manaPercentRaw = UnitPowerPercent("player", Enum.PowerType.Mana, false, CurveConstants.ScaleTo100)
 	local manaPercent = string.format("|c%s%." .. manaPrecision .. "f|r", currentManaColor, manaPercentRaw)--TRB.Functions.Number:RoundTo(manaPercentRaw, manaPrecision, "floor"))
 
+	--$pwRadianceTime
+	local _pwRadianceTime = snapshots[spells.powerWordRadiance.id].cooldown.remaining
+	local pwRadianceTime = TRB.Functions.BarText:TimerPrecision(_pwRadianceTime)
+
+	--$pwRadianceCharges
+	local _pwRadianceCharges = snapshots[spells.powerWordRadiance.id].cooldown.charges
+	local pwRadianceCharges = string.format("%.0f", _pwRadianceCharges)
+
 	--[[
 	--$scTime
 	local _scTime = snapshots[spells.shadowCovenant.id].buff:GetRemainingTime(currentTime)
 	local scTime = TRB.Functions.BarText:TimerPrecision(_scTime)
-
-	--$pwRadianceTime
-	local _pwRadianceTime = snapshots[spells.powerWordRadiance.id].cooldown.remaining
-	local pwRadianceTime = TRB.Functions.BarText:TimerPrecision(_pwRadianceTime)
-	
-	--$pwRadianceCharges
-	local _pwRadianceCharges = snapshots[spells.powerWordRadiance.id].cooldown.charges
-	local pwRadianceCharges = string.format("%.0f", _pwRadianceCharges)
 	
 	--$atonementMinTime
 	local _atonementMinTime = snapshots[spells.atonement.id].attributes.minRemainingTime
@@ -511,14 +554,13 @@ local function RefreshLookupData_Discipline()
 	lookup["$manaPercent"] = manaPercent
 	lookup["$resourcePercent"] = manaPercent
 	lookup["$casting"] = castingMana
-	--[[
 	lookup["$pwRadianceTime"] = pwRadianceTime
 	lookup["$radianceTime"] = pwRadianceTime
 	lookup["$powerWordRadianceTime"] = pwRadianceTime
 	lookup["$pwRadianceCharges"] = pwRadianceCharges
 	lookup["$radianceCharges"] = pwRadianceCharges
 	lookup["$powerWordRadianceCharges"] = pwRadianceCharges
-	lookup["$scTime"] = scTime
+	--[[lookup["$scTime"] = scTime
 	lookup["$shadowCovenantTime"] = scTime
 	lookup["$entropicRiftTime"] = entropicRiftTime]]
 	TRB.Data.lookup = lookup
@@ -531,14 +573,13 @@ local function RefreshLookupData_Discipline()
 	lookupLogic["$manaPercent"] = _manaPercent
 	lookupLogic["$resourcePercent"] = _manaPercent
 	lookupLogic["$casting"] = _castingMana
-	--[[
 	lookupLogic["$pwRadianceTime"] = _pwRadianceTime
 	lookupLogic["$radianceTime"] = _pwRadianceTime
 	lookupLogic["$powerWordRadianceTime"] = _pwRadianceTime
 	lookupLogic["$pwRadianceCharges"] = _pwRadianceCharges
 	lookupLogic["$radianceCharges"] = _pwRadianceCharges
 	lookupLogic["$powerWordRadianceCharges"] = _pwRadianceCharges
-	lookupLogic["$scTime"] = _scTime
+	--[[lookupLogic["$scTime"] = _scTime
 	lookupLogic["$shadowCovenantTime"] = _scTime
 	lookupLogic["$entropicRiftTime"] = _entropicRiftTime]]
 	TRB.Data.lookupLogic = lookupLogic
@@ -956,10 +997,16 @@ function TRB.Functions.Class:SpellCast(event, spellId)
 	local currentTime = GetTime()
 
 	if TRB.Data.character.specId == 1 then
+		local spells = spellsData.spells --[[@as TRB.Classes.Priest.DisciplineSpells]]
+		local snapshots = snapshotData.snapshots
 		casting:SnapshotManaSpell()
 		if event == "UNIT_SPELLCAST_START" or event == "UNIT_SPELLCAST_DELAYED" then
 			casting:SnapshotManaSpell()
 			UpdateCastingResourceFinal_Discipline()
+		elseif event == "UNIT_SPELLCAST_SUCCEEDED" then
+			if spellId == spells.powerWordRadiance.id then
+				snapshots[spells.powerWordRadiance.id].cooldown:SpendCharge(spells.powerWordRadiance.duration)
+			end
 		end
 	elseif TRB.Data.character.specId == 2 then
 		local spells = spellsData.spells --[[@as TRB.Classes.Priest.HolySpells]]
@@ -1356,9 +1403,10 @@ local function UpdateSnapshot_Discipline()
 	---@type table<integer, TRB.Classes.Snapshot>
 	local snapshots = TRB.Data.snapshotData.snapshots
 
-	--[[snapshots[spells.powerWordRadiance.id].cooldown:Refresh(true)
-	snapshots[spells.shadowCovenant.id].buff:GetRemainingTime(currentTime)
+	--[[snapshots[spells.shadowCovenant.id].buff:GetRemainingTime(currentTime)
 	snapshots[spells.entropicRift.id].buff:GetRemainingTime(currentTime)]]
+
+	snapshots[spells.powerWordRadiance.id].cooldown:Refresh(true)
 end
 
 local function UpdateSnapshot_Holy()
@@ -1459,6 +1507,48 @@ local function UpdateResourceBar()
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
+			end
+
+			-- Update Power Words secondary bar
+			if specSettings.displayBar.secondary.visibility ~= "never" then
+				local cpBorderColor = specSettings.colors.comboPoints.border.color
+				local currentCp = 1
+
+				if talents:IsTalentActive(spells.powerWordRadiance) and specSettings.colors.comboPoints.powerWordRadiance.enabled then
+					local cooldown = snapshots[spells.powerWordRadiance.id].cooldown
+					local charges = cooldown.manualCharges or 0
+					local maxCharges = cooldown.manualMaxCharges or 1
+
+					for chargeIndex = 1, maxCharges do
+						if barGroups and barGroups.secondary then
+							local cpNode = barGroups.secondary:GetNode(currentCp)
+							if cpNode then
+								local cpColor = specSettings.colors.comboPoints.powerWordRadiance.color
+								local cpKey = "comboPoint" .. currentCp
+								if chargeIndex <= charges then
+									-- Available charge: full bar
+									cpNode:ClearTimerDuration()
+									TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, cpKey, cpNode, 1, 1)
+								elseif chargeIndex == charges + 1 and cooldown:IsRechargingManual() and cooldown.manualCooldownExpires ~= nil then
+									-- Currently recharging: manual timer-based progress
+									cpNode:ClearTimerDuration()
+									local progress = cooldown:GetManualCooldownProgress(currentTime)
+									TRB.Data.cache.values.bar[cpKey] = nil
+									TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, cpKey, cpNode, progress, 1)
+								else
+									-- Empty charge (not yet recharging)
+									cpNode:ClearTimerDuration()
+									TRB.Data.cache.values.bar[cpKey] = nil
+									TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, cpKey, cpNode, 0, 1)
+								end
+								cpNode:SetColor(cpColor)
+								cpNode:SetBorderColor(cpBorderColor)
+								cpNode:SetBackgroundColorFromString(specSettings.colors.comboPoints.background.color)
+								currentCp = currentCp + 1
+							end
+						end
+					end
+				end
 			end
 
 			-- Update health bar
@@ -1906,10 +1996,10 @@ local function SwitchSpec()
 		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.priest_discipline.settings)
 
 		local lookup = TRB.Data.lookup or {}
-		--[[lookup["#atonement"] = spells.atonement.icon
 		lookup["#pwRadiance"] = spells.powerWordRadiance.icon
 		lookup["#radiance"] = spells.powerWordRadiance.icon
 		lookup["#powerWordRadiance"] = spells.powerWordRadiance.icon
+		--[[lookup["#atonement"] = spells.atonement.icon
 		lookup["#sc"] = spells.shadowCovenant.icon
 		lookup["#shadowCovenant"] = spells.shadowCovenant.icon
 		lookup["#entropicRift"] = spells.entropicRift.icon]]
@@ -1919,6 +2009,13 @@ local function SwitchSpec()
 
 		-- Ensure resource snapshots are initialized before bar construction.
 		TRB.Functions.Class:EventRegistration()
+
+		-- Initialize manual charge tracking for Power Word: Radiance (API returns secret values)
+		local pwrSnapshot = specCache.priest_discipline.snapshotData.snapshots[spells.powerWordRadiance.id]
+		if pwrSnapshot then
+			local maxCharges = specCache.priest_discipline.talents:IsTalentActive(spells.lightsPromise) and 2 or 1
+			pwrSnapshot.cooldown:InitializeManualCharges(maxCharges)
+		end
 
 		talents = specCache.priest_discipline.talents
 		TRB.Data.barConstructedForSpec = "priest_discipline"
@@ -2235,13 +2332,17 @@ function TRB.Functions.Class:CheckCharacter()
 		local settings = TRB.Data.settings.priest.discipline
 		
 		local totalPowerWordCharges = 0
-		
-		--[[if talents:IsTalentActive(spells.powerWordRadiance) and settings.colors.comboPoints.powerWordRadiance.enabled then
-			totalPowerWordCharges = totalPowerWordCharges + 1
-			if talents:IsTalentActive(spells.lightsPromise) then
+
+		local discTalents = TRB.Data.specCache.priest_discipline and TRB.Data.specCache.priest_discipline.talents
+		if discTalents then
+			if discTalents:IsTalentActive(spells.powerWordRadiance) and settings.colors.comboPoints.powerWordRadiance.enabled then
 				totalPowerWordCharges = totalPowerWordCharges + 1
+				if discTalents:IsTalentActive(spells.lightsPromise) then
+					totalPowerWordCharges = totalPowerWordCharges + 1
+				end
 			end
-		end]]
+		end
+
 		local sharedSettings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 	
 		if sharedSettings ~= nil then
@@ -2361,10 +2462,10 @@ function TRB.Functions.Class:HideResourceBar(force)
 				-- "never" means showPrimary stays false
 			end
 
-			-- Determine secondary (Holy Words) bar visibility (Holy only)
-			-- If all 3 Holy Word enables are unchecked (maxResource2 == 0), treat as "never"
+			-- Determine secondary bar visibility (Discipline Power Words / Holy Words)
+			-- If all enables are unchecked (maxResource2 == 0), treat as "never"
 			local showSecondary = false
-			if TRB.Data.character.specId == 2 and not forceHideAll and sharedSettings.displayBar.secondary ~= nil
+			if (TRB.Data.character.specId == 1 or TRB.Data.character.specId == 2) and not forceHideAll and sharedSettings.displayBar.secondary ~= nil
 				and (TRB.Data.character.maxResource2 or 0) > 0 then
 				if sharedSettings.displayBar.secondary.visibility == "always" then
 					showSecondary = true
@@ -2516,7 +2617,7 @@ function TRB.Functions.Class:IsValidVariableForSpec(var)
 
 	if TRB.Data.character.specId == 1 then
 		local spells = spellsData.spells --[[@as TRB.Classes.Priest.DisciplineSpells]]
-		--[[if var == "$pwRadianceTime" or var == "$radianceTime" or var == "$powerWordRadianceTime" then
+		if var == "$pwRadianceTime" or var == "$radianceTime" or var == "$powerWordRadianceTime" then
 			if snapshots[spells.powerWordRadiance.id].cooldown.remaining > 0 then
 				valid = true
 			end
@@ -2524,11 +2625,11 @@ function TRB.Functions.Class:IsValidVariableForSpec(var)
 			if snapshots[spells.powerWordRadiance.id].cooldown.charges > 0 then
 				valid = true
 			end
-		elseif var == "$scTime" or var == "$shadowCovenantTime" then
+		--[[elseif var == "$scTime" or var == "$shadowCovenantTime" then
 			if snapshots[spells.shadowCovenant.id].buff.isActive then
 				valid = true
-			end
-		end]]
+			end]]
+		end
 	elseif TRB.Data.character.specId == 2 then
 		local spells = spellsData.spells --[[@as TRB.Classes.Priest.HolySpells]]
 		--[[if var == "$lightweaverTime" then
@@ -2757,6 +2858,33 @@ function TRB.Functions.Class:GetBarTextFrame(relativeToFrame)
 				end
 			end
 			return nil, true, false
+		end
+
+		-- Handle Power Word: Radiance frames (PowerWordRadiance1, PowerWordRadiance2)
+		if TRB.Data.character.specId == 1 then
+			local pwrMatch = string.match(relativeToFrame, "^PowerWordRadiance(%d+)$")
+			if pwrMatch ~= nil then
+				local chargeIndex = tonumber(pwrMatch)
+				if chargeIndex ~= nil then
+					local discTalents = TRB.Data.specCache.priest_discipline and TRB.Data.specCache.priest_discipline.talents
+					local discSpells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Priest.DisciplineSpells]]
+					local discSettings = TRB.Data.settings.priest.discipline
+
+					if discTalents and discTalents:IsTalentActive(discSpells.powerWordRadiance) and discSettings.colors.comboPoints.powerWordRadiance.enabled then
+						local maxCharges = discTalents:IsTalentActive(discSpells.lightsPromise) and 2 or 1
+						if chargeIndex >= 1 and chargeIndex <= maxCharges then
+							if barGroups and barGroups.secondary then
+								local secondaryNode = barGroups.secondary:GetNode(chargeIndex)
+								if secondaryNode then
+									local isVisible = barGroups.secondary.isVisible and secondaryNode.isVisible
+									return secondaryNode:GetFrame(), true, isVisible
+								end
+							end
+						end
+					end
+				end
+				return nil, false, false
+			end
 		end
 
 		-- Handle Holy Word frames (HolyWordSerenity1, HolyWordSanctify1, HolyWordChastise1, etc.)

--- a/Functions/IO.lua
+++ b/Functions/IO.lua
@@ -78,11 +78,11 @@ local function ExportConfigurationSections(classId, specId, settings, includeBar
 			end 
 		elseif classId == 5 then -- Priests
 			if specId == 1 then -- Discipline
-				--configuration.colors.comboPoints = settings.colors.comboPoints
-				--configuration.comboPoints = settings.comboPoints
+				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
+				configuration.comboPoints = settings.comboPoints
 			elseif specId == 2 then -- Holy
-				--configuration.colors.comboPoints = settings.colors.comboPoints
-				--configuration.comboPoints = settings.comboPoints
+				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
+				configuration.comboPoints = settings.comboPoints
 			elseif specId == 3 then -- Shadow
 				-- Export mana bar settings
 				configuration.bars = configuration.bars or {}

--- a/Functions/News.lua
+++ b/Functions/News.lua
@@ -28,9 +28,14 @@ local content = [====[
 - [#642](#642) Show Abyssal Gaze as a threshold line instead of Eye Beam when in Demon Form and talented into Demonic Intensity (Fel-Scarred).
 
 ## Priest
+### Discipline
+
+- [#508](#508) Restore the ability to track and show the status of Power Words (Radiance) in its own bar group. Features returning include: charges, cooldown remaining, and bar text.
+- [#508](#508) Add default Power Word bar text to show the remaining cooldown of its respective Power Word.
+
 ### Holy
 
--[#508](#508) Add default Holy Word bar text to show the remaining cooldown of its respective Holy Word.
+- [#508](#508) Add default Holy Word bar text to show the remaining cooldown of its respective Holy Word.
 
 ---
 

--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -1940,3 +1940,5 @@ L["DemonHunterHavocThresholdCheckboxEyeBeamAbyssalGaze"] = "Eye Beam / Abyssal G
 L["DemonHunterHavocThresholdCheckboxEyeBeamAbyssalGazeTooltip"] = "This will show the vertical line on the bar denoting how much Fury is required to use Eye Beam. Shows for Abyssal Gaze while in Demon Form with Demonic Intensity talented (Fel-Scarred)."
 
 L["TabPowerWords"] = "Power Words"
+L["PriestDisciplineBarTextNamePWRadiance1"] = "PW Radiance 1"
+L["PriestDisciplineBarTextNamePWRadiance2"] = "PW Radiance 2"

--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -1933,3 +1933,4 @@ L["CheckboxUseGlobalTooltip_HealthBarColors"] = "When checked, the global settin
 L["SoulFragment6"] = "Soul Fragment 6"
 
 L["TabHolyWords"] = "Holy Words"
+L["TabPowerWords"] = "Power Words"

--- a/Options/OptionsUi.lua
+++ b/Options/OptionsUi.lua
@@ -6390,16 +6390,16 @@ function TRB.Functions.OptionsUi:GenerateBarTextEditor(parent, controls, spec, c
 			L["HealthBar"],
 			L["Screen"],
 		}
-	--elseif (classId == 5 and specId == 1) then -- Discipline Priest
-	--	relativeToFrame[L["PowerWordRadianceCharge1"]] = "PowerWord_Radiance_1"
-	--	relativeToFrame[L["PowerWordRadianceCharge2"]] = "PowerWord_Radiance_2"
-	--	relativeToFrameList = {
-	--		L["MainResourceBar"],
-	--		L["PowerWordRadianceCharge1"],
-	--		L["PowerWordRadianceCharge2"],
-	--		L["HealthBar"],
-	--		L["Screen"],
-	--	}
+	elseif (classId == 5 and specId == 1) then -- Discipline Priest
+		relativeToFrame[L["PowerWordRadianceCharge1"]] = "PowerWord_Radiance_1"
+		relativeToFrame[L["PowerWordRadianceCharge2"]] = "PowerWord_Radiance_2"
+		relativeToFrameList = {
+			L["MainResourceBar"],
+			L["PowerWordRadianceCharge1"],
+			L["PowerWordRadianceCharge2"],
+			L["HealthBar"],
+			L["Screen"],
+		}
 	elseif (classId == 5 and specId == 2) then -- Holy Priest
 		relativeToFrame[L["HolyWordSerenityCharge1"]] = "HolyWord_Serenity_1"
 		relativeToFrame[L["HolyWordSerenityCharge2"]] = "HolyWord_Serenity_2"

--- a/TwintopInsanityBar.toc
+++ b/TwintopInsanityBar.toc
@@ -13,7 +13,7 @@
 ## Title-zhTW: Twintop 的資源欄
 ## Author: Twintop
 ## X-AuthorServer: Frostmourne-US/OCE
-## Version: 12.0.1.10
+## Version: 12.0.1.11
 ## X-ReleaseType: release
 ## X-ReleaseDate: 2026-02-23
 ## SavedVariables: TwintopInsanityBarSettings


### PR DESCRIPTION
Adds default bar text entries anchored to Power Word: Radiance charge frames, displaying cooldown timers — mirroring the Holy Word bar text pattern for Holy Priest.

**Changes:**
- Added 2 bar text entries (`PW Radiance 1`, `PW Radiance 2`) in `DisciplineLoadPowerWordBarTextSettings()` with canonical property ordering
- Added migration (`powerWordBarTextSeeded`) to seed entries into existing users' settings without re-adding if deliberately deleted
- Migration flag co-located in `displayText.migrations` so it travels with export/import
- Localized entry names via `L["PriestDisciplineBarTextNamePWRadiance1"]` / `PWRadiance2`
- Set migration flag in all reset-defaults paths and the `midnightBarTextReset` block