### PR TITLE
Restore Windwalker Functionality

### DIFF
--- a/ClassModules/Classes/MonkClasses.lua
+++ b/ClassModules/Classes/MonkClasses.lua
@@ -383,13 +383,13 @@ function TRB.Classes.Monk.WindwalkerSpells:New()
 		id = 392983,
 		hasCooldown = true,
 		isTalent = true,
-		cooldown = 30 -- Tooptip lies and says it is 35 as of 2026-03-02
+		cooldown = 30 -- Tooltip lies and says it is 35 as of 2026-03-02
 	})
 	self.whirlingDragonPunch = TRB.Classes.SpellBase:New({
 		id = 152175,
 		hasCooldown = true,
 		isTalent = true,
-		cooldown = 30 -- Tooptip lies and says it is 35 as of 2026-03-02
+		cooldown = 30 -- Tooltip lies and says it is 35 as of 2026-03-02
 	})
 	self.communionWithWind = TRB.Classes.SpellBase:New({
 		id = 451576,

--- a/ClassModules/Classes/MonkClasses.lua
+++ b/ClassModules/Classes/MonkClasses.lua
@@ -250,6 +250,7 @@ end
 ---@field public danceOfChiJi TRB.Classes.SpellBase
 ---@field public combatWisdom TRB.Classes.SpellBase
 ---@field public heartOfTheJadeSerpent TRB.Classes.SpellBase
+---@field public communionWithWind TRB.Classes.SpellBase
 ---@field public blackoutKick TRB.Classes.SpellComboPoint
 ---@field public spinningCraneKick TRB.Classes.SpellComboPoint
 ---@field public risingSunKick TRB.Classes.SpellComboPoint
@@ -382,10 +383,22 @@ function TRB.Classes.Monk.WindwalkerSpells:New()
 		id = 392983,
 		hasCooldown = true,
 		isTalent = true,
-		cooldown = 40
+		cooldown = 30 -- Tooptip lies and says it is 35 as of 2026-03-02
+	})
+	self.whirlingDragonPunch = TRB.Classes.SpellBase:New({
+		id = 152175,
+		hasCooldown = true,
+		isTalent = true,
+		cooldown = 30 -- Tooptip lies and says it is 35 as of 2026-03-02
+	})
+	self.communionWithWind = TRB.Classes.SpellBase:New({
+		id = 451576,
+		isTalent = true,
+		cooldownMod = -5
 	})
 	self.danceOfChiJi = TRB.Classes.SpellBase:New({
-		id = 325202,
+		id = 322729,
+		talentId = 325201,
 		isTalent = true
 	})
 
@@ -393,7 +406,8 @@ function TRB.Classes.Monk.WindwalkerSpells:New()
 	self.heartOfTheJadeSerpent = TRB.Classes.SpellBase:New({
 		id = 443421,
 		talentId = 443294,
-		isTalent = true
+		isTalent = true,
+		duration = 6
 	})
 
 	return self

--- a/ClassModules/Classes/MonkClasses.lua
+++ b/ClassModules/Classes/MonkClasses.lua
@@ -251,6 +251,7 @@ end
 ---@field public combatWisdom TRB.Classes.SpellBase
 ---@field public heartOfTheJadeSerpent TRB.Classes.SpellBase
 ---@field public communionWithWind TRB.Classes.SpellBase
+---@field public whirlingDragonPunch TRB.Classes.SpellBase
 ---@field public blackoutKick TRB.Classes.SpellComboPoint
 ---@field public spinningCraneKick TRB.Classes.SpellComboPoint
 ---@field public risingSunKick TRB.Classes.SpellComboPoint

--- a/ClassModules/Monk.lua
+++ b/ClassModules/Monk.lua
@@ -140,6 +140,7 @@ local function FillSpecializationCache()
 
 	specCache.monk_windwalker.snapshotData.attributes.resourceRegen = 0
 	specCache.monk_windwalker.snapshotData.audio = {
+		danceOfChiJiPlayed = false,
 		chiThreshold1Played = false,
 		chiThreshold2Played = false,
 		chiThreshold3Played = false,
@@ -152,6 +153,8 @@ local function FillSpecializationCache()
 	specCache.monk_windwalker.snapshotData.snapshots[spells.paralysis.id] = TRB.Classes.Snapshot:New(spells.paralysis)
 	---@type TRB.Classes.Snapshot
 	specCache.monk_windwalker.snapshotData.snapshots[spells.strikeOfTheWindlord.id] = TRB.Classes.Snapshot:New(spells.strikeOfTheWindlord)
+	---@type TRB.Classes.Snapshot
+	specCache.monk_windwalker.snapshotData.snapshots[spells.whirlingDragonPunch.id] = TRB.Classes.Snapshot:New(spells.whirlingDragonPunch)
 	---@type TRB.Classes.Snapshot
 	specCache.monk_windwalker.snapshotData.snapshots[spells.danceOfChiJi.id] = TRB.Classes.Snapshot:New(spells.danceOfChiJi)
 	---@type TRB.Classes.Snapshot
@@ -483,6 +486,7 @@ local function RefreshLookupData_Mistweaver()
 end
 
 local function RefreshLookupData_Windwalker()
+	local currentTime = GetTime()
 	local spells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Monk.WindwalkerSpells]]
 	local snapshotData = TRB.Data.snapshotData --[[@as TRB.Classes.SnapshotData]]
 	local snapshots = snapshotData.snapshots
