### PR TITLE
Add Incoming Heal overlay to Health Bar #519

### DIFF
--- a/ClassModules/DeathKnight.lua
+++ b/ClassModules/DeathKnight.lua
@@ -869,7 +869,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -974,7 +974,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1079,7 +1079,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1581,7 +1581,7 @@ function TRB.Functions.Class:IsValidVariableForSpec(var)
 				break
 			end
 		end
-	elseif var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" then
+	elseif var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" or var == "$incomingHeal" then
 		valid = true
 	end
 

--- a/ClassModules/DemonHunter.lua
+++ b/ClassModules/DemonHunter.lua
@@ -1032,7 +1032,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1195,7 +1195,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1388,7 +1388,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1957,7 +1957,7 @@ function TRB.Functions.Class:IsValidVariableForSpec(var)
 		if snapshotData.snapshots[spells.metamorphosis.id].buff.isActive then
 			valid = true
 		end
-	elseif var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" then
+	elseif var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" or var == "$incomingHeal" then
 		valid = true
 	elseif var == "$resource" or var == "$fury" then
 		-- Do not compare resource as it may be a secret value

--- a/ClassModules/Druid.lua
+++ b/ClassModules/Druid.lua
@@ -1834,7 +1834,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 
 			-- Mana bar update (Balance only)
@@ -2179,7 +2179,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -2382,7 +2382,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -2466,7 +2466,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -3166,7 +3166,7 @@ function TRB.Functions.Class:IsValidVariableForSpec(var)
 	end
 
 	-- Health variables are valid for all specs
-	if var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" then
+	if var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" or var == "$incomingHeal" then
 		valid = true
 		return valid
 	end

--- a/ClassModules/Evoker.lua
+++ b/ClassModules/Evoker.lua
@@ -797,7 +797,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -839,7 +839,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -931,7 +931,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1428,7 +1428,7 @@ function TRB.Functions.Class:IsValidVariableForSpec(var)
 		end
 	elseif var == "$comboPointsMax"or var == "$essenceMax" then
 		valid = true
-	elseif var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" then
+	elseif var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" or var == "$incomingHeal" then
 		valid = true
 	end
 

--- a/ClassModules/Hunter.lua
+++ b/ClassModules/Hunter.lua
@@ -897,7 +897,7 @@ local function UpdateResourceBar()
 				healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 				healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 			end
-			TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+			TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
 	elseif TRB.Data.character.specId == 2 then
@@ -1074,7 +1074,7 @@ local function UpdateResourceBar()
 				healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 				healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 			end
-			TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+			TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
 	elseif TRB.Data.character.specId == 3 then
@@ -1282,7 +1282,7 @@ local function UpdateResourceBar()
 				healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 				healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 			end
-			TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+			TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
 	end
@@ -1804,7 +1804,7 @@ function TRB.Functions.Class:IsValidVariableForSpec(var)
 		if snapshotData.casting.resourceRaw ~= nil and snapshotData.casting.resourceRaw ~= 0 then
 			valid = true
 		end
-	elseif var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" then
+	elseif var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" or var == "$incomingHeal" then
 		valid = true
 	end
 

--- a/ClassModules/Mage.lua
+++ b/ClassModules/Mage.lua
@@ -659,7 +659,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -730,7 +730,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -799,7 +799,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -1328,7 +1328,7 @@ function TRB.Functions.Class:IsValidVariableForSpec(var)
 		valid = false
 	elseif var == "$resourceMax" or var == "$manaMax" then
 		valid = true
-	elseif var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" then
+	elseif var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" or var == "$incomingHeal" then
 		valid = true
 	end
 

--- a/ClassModules/Monk.lua
+++ b/ClassModules/Monk.lua
@@ -1062,7 +1062,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1106,7 +1106,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1277,7 +1277,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -1951,7 +1951,7 @@ function TRB.Functions.Class:IsValidVariableForSpec(var)
 	end
 
 	-- Health variables - valid for all specs
-	if var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" then
+	if var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" or var == "$incomingHeal" then
 		valid = true
 	end
 

--- a/ClassModules/Options/DeathKnightOptions.lua
+++ b/ClassModules/Options/DeathKnightOptions.lua
@@ -221,7 +221,7 @@ local function BloodLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		overcap = {
@@ -393,7 +393,7 @@ local function FrostLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		overcap = {
@@ -561,7 +561,7 @@ local function UnholyLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		overcap = {

--- a/ClassModules/Options/DemonHunterOptions.lua
+++ b/ClassModules/Options/DemonHunterOptions.lua
@@ -114,7 +114,7 @@ local function HavocLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		endOf = {
@@ -274,7 +274,7 @@ local function VengeanceLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = true },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		endOf = {
@@ -469,7 +469,7 @@ local function DevourerLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = true },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		endOf = {

--- a/ClassModules/Options/DruidOptions.lua
+++ b/ClassModules/Options/DruidOptions.lua
@@ -289,7 +289,7 @@ local function BalanceLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			mana = { visibility = "never", smooth = true },
 			dragonriding = true,
 			enableFormSwitching = true
@@ -628,7 +628,7 @@ local function FeralLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true,
 			enableFormSwitching = true
 		},
@@ -810,7 +810,7 @@ local function GuardianLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true,
 			enableFormSwitching = true
 		},
@@ -931,7 +931,7 @@ local function RestorationLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true,
 			enableFormSwitching = true
 		},

--- a/ClassModules/Options/EvokerOptions.lua
+++ b/ClassModules/Options/EvokerOptions.lua
@@ -198,7 +198,7 @@ local function DevastationLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		endOf = {
@@ -336,7 +336,7 @@ local function PreservationLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
@@ -505,7 +505,7 @@ local function AugmentationLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),

--- a/ClassModules/Options/HunterOptions.lua
+++ b/ClassModules/Options/HunterOptions.lua
@@ -85,7 +85,7 @@ local function BeastMasteryLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		endOf = {
@@ -273,7 +273,7 @@ local function MarksmanshipLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		endOf = {
@@ -446,7 +446,7 @@ local function SurvivalLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		endOf = {

--- a/ClassModules/Options/MageOptions.lua
+++ b/ClassModules/Options/MageOptions.lua
@@ -42,7 +42,7 @@ local function ArcaneLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
@@ -168,7 +168,7 @@ local function FireLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
@@ -256,7 +256,7 @@ local function FrostLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),

--- a/ClassModules/Options/MonkOptions.lua
+++ b/ClassModules/Options/MonkOptions.lua
@@ -148,7 +148,7 @@ local function BrewmasterLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			stagger = { visibility = "always", smooth = true },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		endOf = {
@@ -306,7 +306,7 @@ local function MistweaverLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
@@ -448,7 +448,7 @@ local function WindwalkerLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		overcap = {

--- a/ClassModules/Options/PaladinOptions.lua
+++ b/ClassModules/Options/PaladinOptions.lua
@@ -42,7 +42,7 @@ local function HolyLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
@@ -185,7 +185,7 @@ local function ProtectionLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
@@ -317,7 +317,7 @@ local function RetributionLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),

--- a/ClassModules/Options/PriestOptions.lua
+++ b/ClassModules/Options/PriestOptions.lua
@@ -113,7 +113,7 @@ local function DisciplineLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = true },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
@@ -379,7 +379,7 @@ local function HolyLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = true },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
@@ -598,7 +598,7 @@ local function ShadowLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			mana = { visibility = "never", smooth = true },
 			dragonriding = true
 		},

--- a/ClassModules/Options/RogueOptions.lua
+++ b/ClassModules/Options/RogueOptions.lua
@@ -120,7 +120,7 @@ local function AssassinationLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		overcap = {
@@ -374,7 +374,7 @@ local function OutlawLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		overcap = {
@@ -645,7 +645,7 @@ local function SubtletyLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		overcap = {

--- a/ClassModules/Options/ShamanOptions.lua
+++ b/ClassModules/Options/ShamanOptions.lua
@@ -76,7 +76,7 @@ local function ElementalLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			mana = { visibility = "never", smooth = true },
 			dragonriding = true
 		},
@@ -231,7 +231,7 @@ local function EnhancementLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
@@ -387,7 +387,7 @@ local function RestorationLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),

--- a/ClassModules/Options/WarlockOptions.lua
+++ b/ClassModules/Options/WarlockOptions.lua
@@ -38,7 +38,7 @@ local function AfflictionLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
@@ -163,7 +163,7 @@ local function DemonologyLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
@@ -288,7 +288,7 @@ local function DestructionLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),

--- a/ClassModules/Options/WarriorOptions.lua
+++ b/ClassModules/Options/WarriorOptions.lua
@@ -97,7 +97,7 @@ local function ArmsLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		overcap = {
@@ -367,7 +367,7 @@ local function FuryLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			dragonriding = true
 		},
 		overcap = {
@@ -624,7 +624,7 @@ local function ProtectionLoadDefaultSettings(includeBarText, classic)
 		displayBar = {
 			primary = { visibility = "always", smooth = true },
 			secondary = { visibility = "always", smooth = false },
-			health = { visibility = "always", smooth = true, absorbMode = "appended", showAbsorb = true },
+			health = { visibility = "always", smooth = true },
 			defensives = { visibility = "always", smooth = true },
 			dragonriding = true
 		},

--- a/ClassModules/Paladin.lua
+++ b/ClassModules/Paladin.lua
@@ -717,7 +717,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 
 		end
@@ -761,7 +761,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 
 		end
@@ -805,7 +805,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 
 		end
@@ -1281,7 +1281,7 @@ function TRB.Functions.Class:IsValidVariableForSpec(var)
 		valid = true
 	elseif var == "$comboPointsMax"or var == "$holyPowerMax" then
 		valid = true
-	elseif var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" then
+	elseif var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" or var == "$incomingHeal" then
 		valid = true
 	end
 

--- a/ClassModules/Priest.lua
+++ b/ClassModules/Priest.lua
@@ -1583,7 +1583,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1736,7 +1736,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1969,7 +1969,7 @@ local function UpdateResourceBar()
 				healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 				healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 			end
-			TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+			TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 		end
 
 		-- Update mana bar (Shadow only)
@@ -2853,7 +2853,7 @@ function TRB.Functions.Class:IsValidVariableForSpec(var)
 	end
 
 	-- Health variables (all specs)
-	if var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" then
+	if var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" or var == "$incomingHeal" then
 		valid = true
 	end
 

--- a/ClassModules/Rogue.lua
+++ b/ClassModules/Rogue.lua
@@ -1168,7 +1168,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -1469,7 +1469,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -1767,7 +1767,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -2397,7 +2397,7 @@ function TRB.Functions.Class:IsValidVariableForSpec(var)
 		if IsStealthed() then
 			valid = true
 		end
-	elseif var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" then
+	elseif var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" or var == "$incomingHeal" then
 		valid = true
 	end
 

--- a/ClassModules/Shaman.lua
+++ b/ClassModules/Shaman.lua
@@ -903,7 +903,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 
 			-- Mana bar update (Balance only)
@@ -1103,7 +1103,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -1200,7 +1200,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1798,7 +1798,7 @@ function TRB.Functions.Class:IsValidVariableForSpec(var)
 	end
 
 	-- Health variables are valid for all specs
-	if var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" then
+	if var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" or var == "$incomingHeal" then
 		valid = true
 	end
 	

--- a/ClassModules/Warlock.lua
+++ b/ClassModules/Warlock.lua
@@ -719,7 +719,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -764,7 +764,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -809,7 +809,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -1296,7 +1296,7 @@ function TRB.Functions.Class:IsValidVariableForSpec(var)
 		valid = true
 	elseif var == "$comboPointsMax"or var == "$soulShardsMax" then
 		valid = true
-	elseif var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" then
+	elseif var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" or var == "$incomingHeal" then
 		valid = true
 	end
 

--- a/ClassModules/Warrior.lua
+++ b/ClassModules/Warrior.lua
@@ -984,7 +984,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1112,7 +1112,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1228,7 +1228,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, specCacheSettings)
+				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1785,7 +1785,7 @@ function TRB.Functions.Class:IsValidVariableForSpec(var)
 		if snapshotData.casting.resourceRaw ~= nil and snapshotData.casting.resourceRaw ~= 0 then
 			valid = true
 		end
-	elseif var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" then
+	elseif var == "$health" or var == "$healthMax" or var == "$healthPercent" or var == "$absorb" or var == "$incomingHeal" then
 		valid = true
 	end
 

--- a/Classes/Settings.lua
+++ b/Classes/Settings.lua
@@ -104,10 +104,15 @@ TRB.Classes.Settings = TRB.Classes.Settings or {}
 ---@field public border TRB.Classes.Settings.ColorEntry
 ---@field public background TRB.Classes.Settings.ColorEntry
 
+---@class TRB.Classes.Settings.HealthBarOverlayColorEntry : TRB.Classes.Settings.ColorEntry
+---@field public enabled boolean
+---@field public mode trbOverlayMode
+
 ---@class TRB.Classes.Settings.HealthBarColors
 ---@field public border TRB.Classes.Settings.ColorEntry
 ---@field public background TRB.Classes.Settings.ColorEntry
----@field public absorb TRB.Classes.Settings.ColorEntry
+---@field public absorb TRB.Classes.Settings.HealthBarOverlayColorEntry
+---@field public incomingHeal TRB.Classes.Settings.HealthBarOverlayColorEntry
 ---@field public type trbBarColorType
 ---@field public low TRB.Classes.Settings.ColorThresholdEntry
 ---@field public medium TRB.Classes.Settings.ColorThresholdEntry
@@ -213,14 +218,12 @@ TRB.Classes.Settings = TRB.Classes.Settings or {}
 ---@field public visibility trbBarVisibility
 ---@field public smooth boolean
 
----@alias trbAbsorbMode
----| '"overlay"' # Fills from the left edge of the bar up to the absorb amount
----| '"appended"' # Visually appends the absorb region to the right of the current health fill
+---@alias trbOverlayMode
+---| '"overlay"' # Fills from the left edge of the bar up to the overlay amount
+---| '"appended"' # Visually appends the overlay region to the right of the current health fill
 ---| '"inset"' # Reverse-fill from the health fill's trailing edge going leftward
 
 ---@class trbHealthBarVisibilitySetting : trbBarVisibilitySetting
----@field public showAbsorb boolean?
----@field public absorbMode trbAbsorbMode?
 
 ---@alias trbBarColorType
 ---| '"step"' # Step colors

--- a/Functions/Bar.lua
+++ b/Functions/Bar.lua
@@ -1377,6 +1377,16 @@ function TRB.Functions.Bar:ApplyBarGroupsAppearance(settings, barGroups)
 				end
 				absorbSlot:RefreshAppearance()
 			end
+
+			-- Apply incoming heal overlay appearance via named slot (if it exists)
+			local incomingHealSlot = healthNode:GetOverlaySlot("incomingHeal")
+			if incomingHealSlot then
+				incomingHealSlot.texture = settings.textures.incomingHealBar
+				if settings.colors.healthBar.incomingHeal then
+					incomingHealSlot.color = settings.colors.healthBar.incomingHeal.color
+				end
+				incomingHealSlot:RefreshAppearance()
+			end
 		end
 	end
 
@@ -1404,13 +1414,13 @@ function TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData
 
 	local absorbSlot = healthNode:GetOrCreateOverlaySlot("absorb")
 
-	local showAbsorb = settings.displayBar and settings.displayBar.health and settings.displayBar.health.showAbsorb
-	if not showAbsorb then
+	local absorbColorEntry = settings.colors.healthBar and settings.colors.healthBar.absorb
+	if not absorbColorEntry or not absorbColorEntry.enabled then
 		absorbSlot:HideAll()
 		return
 	end
 
-	local absorbMode = (settings.displayBar and settings.displayBar.health and settings.displayBar.health.absorbMode) or "overlay"
+	local absorbMode = absorbColorEntry.mode or "overlay"
 	local healthMax = snapshotData.attributes.healthMax or 1
 	local absorbAmount = snapshotData.attributes.absorb or 0
 	local hasAbsorb = issecretvalue(absorbAmount) or absorbAmount > 0
@@ -1480,6 +1490,110 @@ function TRB.Functions.Bar:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData
 			absorbSlot:HideOverlay()
 		end
 	end
+end
+
+---Updates the incoming heal overlay on the health bar node.
+---Lazily creates the overlay, sets min/max/value, applies texture and color, and shows/hides.
+---Supports three display modes:
+---  "overlay" (default): fills from the left edge of the bar up to the incoming heal amount.
+---  "appended": visually appends the incoming heal region to the right of the current health fill,
+---              using a clip frame so it never extends past the bar's right boundary.
+---  "inset": reverse-fill incoming heal bar RIGHT-anchored to the health fill's RIGHT edge,
+---           filling leftward to show incoming heals "eating into" visible health.
+---@param healthNode TRB.Classes.BarNode # The health bar node
+---@param snapshotData TRB.Classes.SnapshotData # The current snapshot data
+---@param settings table # The spec cache settings (specCacheSettings)
+function TRB.Functions.Bar:UpdateHealthBarIncomingHealOverlay(healthNode, snapshotData, settings)
+	if not healthNode then return end
+
+	local incomingHealSlot = healthNode:GetOrCreateOverlaySlot("incomingHeal")
+
+	local incomingHealColorEntry = settings.colors.healthBar and settings.colors.healthBar.incomingHeal
+	if not incomingHealColorEntry or not incomingHealColorEntry.enabled then
+		incomingHealSlot:HideAll()
+		return
+	end
+
+	local incomingHealMode = incomingHealColorEntry.mode or "overlay"
+	local healthMax = snapshotData.attributes.healthMax or 1
+	local incomingHealAmount = snapshotData.attributes.incomingHeal or 0
+	local hasIncomingHeal = issecretvalue(incomingHealAmount) or incomingHealAmount > 0
+
+	-- Store for RefreshAppearance
+	incomingHealSlot.texture = settings.textures.incomingHealBar
+	if settings.colors.healthBar and settings.colors.healthBar.incomingHeal then
+		incomingHealSlot.color = settings.colors.healthBar.incomingHeal.color
+	end
+
+	if incomingHealMode == "appended" then
+		-- Appended mode: incoming heal bar LEFT anchored to health fill's RIGHT, inside a clip frame
+		incomingHealSlot:HideOverlay()
+		incomingHealSlot:HideInsetOverlay()
+		incomingHealSlot:CreateAppendedOverlay()
+
+		incomingHealSlot:SetAppendedOverlayMinMax(0, healthMax)
+		incomingHealSlot:SetAppendedOverlayValue(incomingHealAmount)
+		incomingHealSlot:SetAppendedOverlayTexture(settings.textures.incomingHealBar)
+
+		if settings.colors.healthBar and settings.colors.healthBar.incomingHeal then
+			incomingHealSlot:SetAppendedOverlayColor(settings.colors.healthBar.incomingHeal.color)
+		end
+
+		if hasIncomingHeal then
+			incomingHealSlot:ShowAppendedOverlay()
+		else
+			incomingHealSlot:HideAppendedOverlay()
+		end
+	elseif incomingHealMode == "inset" then
+		-- Inset mode: reverse-fill incoming heal bar RIGHT anchored to health fill's RIGHT,
+		-- fills leftward to show incoming heals "eating into" the visible health.
+		incomingHealSlot:HideOverlay()
+		incomingHealSlot:HideAppendedOverlay()
+		incomingHealSlot:CreateInsetOverlay()
+
+		incomingHealSlot:SetInsetOverlayMinMax(0, healthMax)
+		incomingHealSlot:SetInsetOverlayValue(incomingHealAmount)
+		incomingHealSlot:SetInsetOverlayTexture(settings.textures.incomingHealBar)
+
+		if settings.colors.healthBar and settings.colors.healthBar.incomingHeal then
+			incomingHealSlot:SetInsetOverlayColor(settings.colors.healthBar.incomingHeal.color)
+		end
+
+		if hasIncomingHeal then
+			incomingHealSlot:ShowInsetOverlay()
+		else
+			incomingHealSlot:HideInsetOverlay()
+		end
+	else
+		-- Overlay mode (default): fills from left edge
+		incomingHealSlot:HideAppendedOverlay()
+		incomingHealSlot:HideInsetOverlay()
+		incomingHealSlot:CreateOverlay()
+
+		incomingHealSlot:SetOverlayMinMax(0, healthMax)
+		incomingHealSlot:SetOverlayValue(incomingHealAmount)
+		incomingHealSlot:SetOverlayTexture(settings.textures.incomingHealBar)
+
+		if settings.colors.healthBar and settings.colors.healthBar.incomingHeal then
+			incomingHealSlot:SetOverlayColor(settings.colors.healthBar.incomingHeal.color)
+		end
+
+		if hasIncomingHeal then
+			incomingHealSlot:ShowOverlay()
+		else
+			incomingHealSlot:HideOverlay()
+		end
+	end
+end
+
+---Updates all health bar overlays (absorb shield, incoming heals).
+---Wrapper that calls each individual overlay update function.
+---@param healthNode TRB.Classes.BarNode # The health bar node
+---@param snapshotData TRB.Classes.SnapshotData # The current snapshot data
+---@param settings table # The spec cache settings (specCacheSettings)
+function TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, settings)
+	self:UpdateHealthBarAbsorbOverlay(healthNode, snapshotData, settings)
+	self:UpdateHealthBarIncomingHealOverlay(healthNode, snapshotData, settings)
 end
 
 ---Updates the casting resource overlay on the primary resource bar node.