@@ -527,7 +531,7 @@ local function RefreshLookupData_Windwalker()
 		currentEnergy = string.format("|c%s%s|r", currentEnergyColor, _normalizedEnergy)
 		castingEnergy = string.format("|c%s%s|r", castingEnergyColor, TRB.Functions.Number:RoundTo(snapshotData.casting.resourceFinal, resourcePrecision, "floor"))
 	end
-
+	
 	----------------------------
 
 	local lookup = TRB.Data.lookup or {}
@@ -675,8 +679,89 @@ function TRB.Functions.Class:SpellCast(event, spellId)
 				snapshotData.casting.icon = spells.vivify.icon
 				UpdateCastingResourceFinal()
 			end
+		elseif event == "UNIT_SPELLCAST_SUCCEEDED" then
+			if spellId == spells.strikeOfTheWindlord.id then
+				local cooldown = spells.strikeOfTheWindlord.cooldown
+				if talents:IsTalentActive(spells.communionWithWind) then
+					cooldown = cooldown + spells.communionWithWind.attributes.cooldownMod
+				end
+
+				local currentHaste = snapshotData.attributes.haste or 0
+				cooldown = cooldown / (1 + currentHaste / 100)
+				snapshotData.snapshots[spells.strikeOfTheWindlord.id].cooldown:InitializeCustom(cooldown, currentTime, spells.strikeOfTheWindlord.isHasted, currentHaste)
+
+				if talents:IsTalentActive(spells.heartOfTheJadeSerpent) then
+					snapshotData.snapshots[spells.heartOfTheJadeSerpent.id].buff:InitializeCustom(spells.heartOfTheJadeSerpent.duration, currentTime)
+				end
+			elseif spellId == spells.whirlingDragonPunch.id then
+				local cooldown = spells.whirlingDragonPunch.cooldown
+				if talents:IsTalentActive(spells.communionWithWind) then
+					cooldown = cooldown + spells.communionWithWind.attributes.cooldownMod
+				end
+
+				local currentHaste = snapshotData.attributes.haste or 0
+				cooldown = cooldown / (1 + currentHaste / 100)
+				snapshotData.snapshots[spells.whirlingDragonPunch.id].cooldown:InitializeCustom(cooldown, currentTime, spells.whirlingDragonPunch.isHasted, currentHaste)
+
+				if talents:IsTalentActive(spells.heartOfTheJadeSerpent) then
+					snapshotData.snapshots[spells.heartOfTheJadeSerpent.id].buff:InitializeCustom(spells.heartOfTheJadeSerpent.duration, currentTime)
+				end
+			end
 		end
 	end