--- a/Functions/BarText.lua
+++ b/Functions/BarText.lua
@@ -58,6 +58,7 @@ function TRB.Functions.BarText:GetCommonValues(additionalValues)
 		{ variable = "$healthMax", description = L["BarTextVariable_healthMax"], printInSettings = true, color = false },
 		{ variable = "$healthPercent", description = L["BarTextVariable_healthPercent"], printInSettings = true, color = false },
 		{ variable = "$absorb", description = L["BarTextVariable_absorb"], printInSettings = true, color = false },
+		{ variable = "$incomingHeal", description = L["BarTextVariable_incomingHeal"], printInSettings = true, color = false },
 
 		{ variable = "$inCombat", description = L["BarTextVariableInCombat"], printInSettings = true, color = false },
 		{ variable = "$inCombatTime", description = L["BarTextVariableInCombatTime"], printInSettings = true, color = false },
@@ -921,6 +922,12 @@ function TRB.Functions.BarText:RefreshLookupDataBase(settings)
 	local absorb = string.format("%s", TRB.Functions.String:ConvertToAbbreviatedNumber(absorbRaw))
 	lookup["$absorb"] = absorb
 	lookupLogic["$absorb"] = absorbRaw
+
+	--$incomingHeal - always update since incoming heals change frequently
+	local incomingHealRaw = snapshotData.attributes.incomingHeal or 0
+	local incomingHeal = string.format("%s", TRB.Functions.String:ConvertToAbbreviatedNumber(incomingHealRaw))
+	lookup["$incomingHeal"] = incomingHeal
+	lookupLogic["$incomingHeal"] = incomingHealRaw
 
 	if checkSecondaryStats or lookup["$haste"] == nil then
 		--$critRating