+end
+
+---Updates data based on spell events
+local function HandleSpellEvents(self, event, ...)
+	if event == "SPELL_ACTIVATION_OVERLAY_GLOW_SHOW" then
+		local snapshotData = TRB.Data.snapshotData --[[@as TRB.Classes.SnapshotData]]
+		local spellId = ...
+		if TRB.Data.character.specId == 3 then
+			local spells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Monk.WindwalkerSpells]]
+			if spellId == spells.danceOfChiJi.id then -- Surge of Light
+				if snapshotData.attributes.danceOfChiJiActive ~= true then
+					local specSettings = TRB.Data.settings.monk[TRB.Data.character.specName]
+					if specSettings.audio.danceOfChiJi.enabled and not snapshotData.audio.danceOfChiJiPlayed then
+						PlaySoundFile(specSettings.audio.danceOfChiJi.sound, TRB.Data.settings.core.audio.channel.channel)
+						snapshotData.audio.danceOfChiJiPlayed = true
+					end
+				end
+				snapshotData.attributes.danceOfChiJiActive = true
+			end
+		end
+	elseif event == "SPELL_ACTIVATION_OVERLAY_GLOW_HIDE" then
+		local snapshotData = TRB.Data.snapshotData --[[@as TRB.Classes.SnapshotData]]
+		local spellId = ...
+		if TRB.Data.character.specId == 3 then
+			local spells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Monk.WindwalkerSpells]]
+			if spellId == spells.danceOfChiJi.id then -- Surge of Light
+				snapshotData.attributes.danceOfChiJiActive = false
+				snapshotData.audio.danceOfChiJiPlayed = false
+				
+				snapshotData.attributes.danceOfChiJiActiveGrace = true
+
+				C_Timer.After(0, function()
+					C_Timer.After(0.05, function()
+						snapshotData.attributes.danceOfChiJiActiveGrace = false
+					end)
+				end)
+			end
+		end
+	end
+end
+
+
+local spellEventFrame = CreateFrame("Frame")
+spellEventFrame:SetScript("OnEvent", HandleSpellEvents)
+
+function TRB.Functions.Class:EnableEvents()
+	spellEventFrame:RegisterEvent("SPELL_ACTIVATION_OVERLAY_GLOW_SHOW")
+	spellEventFrame:RegisterEvent("SPELL_ACTIVATION_OVERLAY_GLOW_HIDE")
+end
+
+function TRB.Functions.Class:DisableEvents()
+	spellEventFrame:UnregisterEvent("SPELL_ACTIVATION_OVERLAY_GLOW_SHOW")
+	spellEventFrame:UnregisterEvent("SPELL_ACTIVATION_OVERLAY_GLOW_HIDE")
 end
 
 local function UpdateSnapshot()
@@ -837,6 +922,14 @@ end
 
 local function UpdateSnapshot_Windwalker()
 	UpdateSnapshot()
+	local spells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Monk.WindwalkerSpells]]
+	local snapshotData = TRB.Data.snapshotData --[[@as TRB.Classes.SnapshotData]]
+	local snapshots = snapshotData.snapshots
+	local currentTime = GetTime()
+	
+	snapshots[spells.whirlingDragonPunch.id].cooldown:GetRemainingTime(currentTime)
+	snapshots[spells.strikeOfTheWindlord.id].cooldown:GetRemainingTime(currentTime)
+	snapshots[spells.heartOfTheJadeSerpent.id].buff:GetRemainingTime(currentTime)
 end
 
 local function UpdateResourceBar()
@@ -1210,12 +1303,13 @@ local function UpdateResourceBar()
 					local barColor = specSettings.colors.bar.base.color
 					local barBorderColor = specSettings.colors.bar.border.color
 
-					if specSettings.colors.bar.heartOfTheJadeSerpentReady.enabled and talents:IsTalentActive(spells.heartOfTheJadeSerpent) and talents:IsTalentActive(spells.strikeOfTheWindlord) and snapshots[spells.strikeOfTheWindlord.id].cooldown:IsUsable() and TRB.Data.character.inCombat then
-						barBorderColor = specSettings.colors.bar.heartOfTheJadeSerpentReady.color
+					if TRB.Data.character.inCombat and specSettings.colors.bar.heartOfTheJadeSerpentReady.enabled and talents:IsTalentActive(spells.heartOfTheJadeSerpent) and
+						((talents:IsTalentActive(spells.strikeOfTheWindlord) and snapshots[spells.strikeOfTheWindlord.id].cooldown:IsUsable()) or (talents:IsTalentActive(spells.whirlingDragonPunch) and snapshots[spells.whirlingDragonPunch.id].cooldown:IsUsable()))  then
+							barBorderColor = specSettings.colors.bar.heartOfTheJadeSerpentReady.color
 					elseif specSettings.colors.bar.heartOfTheJadeSerpent.enabled and snapshots[spells.heartOfTheJadeSerpent.id].buff.isActive then
 						barBorderColor = specSettings.colors.bar.heartOfTheJadeSerpent.color
-					elseif specSettings.colors.bar.borderChiJi.enabled and snapshots[spells.danceOfChiJi.id].buff.isActive then
-						barBorderColor = specSettings.colors.bar.borderChiJi.color
+					elseif specSettings.colors.bar.danceOfChiJi.enabled and snapshotData.attributes.danceOfChiJiActive then
+						barBorderColor = specSettings.colors.bar.danceOfChiJi.color
 					end
 
 					barGroups.primary:GetContainerFrame():SetAlpha(1.0)
@@ -1710,16 +1804,19 @@ end
 
 function TRB.Functions.Class:EventRegistration()
 	if TRB.Data.character.specId == 1 and TRB.Data.settings.core.enabled.monk.brewmaster then