--- a/Functions/Character.lua
+++ b/Functions/Character.lua
@@ -89,6 +89,7 @@ function TRB.Functions.Character:UpdateHealthValues()
 	snapshotData.attributes.healthMax = UnitHealthMax("player")
 	snapshotData.attributes.healthPercent = UnitHealthPercent("player", true, CurveConstants.ScaleTo100)
 	snapshotData.attributes.absorb = UnitGetTotalAbsorbs("player")
+	snapshotData.attributes.incomingHeal = UnitGetIncomingHeals("player") or 0
 
 	-- Get configurable color curve settings from spec settings
 	local healthBarSettings = nil
@@ -264,7 +265,7 @@ local function CharacterChange(self, event, ...)
 			UpdateResourceValues()
 			TRB.Functions.Character:UpdateOvercapColor()
 		end
-	elseif event == "UNIT_HEALTH" or event == "UNIT_MAXHEALTH" or event == "UNIT_ABSORB_AMOUNT_CHANGED" then
+	elseif event == "UNIT_HEALTH" or event == "UNIT_MAXHEALTH" or event == "UNIT_ABSORB_AMOUNT_CHANGED" or event == "UNIT_HEAL_PREDICTION" then
 		local unitTarget = ...
 		if unitTarget == "player" then
 			TRB.Functions.Character:UpdateHealthValues()
@@ -307,6 +308,7 @@ function TRB.Functions.Character:EnableCharacterChange()
 	characterChangeFrame:RegisterEvent("UNIT_HEALTH")
 	characterChangeFrame:RegisterEvent("UNIT_MAXHEALTH")
 	characterChangeFrame:RegisterEvent("UNIT_ABSORB_AMOUNT_CHANGED")
+	characterChangeFrame:RegisterEvent("UNIT_HEAL_PREDICTION")
 	characterChangeFrame:RegisterEvent("UNIT_STATS")
 	characterChangeFrame:RegisterEvent("COMBAT_RATING_UPDATE")
 	characterChangeFrame:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
@@ -325,6 +327,7 @@ function TRB.Functions.Character:DisableCharacterChange()
 	characterChangeFrame:UnregisterEvent("UNIT_HEALTH")
 	characterChangeFrame:UnregisterEvent("UNIT_MAXHEALTH")
 	characterChangeFrame:UnregisterEvent("UNIT_ABSORB_AMOUNT_CHANGED")
+	characterChangeFrame:UnregisterEvent("UNIT_HEAL_PREDICTION")
 	characterChangeFrame:UnregisterEvent("UNIT_STATS")
 	characterChangeFrame:UnregisterEvent("COMBAT_RATING_UPDATE")
 	characterChangeFrame:UnregisterEvent("PLAYER_EQUIPMENT_CHANGED")
@@ -843,6 +846,7 @@ function TRB.Functions.Character:FillSpecializationCacheSettings(className, spec
 		specCache.settings.colors.healthBar.border = core.colors.healthBar.border
 		specCache.settings.colors.healthBar.background = core.colors.healthBar.background
 		specCache.settings.colors.healthBar.absorb = core.colors.healthBar.absorb
+		specCache.settings.colors.healthBar.incomingHeal = core.colors.healthBar.incomingHeal
 		specCache.settings.colors.healthBar.high = core.colors.healthBar.high
 		specCache.settings.colors.healthBar.medium = core.colors.healthBar.medium
 		specCache.settings.colors.healthBar.low = core.colors.healthBar.low
@@ -851,6 +855,7 @@ function TRB.Functions.Character:FillSpecializationCacheSettings(className, spec
 		specCache.settings.colors.healthBar.border = spec.colors.healthBar.border
 		specCache.settings.colors.healthBar.background = spec.colors.healthBar.background
 		specCache.settings.colors.healthBar.absorb = spec.colors.healthBar.absorb
+		specCache.settings.colors.healthBar.incomingHeal = spec.colors.healthBar.incomingHeal
 		specCache.settings.colors.healthBar.high = spec.colors.healthBar.high
 		specCache.settings.colors.healthBar.medium = spec.colors.healthBar.medium
 		specCache.settings.colors.healthBar.low = spec.colors.healthBar.low
@@ -1002,17 +1007,6 @@ function TRB.Functions.Character:FillSpecializationCacheSettings(className, spec
 		if spec.displayBar then
 			if spec.displayBar.enableFormSwitching ~= nil then
 				specCache.settings.displayBar.enableFormSwitching = spec.displayBar.enableFormSwitching
-			end
-		end
-		-- Override with spec-specific absorb display settings
-		-- showAbsorb and absorbMode are always spec-specific, not global
-		if spec.displayBar and spec.displayBar.health then
-			specCache.settings.displayBar.health = specCache.settings.displayBar.health or {}
-			if spec.displayBar.health.showAbsorb ~= nil then
-				specCache.settings.displayBar.health.showAbsorb = spec.displayBar.health.showAbsorb
-			end
-			if spec.displayBar.health.absorbMode ~= nil then
-				specCache.settings.displayBar.health.absorbMode = spec.displayBar.health.absorbMode
 			end
 		end
 	else

--- a/Functions/News.lua
+++ b/Functions/News.lua
@@ -12,6 +12,13 @@ local content = [====[
 
 ---
 
+# 12.0.1.16-release (2026-02-26)
+## General
+
+- Add support for tracking incoming heals as an optional overlay on the health bar and via a new `$incomingHeal` bar text.
+
+---
+
 # 12.0.1.15-release (2026-02-26)
 ## General
 

--- a/Functions/Settings.lua
+++ b/Functions/Settings.lua
@@ -4301,6 +4301,71 @@ function TRB.Functions.Settings:PortForwardSettings()
 		end
 	end
 
+	-- Migrate health bar overlay settings from displayBar.health to colors.healthBar
+	-- Previously: displayBar.health.showAbsorb, .absorbMode, .showIncomingHeal, .incomingHealMode
+	-- Now:        colors.healthBar.absorb.enabled, .mode; colors.healthBar.incomingHeal.enabled, .mode
+	do
+		local function MigrateHealthBarOverlays(settings)
+			if settings == nil then
+				return
+			end
+			local dh = settings.displayBar and settings.displayBar.health
+			if dh == nil then
+				return
+			end
+
+			-- Ensure colors.healthBar.absorb and .incomingHeal exist as tables
+			if settings.colors == nil then settings.colors = {} end
+			if settings.colors.healthBar == nil then settings.colors.healthBar = {} end
+			if settings.colors.healthBar.absorb == nil then settings.colors.healthBar.absorb = {} end
+			if settings.colors.healthBar.incomingHeal == nil then settings.colors.healthBar.incomingHeal = {} end
+
+			-- Migrate absorb overlay
+			if dh.showAbsorb ~= nil then
+				if settings.colors.healthBar.absorb.enabled == nil then
+					settings.colors.healthBar.absorb.enabled = dh.showAbsorb
+				end
+				dh.showAbsorb = nil
+			end
+			if dh.absorbMode ~= nil then
+				if settings.colors.healthBar.absorb.mode == nil then
+					settings.colors.healthBar.absorb.mode = dh.absorbMode
+				end
+				dh.absorbMode = nil
+			end
+
+			-- Migrate incoming heal overlay
+			if dh.showIncomingHeal ~= nil then
+				if settings.colors.healthBar.incomingHeal.enabled == nil then
+					settings.colors.healthBar.incomingHeal.enabled = dh.showIncomingHeal
+				end
+				dh.showIncomingHeal = nil
+			end
+			if dh.incomingHealMode ~= nil then
+				if settings.colors.healthBar.incomingHeal.mode == nil then
+					settings.colors.healthBar.incomingHeal.mode = dh.incomingHealMode
+				end
+				dh.incomingHealMode = nil
+			end
+		end
+
+		-- Migrate core settings
+		if TwintopInsanityBarSettings and TwintopInsanityBarSettings.core then
+			MigrateHealthBarOverlays(TwintopInsanityBarSettings.core)
+		end
+
+		-- Migrate all class/spec settings
+		for _, className in ipairs(classes) do
+			if TwintopInsanityBarSettings and TwintopInsanityBarSettings[className] then
+				for specName, specSettings in pairs(TwintopInsanityBarSettings[className]) do
+					if type(specSettings) == "table" then
+						MigrateHealthBarOverlays(specSettings)
+					end
+				end
+			end
+		end
+	end
+
 	-- Abyssal Gaze for Havoc Demon Hunters
 	if TwintopInsanityBarSettings ~= nil and
 		TwintopInsanityBarSettings.demonhunter ~= nil and
@@ -4459,7 +4524,8 @@ function TRB.Functions.Settings:DefaultHealthBarColors()
 	return {
 		border = { color = "FF008800" },
 		background = { color = "66000000" },
-		absorb = { color = "CCFFFFB9" },
+		absorb = { color = "CCFFFFB9", enabled = true, mode = "appended" },
+		incomingHeal = { color = "CC80b980", enabled = true, mode = "appended" },
 		type = "step",
 		low = { color = "FFFF0000", threshold = 0.0 },
 		medium = { color = "FFFFFF00", threshold = 0.30 },
@@ -4791,6 +4857,8 @@ function TRB.Functions.Settings:DefaultTextures(includeComboPoints, includeManaB
 		healthBarName=L["LSMStatusBarSmoother"],
 		absorbBar="Interface\\Buttons\\WHITE8X8",
 		absorbBarName="Solid",
+		incomingHealBar="Interface\\Buttons\\WHITE8X8",
+		incomingHealBarName="Solid",
 		castingBar="Interface\\Addons\\TwintopInsanityBar\\StatusBars\\smoother.tga",
 		castingBarName=L["LSMStatusBarSmoother"],
 	}

--- a/Localization/enGB.lua
+++ b/Localization/enGB.lua
@@ -257,51 +257,38 @@ if locale == "enGB" then
     L["EvokerDevastationCheckboxDragonrageTooltip"] = "Changes the bar colour when Dragonrage is active."
     L["EvokerDevastationCheckboxDragonrageEnd"] = "Change bar colour when Dragonrage is ending"
     L["EvokerDevastationCheckboxDragonrageEndTooltip"] = "Changes the bar colour when Dragonrage is ending in the next X GCDs or fixed length of time. Select which to use from the options below."
-
     L["StaggerBarColorExtreme"] = "Extremely Heavy Stagger Colour"
     L["StaggerBarThresholdExtremeTooltip"] = "Stagger percentage at which the bar colour transitions from Heavy to Extremely Heavy."
-
     L["PaladinHolyCheckboxInfusionOfLightTooltip"] = "This will change the bar border colour when you have Infusion of Light."
-
     L["BarTextInstructions1"] = "For more detailed information about Bar Text customisation, see the TRB Wiki on GitHub.\n\n"
     L["StaggerBarColorType"] = "Colour Transition Type"
     L["EvokerCheckboxEssenceBurstTooltip"] = "This will change the bar border colour when you have Essence Burst."
-
     L["PriestHolyCheckboxApotheosisTooltip"] = "This will change the bar colour when you have Apotheosis active."
     L["PriestShadowCheckboxVoidformTooltip"] = "This will change the bar colour when you have Voidform active."
     L["ShamanElementalCheckboxEarthShockTooltip"] = "This will change the bar colour when you have enough Maelstrom to use Earth Shock or Elemental Blast."
     L["ShamanElementalCheckboxAscendanceTooltip"] = "This will change the bar colour when you have Ascendance active."
     L["ShamanManaCheckboxAscendanceTooltip"] = "This will change the bar colour when you have Ascendance active."
     L["RogueCheckboxStealthTooltip"] = "This will change the bar border colour when you are stealthed."
-
     L["PriestShadowCheckboxShadowWordMadnessUsableTooltip"] = "This will change the bar colour when you have enough Insanity to cast Shadow Word: Madness."
-
     L["DemonHunterHavocCheckboxMetamorphosisTooltip"] = "This will change the bar colour when you have Metamorphosis active."
     L["DemonHunterVengeanceCheckboxMetamorphosisTooltip"] = "This will change the bar colour when you have Metamorphosis active."
-
     L["DruidBalanceCheckboxSolarTooltip"] = "This will change the bar colour when you are in Solar Eclipse."
     L["DruidBalanceCheckboxLunarTooltip"] = "This will change the bar colour when you are in Lunar Eclipse."
     L["DruidBalanceCheckboxCelestialTooltip"] = "This will change the bar colour when you have Celestial Alignment or Incarnation: Chosen of Elune active."
-
     L["DruidFeralCheckboxClearcastingTooltip"] = "This will change the bar colour when you have a Clearcasting proc."
     L["DruidFeralCheckboxMaxBiteTooltip"] = "This will change the bar colour when you have enough Energy to cast a maximum damage Ferocious Bite."
     L["DruidFeralCheckboxApexPredatorTooltip"] = "This will change the bar colour when you have an Apex Predator's Craving proc."
-
     L["DruidRestorationCheckboxNoEfflorescenceTooltip"] = "This will change the bar colour when Efflorescence is not active on the ground."
     L["DruidRestorationCheckboxIncarnationTooltip"] = "This will change the bar colour when you have Incarnation: Tree of Life active."
-
     L["HunterMarksmanshipCheckboxTrueshotTooltip"] = "This will change the bar colour when you have Trueshot active."
     L["CheckboxBorderStealthTooltip"] = "This will change the bar border colour when you are stealthed."
-
     L["CheckboxUseGlobalTooltip_HealthBarColors"] = "When checked, the global setting for health bar colours will be used instead of the specialization-specific setting."
-
     L["BarColorSpendingOverlayCheckboxTooltip"] = "When checked, spells that spend your resource will use this overlay colour."
-
     L["MageFrostIciclesColorsHeader"] = "Icicle Colours"
     L["MageFrostCheckboxSameColorIcicles"] = "Use highest stack colour for all filled Icicle nodes"
     L["MageFrostCheckboxSameColorIciclesTooltip"] = "When checked, all filled Icicle nodes will use the colour of the highest applicable colour (e.g., if at max Icicles, all nodes use the Final colour)."
-
     L["HunterSurvivalTipOfTheSpearColorsHeader"] = "Tip of the Spear Colours"
     L["HunterSurvivalCheckboxTipOfTheSpearSameColor"] = "Use highest stack colour for all filled Tip of the Spear nodes"
     L["HunterSurvivalCheckboxTipOfTheSpearSameColorTooltip"] = "When checked, all filled Tip of the Spear nodes will use the colour of the highest applicable colour (e.g., if at max stacks, all nodes use the 3 Charges colour)."
+    L["BarTextVariable_incomingHeal"] = "Your current total incoming heal amount."
 end

--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -1975,9 +1975,9 @@ L["HealthBarShowAbsorbTooltip"] = "When checked, a semi-transparent overlay will
 -- Absorb Display Mode
 L["HealthBarAbsorbMode"] = "Absorb Display Mode"
 L["HealthBarAbsorbModeTooltip"] = "Controls how the absorb shield is displayed on the Health Bar."
-L["AbsorbModeAppended"] = "Appended"
-L["AbsorbModeOverlay"] = "Overlay (from left)"
-L["AbsorbModeInset"] = "Overlay (from right / inset)"
+L["OverlayModeAppended"] = "Appended"
+L["OverlayModeOverlay"] = "Overlay (from left)"
+L["OverlayModeInset"] = "Overlay (from right / inset)"
 
 -- Overlay Textures
 L["OverlayTexturesSectionHeader"] = "Overlay Textures"
@@ -2068,3 +2068,12 @@ L["EditModeMatchAnchorHeight"] = "Match Anchor Frame Height"
 L["EditModeMatchAnchorHeightTooltip"] = "When enabled, the bar's height will automatically match the height of the anchor frame."
 L["EditModeCustomFrameDialogText"] = "Enter the global name of a WoW frame to anchor to (e.g., PlayerFrame, TargetFrame):"
 L["EditModeCustomFrameWarning"] = "Warning: Frame '%s' was not found. Anchoring will use free positioning until the frame becomes available."
+
+-- Incoming Heal Overlay
+L["BarTextVariable_incomingHeal"] = "Your current total incoming heal amount."
+L["IncomingHealBarTexture"] = "Incoming Heal Overlay Texture"
+L["HealthBarIncomingHealColor"] = "Incoming Heal Overlay"
+L["HealthBarShowIncomingHeal"] = "Show incoming heal overlay on Health Bar"
+L["HealthBarShowIncomingHealTooltip"] = "When checked, a semi-transparent overlay will be displayed on the Health Bar showing incoming heals for the player."
+L["HealthBarIncomingHealMode"] = "Incoming Heal Display Mode"
+L["HealthBarIncomingHealModeTooltip"] = "Controls how incoming heals are displayed on the Health Bar."

--- a/Localization/zhCN.lua
+++ b/Localization/zhCN.lua
@@ -1867,9 +1867,9 @@ if locale == "zhCN" then
 	
 	L["HealthBarAbsorbMode"] = "吸收护盾显示模式"
 	L["HealthBarAbsorbModeTooltip"] = "控制吸收护盾在生命值条上的显示方式。"
-	L["AbsorbModeAppended"] = "追加显示"
-	L["AbsorbModeOverlay"] = "叠加显示（从左侧）"
-	L["AbsorbModeInset"] = "叠加显示（从右侧/内嵌）"
+	L["OverlayModeAppended"] = "追加显示"
+	L["OverlayModeOverlay"] = "叠加显示（从左侧）"
+	L["OverlayModeInset"] = "叠加显示（从右侧/内嵌）"
 	
 	L["OverlayTexturesSectionHeader"] = "叠加层纹理"
 	L["CastingBarTexture"] = "施法覆盖层材质"

--- a/Options/OptionsUi.lua
+++ b/Options/OptionsUi.lua
@@ -3879,10 +3879,12 @@ function TRB.Functions.OptionsUi:UpdateOverlayDropdowns(controls, textures, newV
 	DropdownSetupMenuWrapper(controls[variable.."Bar"])
 	if textures.textureLock then
 		-- Sync all overlay textures to the changed value.
-		-- Currently only absorbBar; future overlays would be synced here.
 		textures.absorbBar = newValue
 		textures.absorbBarName = newName
 		DropdownSetupMenuWrapper(controls.absorbBar)
+		textures.incomingHealBar = newValue
+		textures.incomingHealBarName = newName
+		DropdownSetupMenuWrapper(controls.incomingHealBar)
 	end
 
 	TRB.Functions.Character:ResetCaches()
@@ -4049,10 +4051,15 @@ function TRB.Functions.OptionsUi:GenerateBarTexturesOptions(parent, controls, sp
 
 	yCoord = yCoord - 20
 
-	-- Row 1: Absorb Overlay
+	-- Row 1: Absorb Overlay + Incoming Heal Overlay
 	TRB.Functions.OptionsUi:CreateLsmDropdown(parent, controls.dropDown.textures, spec.textures, classId, specId, oUi.xCoord, yCoord, "statusbar", "absorbBar", L["AbsorbBarTexture"], L["StatusBarTextures"],
 		function(newValue)
 			OverlaySetValue("absorb", newValue)
+		end)
+
+	TRB.Functions.OptionsUi:CreateLsmDropdown(parent, controls.dropDown.textures, spec.textures, classId, specId, oUi.xCoord2, yCoord, "statusbar", "incomingHealBar", L["IncomingHealBarTexture"], L["StatusBarTextures"],
+		function(newValue)
+			OverlaySetValue("incomingHeal", newValue)
 		end)
 
 	yCoord = yCoord - 70
@@ -4469,7 +4476,12 @@ function TRB.Functions.OptionsUi:GenerateBarTexturesOptions(parent, controls, sp
 			DropdownSetupMenuWrapper(controls.dropDown.textures.castingBar)
 
 			-- Sync overlay textures
-			-- Currently only absorbBar; future overlays would be synced here.
+			spec.textures.absorbBar = spec.textures.resourceBar
+			spec.textures.absorbBarName = spec.textures.resourceBarName
+			DropdownSetupMenuWrapper(controls.dropDown.textures.absorbBar)
+			spec.textures.incomingHealBar = spec.textures.resourceBar
+			spec.textures.incomingHealBarName = spec.textures.resourceBarName
+			DropdownSetupMenuWrapper(controls.dropDown.textures.incomingHealBar)
 
 			-- Sync border textures
 			if includeComboPoints then
@@ -5569,30 +5581,7 @@ function TRB.Functions.OptionsUi:GenerateHealthBarColorOptions(parent, controls,
 	)
 
 	yCoord = yCoord + 20
-	controls.checkBoxes.showAbsorb = CreateFrame("CheckButton", "TwintopResourceBar_" .. namePrefix .. "_showAbsorb", parent, "ChatConfigCheckButtonTemplate")
-	f = controls.checkBoxes.showAbsorb
-	f:SetPoint("TOPLEFT", oUi.xCoord, yCoord)
-	getglobal(f:GetName() .. 'Text'):SetText(L["HealthBarShowAbsorb"])
-	---@diagnostic disable-next-line: inject-field
-	f.tooltip = L["HealthBarShowAbsorbTooltip"]
-	f:SetChecked(spec.displayBar.health.showAbsorb)
-	f:SetScript("OnClick", function(self, ...)
-		spec.displayBar.health.showAbsorb = self:GetChecked()
-		if TRB.Functions.OptionsUi:IsEditingActiveSpec(classId, specId) then
-			if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
-				TRB.Functions.Class:TriggerResourceBarUpdates()
-			end
-		end
-	end)
-
-	controls.colors = controls.colors or {}
-	controls.colors.absorb = TRB.Functions.OptionsUi:BuildColorPicker(parent, L["HealthBarAbsorbColor"], spec.colors.healthBar.absorb.color, oUi.colorPickerTextWidth, oUi.colorPickerFrameSize, oUi.xCoord2, yCoord)
-	controls.colors.absorb:SetScript("OnMouseDown", function(self, button, ...)
-		TRB.Functions.OptionsUi:ColorOnMouseDown(button, spec.colors.healthBar, controls.colors, "absorb", "health")
-	end)
-
 	-- Absorb Display Mode dropdown
-	yCoord = yCoord - 30
 	controls.dropDown = controls.dropDown or {}
 	controls.dropDown.absorbMode = CreateFrame("DropdownButton", "TwintopResourceBar_" .. namePrefix .. "_AbsorbMode", parent, "WowStyle1DropdownTemplate")
 	controls.dropDown.absorbMode:SetWidth(oUi.sliderWidth)
@@ -5602,21 +5591,21 @@ function TRB.Functions.OptionsUi:GenerateHealthBarColorOptions(parent, controls,
 	controls.dropDown.absorbMode.label.font.tooltip = L["HealthBarAbsorbModeTooltip"]
 
 	local function AbsorbModeIsSelected(value)
-		return value == spec.displayBar.health.absorbMode
+		return value == spec.colors.healthBar.absorb.mode
 	end
 
 	local function AbsorbModeGetDisplayName(value)
 		if value == "appended" then
-			return L["AbsorbModeAppended"]
+			return L["OverlayModeAppended"]
 		elseif value == "inset" then
-			return L["AbsorbModeInset"]
+			return L["OverlayModeInset"]
 		else
-			return L["AbsorbModeOverlay"]
+			return L["OverlayModeOverlay"]
 		end
 	end
 
 	local function AbsorbModeSetSelected(newValue)
-		spec.displayBar.health.absorbMode = newValue
+		spec.colors.healthBar.absorb.mode = newValue
 		controls.dropDown.absorbMode:SetDefaultText(AbsorbModeGetDisplayName(newValue))
 		if TRB.Functions.OptionsUi:IsEditingActiveSpec(classId, specId) then
 			if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
@@ -5626,14 +5615,106 @@ function TRB.Functions.OptionsUi:GenerateHealthBarColorOptions(parent, controls,
 	end
 
 	local function AbsorbModeGenerator(dropdown, rootDescription)
-		rootDescription:CreateRadio(L["AbsorbModeAppended"], AbsorbModeIsSelected, AbsorbModeSetSelected, "appended")
-		rootDescription:CreateRadio(L["AbsorbModeOverlay"], AbsorbModeIsSelected, AbsorbModeSetSelected, "overlay")		
-		rootDescription:CreateRadio(L["AbsorbModeInset"], AbsorbModeIsSelected, AbsorbModeSetSelected, "inset")
+		rootDescription:CreateRadio(L["OverlayModeAppended"], AbsorbModeIsSelected, AbsorbModeSetSelected, "appended")
+		rootDescription:CreateRadio(L["OverlayModeOverlay"], AbsorbModeIsSelected, AbsorbModeSetSelected, "overlay")		
+		rootDescription:CreateRadio(L["OverlayModeInset"], AbsorbModeIsSelected, AbsorbModeSetSelected, "inset")
 	end
 
 	controls.dropDown.absorbMode:SetupMenu(AbsorbModeGenerator)
-	controls.dropDown.absorbMode:SetDefaultText(AbsorbModeGetDisplayName(spec.displayBar.health.absorbMode))
+	controls.dropDown.absorbMode:SetDefaultText(AbsorbModeGetDisplayName(spec.colors.healthBar.absorb.mode))
 	controls.dropDown.absorbMode:SetPoint("TOPLEFT", oUi.xCoord, yCoord - 30)
+
+	yCoord = yCoord - 10
+
+	controls.colors = controls.colors or {}
+	controls.colors.absorb = TRB.Functions.OptionsUi:BuildColorPicker(parent, L["HealthBarAbsorbColor"], spec.colors.healthBar.absorb.color, oUi.colorPickerTextWidth, oUi.colorPickerFrameSize, oUi.xCoord2, yCoord)
+	controls.colors.absorb:SetScript("OnMouseDown", function(self, button, ...)
+		TRB.Functions.OptionsUi:ColorOnMouseDown(button, spec.colors.healthBar, controls.colors, "absorb", "health")
+	end)
+	
+	yCoord = yCoord - 30
+	controls.checkBoxes.showAbsorb = CreateFrame("CheckButton", "TwintopResourceBar_" .. namePrefix .. "_showAbsorb", parent, "ChatConfigCheckButtonTemplate")
+	f = controls.checkBoxes.showAbsorb
+	f:SetPoint("TOPLEFT", oUi.xCoord2, yCoord)
+	getglobal(f:GetName() .. 'Text'):SetText(L["HealthBarShowAbsorb"])
+	---@diagnostic disable-next-line: inject-field
+	f.tooltip = L["HealthBarShowAbsorbTooltip"]
+	f:SetChecked(spec.colors.healthBar.absorb.enabled)
+	f:SetScript("OnClick", function(self, ...)
+		spec.colors.healthBar.absorb.enabled = self:GetChecked()
+		if TRB.Functions.OptionsUi:IsEditingActiveSpec(classId, specId) then
+			if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
+				TRB.Functions.Class:TriggerResourceBarUpdates()
+			end
+		end
+	end)
+
+	-- Incoming Heal Display Mode dropdown
+	yCoord = yCoord - 20
+	controls.dropDown.incomingHealMode = CreateFrame("DropdownButton", "TwintopResourceBar_" .. namePrefix .. "_IncomingHealMode", parent, "WowStyle1DropdownTemplate")
+	controls.dropDown.incomingHealMode:SetWidth(oUi.sliderWidth)
+	controls.dropDown.incomingHealMode.label = TRB.Functions.OptionsUi:BuildSectionHeader(parent, L["HealthBarIncomingHealMode"], oUi.xCoord, yCoord)
+	controls.dropDown.incomingHealMode.label.font:SetFontObject(GameFontNormal)
+	---@diagnostic disable-next-line: inject-field
+	controls.dropDown.incomingHealMode.label.font.tooltip = L["HealthBarIncomingHealModeTooltip"]
+
+	local function IncomingHealModeIsSelected(value)
+		return value == spec.colors.healthBar.incomingHeal.mode
+	end
+
+	local function IncomingHealModeGetDisplayName(value)
+		if value == "appended" then
+			return L["OverlayModeAppended"]
+		elseif value == "inset" then
+			return L["OverlayModeInset"]
+		else
+			return L["OverlayModeOverlay"]
+		end
+	end
+
+	local function IncomingHealModeSetSelected(newValue)
+		spec.colors.healthBar.incomingHeal.mode = newValue
+		controls.dropDown.incomingHealMode:SetDefaultText(IncomingHealModeGetDisplayName(newValue))
+		if TRB.Functions.OptionsUi:IsEditingActiveSpec(classId, specId) then
+			if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
+				TRB.Functions.Class:TriggerResourceBarUpdates()
+			end
+		end
+	end
+
+	local function IncomingHealModeGenerator(dropdown, rootDescription)
+		rootDescription:CreateRadio(L["OverlayModeAppended"], IncomingHealModeIsSelected, IncomingHealModeSetSelected, "appended")
+		rootDescription:CreateRadio(L["OverlayModeOverlay"], IncomingHealModeIsSelected, IncomingHealModeSetSelected, "overlay")
+		rootDescription:CreateRadio(L["OverlayModeInset"], IncomingHealModeIsSelected, IncomingHealModeSetSelected, "inset")
+	end
+
+	controls.dropDown.incomingHealMode:SetupMenu(IncomingHealModeGenerator)
+	controls.dropDown.incomingHealMode:SetDefaultText(IncomingHealModeGetDisplayName(spec.colors.healthBar.incomingHeal.mode))
+	controls.dropDown.incomingHealMode:SetPoint("TOPLEFT", oUi.xCoord, yCoord - 30)
+
+	yCoord = yCoord - 10
+	-- Incoming Heal Overlay
+	controls.colors.incomingHeal = TRB.Functions.OptionsUi:BuildColorPicker(parent, L["HealthBarIncomingHealColor"], spec.colors.healthBar.incomingHeal.color, oUi.colorPickerTextWidth, oUi.colorPickerFrameSize, oUi.xCoord2, yCoord)
+	controls.colors.incomingHeal:SetScript("OnMouseDown", function(self, button, ...)
+		TRB.Functions.OptionsUi:ColorOnMouseDown(button, spec.colors.healthBar, controls.colors, "incomingHeal", "health")
+	end)
+
+	yCoord = yCoord - 30
+	controls.checkBoxes.showIncomingHeal = CreateFrame("CheckButton", "TwintopResourceBar_" .. namePrefix .. "_showIncomingHeal", parent, "ChatConfigCheckButtonTemplate")
+	f = controls.checkBoxes.showIncomingHeal
+	f:SetPoint("TOPLEFT", oUi.xCoord2, yCoord)
+	getglobal(f:GetName() .. 'Text'):SetText(L["HealthBarShowIncomingHeal"])
+	---@diagnostic disable-next-line: inject-field
+	f.tooltip = L["HealthBarShowIncomingHealTooltip"]
+	f:SetChecked(spec.colors.healthBar.incomingHeal.enabled)
+	f:SetScript("OnClick", function(self, ...)
+		spec.colors.healthBar.incomingHeal.enabled = self:GetChecked()
+		if TRB.Functions.OptionsUi:IsEditingActiveSpec(classId, specId) then
+			if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
+				TRB.Functions.Class:TriggerResourceBarUpdates()
+			end
+		end
+	end)
 
 	return yCoord - 30
 end


### PR DESCRIPTION
Adds an incoming heals overlay to the health bar (mirroring the existing absorb shield overlay) and fixes both overlays not respecting the "use global settings" toggle.

### Changes

**New feature: Incoming heals overlay**
- New overlay on the health bar showing incoming heals, with the same three display modes as absorbs (appended, overlay, inset)
- Configurable color, texture, enable/disable toggle, and display mode
- New `$incomingHeal` bar text variable across all 40 specs
- New `UpdateHealthBarIncomingHealOverlay` and unified `UpdateHealthBarOverlays` wrapper in Bar.lua

**Bug fix: Overlay settings now follow the global settings toggle**
- Moved `enabled` and `mode` properties from `displayBar.health` into `colors.healthBar.absorb` and `colors.healthBar.incomingHeal` as a new `HealthBarOverlayColorEntry` type
- These properties now live inside the color tables, which already follow the `s.healthBarColors` global toggle via `FillSpecializationCacheSettings` — no special-case override logic needed
- Unified `trbAbsorbMode` / `trbIncomingHealMode` into a single `trbOverlayMode` alias
- Migration code moves existing saved settings from old to new location (core + all specs)

**Localization**
- Added overlay mode labels (`OverlayModeAppended`, `OverlayModeOverlay`, `OverlayModeInset`) replacing absorb-specific variants
- Added incoming heal UI strings (color picker, checkbox, mode dropdown, tooltips)