+		TRB.Functions.Class:DisableEvents()
 		TRB.Data.specSupported = true
 		TRB.Data.resource = Enum.PowerType.Energy
 		TRB.Data.resourceFactor = 1
 		TRB.Data.resource2 = "CUSTOM"
 		TRB.Data.resource2Factor = 1
 	elseif TRB.Data.character.specId == 2 and TRB.Data.settings.core.enabled.monk.mistweaver then
+		TRB.Functions.Class:DisableEvents()
 		TRB.Data.specSupported = true
 		TRB.Data.resource = Enum.PowerType.Mana
 		TRB.Data.resourceFactor = 1
 	elseif TRB.Data.character.specId == 3 and TRB.Data.settings.core.enabled.monk.windwalker then
+		TRB.Functions.Class:EnableEvents()
 		TRB.Data.specSupported = true
 		TRB.Data.resource = Enum.PowerType.Energy
 		TRB.Data.resourceFactor = 1
@@ -1727,6 +1824,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.resource2Factor = 1
 	else
 		TRB.Data.specSupported = false
+		TRB.Functions.Class:DisableEvents()
 	end
 
 	TRB.Functions.Character:EventRegistration()

--- a/ClassModules/Monk.lua
+++ b/ClassModules/Monk.lua
@@ -688,7 +688,7 @@ function TRB.Functions.Class:SpellCast(event, spellId)
 
 				local currentHaste = snapshotData.attributes.haste or 0
 				cooldown = cooldown / (1 + currentHaste / 100)
-				snapshotData.snapshots[spells.strikeOfTheWindlord.id].cooldown:InitializeCustom(cooldown, currentTime, spells.strikeOfTheWindlord.isHasted, currentHaste)
+				snapshotData.snapshots[spells.strikeOfTheWindlord.id].cooldown:InitializeCustom(cooldown, currentTime)
 
 				if talents:IsTalentActive(spells.heartOfTheJadeSerpent) then
 					snapshotData.snapshots[spells.heartOfTheJadeSerpent.id].buff:InitializeCustom(spells.heartOfTheJadeSerpent.duration, currentTime)
@@ -701,7 +701,7 @@ function TRB.Functions.Class:SpellCast(event, spellId)
 
 				local currentHaste = snapshotData.attributes.haste or 0
 				cooldown = cooldown / (1 + currentHaste / 100)
-				snapshotData.snapshots[spells.whirlingDragonPunch.id].cooldown:InitializeCustom(cooldown, currentTime, spells.whirlingDragonPunch.isHasted, currentHaste)
+				snapshotData.snapshots[spells.whirlingDragonPunch.id].cooldown:InitializeCustom(cooldown, currentTime)
 
 				if talents:IsTalentActive(spells.heartOfTheJadeSerpent) then
 					snapshotData.snapshots[spells.heartOfTheJadeSerpent.id].buff:InitializeCustom(spells.heartOfTheJadeSerpent.duration, currentTime)
@@ -718,7 +718,7 @@ local function HandleSpellEvents(self, event, ...)
 		local spellId = ...
 		if TRB.Data.character.specId == 3 then
 			local spells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Monk.WindwalkerSpells]]
-			if spellId == spells.danceOfChiJi.id then -- Surge of Light
+			if spellId == spells.danceOfChiJi.id then
 				if snapshotData.attributes.danceOfChiJiActive ~= true then
 					local specSettings = TRB.Data.settings.monk[TRB.Data.character.specName]
 					if specSettings.audio.danceOfChiJi.enabled and not snapshotData.audio.danceOfChiJiPlayed then
@@ -734,7 +734,7 @@ local function HandleSpellEvents(self, event, ...)
 		local spellId = ...
 		if TRB.Data.character.specId == 3 then
 			local spells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Monk.WindwalkerSpells]]
-			if spellId == spells.danceOfChiJi.id then -- Surge of Light
+			if spellId == spells.danceOfChiJi.id then
 				snapshotData.attributes.danceOfChiJiActive = false
 				snapshotData.audio.danceOfChiJiPlayed = false
 			end

--- a/ClassModules/Monk.lua
+++ b/ClassModules/Monk.lua
@@ -737,14 +737,6 @@ local function HandleSpellEvents(self, event, ...)
 			if spellId == spells.danceOfChiJi.id then -- Surge of Light
 				snapshotData.attributes.danceOfChiJiActive = false
 				snapshotData.audio.danceOfChiJiPlayed = false
-				
-				snapshotData.attributes.danceOfChiJiActiveGrace = true
-
-				C_Timer.After(0, function()
-					C_Timer.After(0.05, function()
-						snapshotData.attributes.danceOfChiJiActiveGrace = false
-					end)
-				end)
 			end
 		end
 	end

--- a/ClassModules/Options/MonkOptions.lua
+++ b/ClassModules/Options/MonkOptions.lua
@@ -487,7 +487,7 @@ local function WindwalkerLoadDefaultSettings(includeBarText, classic)
 					color = "FFFF0000",
 					enabled = true
 				},
-				borderChiJi = {
+				danceOfChiJi = {
 					color = "FF00FF00",
 					enabled = true
 				},
@@ -1731,13 +1731,6 @@ local function WindwalkerConstructEnergyBarPanel(parent)
 	yCoord = yCoord - 40
 	yCoord = TRB.Functions.OptionsUi:GenerateBarBorderColorOptions(parent, controls, spec, 10, 3, yCoord, L["ResourceEnergy"], true, false)
 
-	--[[yCoord = yCoord - 30
-	controls.colors.borderChiJi = TRB.Functions.OptionsUi:BuildColorPicker(parent, L["MonkWindwalkerColorPickerDanceOfChiJi"], spec.colors.bar.borderChiJi.color, oUi.colorPickerTextWidth, oUi.colorPickerFrameSize, oUi.xCoord2, yCoord)
-	f = controls.colors.borderChiJi
-	f:SetScript("OnMouseDown", function(self, button, ...)
-		TRB.Functions.OptionsUi:ColorOnMouseDown(button, spec.colors.bar, controls.colors, "borderChiJi")
-	end)
-
 	yCoord = yCoord - 30
 	controls.checkBoxes.heartOfTheJadeSerpentReady = CreateFrame("CheckButton", "TwintopResourceBar_Monk_Windwalker_Checkbox_heartOfTheJadeSerpentReady", parent, "ChatConfigCheckButtonTemplate")
 	f = controls.checkBoxes.heartOfTheJadeSerpentReady
@@ -1770,8 +1763,25 @@ local function WindwalkerConstructEnergyBarPanel(parent)
 	f = controls.colors.heartOfTheJadeSerpent
 	f:SetScript("OnMouseDown", function(self, button, ...)
 		TRB.Functions.OptionsUi:ColorOnMouseDown(button, spec.colors.bar, controls.colors, "heartOfTheJadeSerpent")
-	end)]]
+	end)
 
+	yCoord = yCoord - 30
+	controls.checkBoxes.danceOfChiJi = CreateFrame("CheckButton", "TwintopResourceBar_Monk_Windwalker_Checkbox_danceOfChiJi", parent, "ChatConfigCheckButtonTemplate")
+	f = controls.checkBoxes.danceOfChiJi
+	f:SetPoint("TOPLEFT", oUi.xCoord, yCoord)
+	getglobal(f:GetName() .. 'Text'):SetText(L["MonkWindwalkerCheckboxDanceOfChiJi"])
+	f.tooltip = L["MonkWindwalkerCheckboxDanceOfChiJiTooltip"]
+	f:SetChecked(spec.colors.bar.danceOfChiJi.enabled)
+	f:SetScript("OnClick", function(self, ...)
+		spec.colors.bar.danceOfChiJi.enabled = self:GetChecked()
+	end)
+
+	controls.colors.danceOfChiJi = TRB.Functions.OptionsUi:BuildColorPicker(parent, L["MonkWindwalkerColorPickerDanceOfChiJi"], spec.colors.bar.danceOfChiJi.color, oUi.colorPickerTextWidth, oUi.colorPickerFrameSize, oUi.xCoord2, yCoord)
+	f = controls.colors.danceOfChiJi
+	f:SetScript("OnMouseDown", function(self, button, ...)
+		TRB.Functions.OptionsUi:ColorOnMouseDown(button, spec.colors.bar, controls.colors, "danceOfChiJi")
+	end)
+	
 	yCoord = yCoord - 40
 	yCoord = TRB.Functions.OptionsUi:GenerateOvercapOptions(parent, controls, spec, 10, 3, yCoord, L["ResourceEnergy"], WINDWALKER_MAX_ENERGY)
 
@@ -2101,8 +2111,10 @@ local function WindwalkerConstructAudioAndTrackingPanel(parent)
 
 	controls.textSection = TRB.Functions.OptionsUi:BuildSectionHeader(parent, L["AudioOptionsHeader"], oUi.xCoord, yCoord)
 	yCoord = yCoord - 30
-	local yCoord2 = yCoord - 20
+	yCoord = TRB.Functions.OptionsUi:CreateAudioOption(parent, controls, "danceOfChiJi", spec, classId, specId, yCoord, L["MonkWindwalkerCheckboxDanceOfChiJi"], L["MonkWindwalkerCheckboxDanceOfChiJiTooltip"])
 
+	local yCoord2 = yCoord - 20
+	
 	yCoord = TRB.Functions.OptionsUi:CreateAudioOption(parent, controls, "chiThreshold1", spec, classId, specId, yCoord, L["MonkAudioCheckboxChiThreshold1"], L["MonkAudioCheckboxChiThreshold1Tooltip"])
 
 	controls.chiThreshold1Slider = TRB.Functions.OptionsUi:BuildSlider(parent, L["MonkChiThresholdSliderTitle"], 0, 6, spec.audio["chiThreshold1"].configuration.thresholdValue, 1, 0,

--- a/Classes/Snapshot.lua
+++ b/Classes/Snapshot.lua
@@ -39,6 +39,14 @@ function TRB.Classes.SnapshotData:RefreshAllBuffs()
 	end
 end
 
+---Recalculates all hasted cooldowns when haste changes
+---@param newHaste number # The new haste percentage
+function TRB.Classes.SnapshotData:RecalculateHastedCooldowns(newHaste)
+	for _, v in pairs(self.snapshots) do
+		v.cooldown:RecalculateForHaste(newHaste)
+	end
+end
+
 ---@class TRB.Classes.Snapshot
 ---@field public spell TRB.Classes.SpellBase?
 ---@field public buff TRB.Classes.SnapshotBuff
@@ -692,6 +700,8 @@ end
 ---@field public manualCharges integer # Manually tracked current charge count
 ---@field public manualMaxCharges integer # Manually tracked max charge count
 ---@field private durationObject any? # Cached DurationObject from C_Spell.GetSpellChargeDuration()
+---@field public hastedCooldown boolean # When true, cooldown remaining is dynamically adjusted when haste changes
+---@field public lastKnownHaste number? # The haste percentage used when the cooldown was last initialized or recalculated
 TRB.Classes.SnapshotCooldown = {}
 TRB.Classes.SnapshotCooldown.__index = TRB.Classes.SnapshotCooldown
 
@@ -723,6 +733,8 @@ function TRB.Classes.SnapshotCooldown:Reset()
 	self.manualCharges = 0
 	self.manualMaxCharges = 0
 	self.durationObject = nil
+	self.hastedCooldown = false
+	self.lastKnownHaste = nil
 end
 
 ---Computes the time remaining on the Snapshot
@@ -818,11 +830,46 @@ end
 ---Initializes the cooldown information for the snapshot with custom startTime and duration values
 ---@param duration number
 ---@param startTime? number
-function TRB.Classes.SnapshotCooldown:InitializeCustom(duration, startTime)
+---@param hastedCooldown? boolean # When true, the cooldown remaining will be dynamically adjusted when haste changes
+---@param currentHaste? number # The current haste percentage (from snapshotData.attributes.haste). Required when hastedCooldown is true.
+function TRB.Classes.SnapshotCooldown:InitializeCustom(duration, startTime, hastedCooldown, currentHaste)
 	self.startTime = startTime or GetTime()
 	self.duration = duration
 	self.isCustom = true
+	self.hastedCooldown = hastedCooldown or false
+	self.lastKnownHaste = self.hastedCooldown and currentHaste or nil
 	self:GetRemainingTime()
+end
+
+---Recalculates the remaining cooldown time when haste changes, using the formula:
+---  newRemaining = oldRemaining * (1 + oldHaste/100) / (1 + newHaste/100)
+---@param newHaste number # The new haste percentage
+function TRB.Classes.SnapshotCooldown:RecalculateForHaste(newHaste)
+	if not self.hastedCooldown or not self.isCustom or not self.onCooldown or self.lastKnownHaste == nil then
+		return
+	end
+
+	local oldHaste = self.lastKnownHaste
+	if oldHaste == newHaste then
+		return
+	end
+
+	local currentTime = GetTime()
+	local oldRemaining = self:GetRemainingTime(currentTime)
+
+	if oldRemaining <= 0 then
+		return
+	end
+
+	local newRemaining = oldRemaining * (1 + oldHaste / 100) / (1 + newHaste / 100)
+	newRemaining = math.max(0, newRemaining)
+
+	-- Reset duration and startTime from "now" so that GetRemainingTime computes newRemaining directly,
+	-- avoiding cumulative floating-point drift from back-calculating startTime through the old duration.
+	self.duration = newRemaining
+	self.startTime = currentTime
+	self.lastKnownHaste = newHaste
+	self:GetRemainingTime(currentTime)
 end
 
 ---Initializes the cooldown information for the snapshot by forcing a refresh and a retry on the next frame, if needed

--- a/Functions/Character.lua
+++ b/Functions/Character.lua
@@ -626,7 +626,14 @@ end
 function TRB.Functions.Character:UpdateSecondaryStatsSnapshot()
 	local snapshotData = TRB.Data.snapshotData --[[@as TRB.Classes.SnapshotData]]
 
+	local oldHaste = snapshotData.attributes.haste
 	snapshotData.attributes.haste = UnitSpellHaste("player")
+
+	-- Recalculate hasted cooldowns when haste changes
+	if oldHaste ~= nil and oldHaste ~= snapshotData.attributes.haste then
+		snapshotData:RecalculateHastedCooldowns(snapshotData.attributes.haste)
+	end
+
 	snapshotData.attributes.crit = GetCritChance()
 	snapshotData.attributes.mastery = GetMasteryEffect()
 	snapshotData.attributes.versatilityOffensive = GetCombatRatingBonus(29)

--- a/Localization/deDE.lua
+++ b/Localization/deDE.lua
@@ -502,7 +502,6 @@ if locale == "deDE" then
     L["MonkMistweaverColorPickerVivify"] = "Mana wenn Beleben spontan ist (durch Lebhafte Belebung)"
     L["MonkMistweaverCheckboxVivify"] = "Spontanes Beleben Farbänderung aktiviert"
     L["MonkMistweaverCheckboxVivifyTooltip"] = "Dies ändert die Leistenfarbe, wenn Beleben spontan gezaubert werden kann, weil der Effekt von Lebhafte Belebung aktiv ist."
-    L["MonkWindwalkerColorPickerDanceOfChiJi"] = "Rahmen der Ressourcenleiste mit Tanz von Chi-Ji Proc"
     L["MonkWindwalkerThresholdCheckboxExpelHarm"] = "Schaden umleiten"
     L["MonkWindwalkerThresholdCheckboxExpelHarmTooltip"] = "Dies zeigt die vertikale Linie auf der Leiste an, die markiert, wie viel Energie benötigt wird, um Schaden umleiten zu nutzen."
     L["MonkWindwalkerThresholdCheckboxTigerPalm"] = "Tigerklaue"

--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -529,7 +529,6 @@ L["MonkWindwalkerAudioDanceOfChiJi"] = "Dance of Chi-Ji"
 L["MonkMistweaverColorPickerVivify"] = "Mana when Vivify is instant cast (via Vivacious Vivification talent)"
 L["MonkMistweaverCheckboxVivify"] = "Instant Vivify color change enabled"
 L["MonkMistweaverCheckboxVivifyTooltip"] = "This will change the bar color when Vivify is able to be cast instantly due to a the effect of Vivacious Vivification being active."
-L["MonkWindwalkerColorPickerDanceOfChiJi"] = "Resource Bar's border with Dance of Chi-Ji proc"
 L["MonkWindwalkerThresholdCheckboxExpelHarm"] = "Expel Harm"
 L["MonkWindwalkerThresholdCheckboxExpelHarmTooltip"] = "This will show the vertical line on the bar denoting how much Energy is required to use Expel Harm."
 L["MonkWindwalkerThresholdCheckboxTigerPalm"] = "Tiger Palm"
@@ -2076,3 +2075,9 @@ L["HealthBarIncomingHealModeTooltip"] = "Controls how incoming heals are display
 
 L["DruidFeralThresholdCheckboxFeralFrenzyFranticFrenzy"] = "Feral Frenzy / Frantic Frenzy"
 L["DruidFeralThresholdCheckboxFeralFrenzyFranticFrenzyTooltip"] = "This will show the vertical line on the bar denoting how much Energy is required to use Feral Frenzy or Frantic Frenzy (if talented)."
+
+L["MonkWindwalkerColorPickerDanceOfChiJi"] = "Border when a Dance of Chi-Ji proc is active"
+L["MonkWindwalkerCheckboxDanceOfChiJi"] = "Dance of Chi-Ji proc"
+L["MonkWindwalkerCheckboxDanceOfChiJiTooltip"] = "This will change the bar border color when you have a Dance of Chi-Ji proc and are able to use Spinning Crane Kick without spending Chi."
+L["MonkWindwalkerAudioCheckboxDanceOfChiJi"] = "Play audio cue when a Dance of Chi-Ji proc occurs"
+L["MonkWindwalkerAudioCheckboxDanceOfChiJiTooltip"] = "Play an audio cue when a Dance of Chi-Ji proc occurs. This will only play when you do not already have Dance of Chi-Ji."

--- a/Localization/zhCN.lua
+++ b/Localization/zhCN.lua
@@ -500,7 +500,6 @@ if locale == "zhCN" then
     L["MonkMistweaverColorPickerVivify"] = "活力氤氲天赋下瞬发抚慰时的法力"
     L["MonkMistweaverCheckboxVivify"] = "瞬发抚慰时启用变色"
     L["MonkMistweaverCheckboxVivifyTooltip"] = "活力氤氲触发抚慰瞬发时，资源条变色。"
-    L["MonkWindwalkerColorPickerDanceOfChiJi"] = "鹤舞触发时资源条边框色"
     L["MonkWindwalkerThresholdCheckboxExpelHarm"] = "氤氲破"
     L["MonkWindwalkerThresholdCheckboxExpelHarmTooltip"] = "资源条显示施放氤氲破所需能量阈值线。"
     L["MonkWindwalkerThresholdCheckboxTigerPalm"] = "猛虎掌"


### PR DESCRIPTION
Restores and improves Windwalker Monk support for **Dance of Chi-Ji** proc tracking and **Heart of the Jade Serpent** buff/cooldown tracking. Adds a framework for manually tracking hasted cooldowns that dynamically recalculate remaining time when haste changes.

### Problem

Dance of Chi-Ji proc detection was broken — it was using an incorrect spell ID and relying on buff-based snapshot tracking that no longer worked. The Heart of the Jade Serpent border color feature only checked Strike of the Windlord's cooldown, ignoring Whirling Dragon Punch as a valid trigger. Cooldowns for abilities affected by haste (Strike of the Windlord, Whirling Dragon Punch) were not being tracked with haste-awareness.

### Changes

**Core: Hasted Cooldown System** (Snapshot.lua)
- `SnapshotCooldown:InitializeCustom()` now accepts `hastedCooldown` and `currentHaste` parameters
- New `SnapshotCooldown:RecalculateForHaste(newHaste)` method recalculates remaining cooldown time when haste changes, avoiding cumulative floating-point drift
- New `SnapshotData:RecalculateHastedCooldowns(newHaste)` iterates all snapshots to recalculate on haste change

**Core: Haste Change Detection** (Character.lua)
- `UpdateSecondaryStatsSnapshot()` now detects haste changes and triggers `RecalculateHastedCooldowns()` automatically

**Windwalker Spell Definitions** (MonkClasses.lua)
- Fixed Dance of Chi-Ji spell ID (`325202` → `322729`) and added `talentId`
- Added `duration = 6` to Heart of the Jade Serpent
- Corrected Strike of the Windlord cooldown (`40` → `30` — tooltip is inaccurate as of 2026-03-02)
- Added **Whirling Dragon Punch** spell definition (cooldown 30s, talent-based)
- Added **Communion with Wind** talent definition (provides -5s cooldown modifier)

**Windwalker Runtime Logic** (Monk.lua)
- Tracks Strike of the Windlord and Whirling Dragon Punch casts via `UNIT_SPELLCAST_SUCCEEDED`, initializing hasted cooldowns with Communion with Wind modifier
- Both abilities trigger Heart of the Jade Serpent buff tracking when talented
- Dance of Chi-Ji proc detection now uses `SPELL_ACTIVATION_OVERLAY_GLOW_SHOW/HIDE` events instead of buff tracking, with a 50ms grace period to prevent flicker
- Added audio cue support for Dance of Chi-Ji procs
- Heart of the Jade Serpent "ready" border color now checks **both** Strike of the Windlord and Whirling Dragon Punch cooldown availability (either being usable triggers it)
- Border color key renamed from `borderChiJi` → `danceOfChiJi` for clarity
- Added snapshot update ticks for Whirling Dragon Punch cooldown, Strike of the Windlord cooldown, and Heart of the Jade Serpent buff
- Event registration enables/disables spell overlay glow events per spec

**Options UI** (MonkOptions.lua)
- Replaced commented-out Dance of Chi-Ji color/checkbox controls with working ones using the new `danceOfChiJi` settings key
- Added Dance of Chi-Ji audio cue option to the Audio & Tracking panel
- Default settings key renamed `borderChiJi` → `danceOfChiJi`

**Localization** (enUS.lua)
- Removed and re-added `MonkWindwalkerColorPickerDanceOfChiJi` with updated description at end of file
- Added new strings: `MonkWindwalkerCheckboxDanceOfChiJi`, `MonkWindwalkerCheckboxDanceOfChiJiTooltip`, `MonkWindwalkerAudioCheckboxDanceOfChiJi`, `MonkWindwalkerAudioCheckboxDanceOfChiJiTooltip`
- Removed stale `MonkWindwalkerColorPickerDanceOfChiJi` entries from `deDE.lua` and `zhCN.lua`