### PR TITLE
Global bar text

### DIFF
--- a/ClassModules/DeathKnight.lua
+++ b/ClassModules/DeathKnight.lua
@@ -1238,6 +1238,14 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 						settings.deathknight.unholy.displayText.barText = TRB.Options.DeathKnight.UnholyLoadDefaultBarTextSettings()
 					end
 
+					-- Clear core barText defaults before merge to prevent per-index array duplication.
+					-- Only clear if saved vars have entries; otherwise let defaults seed the list.
+					if TwintopInsanityBarSettings.core
+						and TwintopInsanityBarSettings.core.displayText
+						and TwintopInsanityBarSettings.core.displayText.barText
+						and #TwintopInsanityBarSettings.core.displayText.barText > 0 then
+						settings.core.displayText.barText = {}
+					end
 					TRB.Data.settings = TRB.Functions.Table:Merge(settings, TwintopInsanityBarSettings)
 					TRB.Data.settings = TRB.Functions.Settings:CleanupSettings(TRB.Data.settings)
 

--- a/ClassModules/DemonHunter.lua
+++ b/ClassModules/DemonHunter.lua
@@ -1592,6 +1592,14 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 						settings.demonhunter.devourer.displayText.barText = TRB.Options.DemonHunter.DevourerLoadDefaultBarTextSettings()
 					end
 
+					-- Clear core barText defaults before merge to prevent per-index array duplication.
+					-- Only clear if saved vars have entries; otherwise let defaults seed the list.
+					if TwintopInsanityBarSettings.core
+						and TwintopInsanityBarSettings.core.displayText
+						and TwintopInsanityBarSettings.core.displayText.barText
+						and #TwintopInsanityBarSettings.core.displayText.barText > 0 then
+						settings.core.displayText.barText = {}
+					end
 					TRB.Data.settings = TRB.Functions.Table:Merge(settings, TwintopInsanityBarSettings)
 					TRB.Data.settings = TRB.Functions.Settings:CleanupSettings(TRB.Data.settings)
 

--- a/ClassModules/Druid.lua
+++ b/ClassModules/Druid.lua
@@ -2753,6 +2753,14 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 						settings.druid.restoration.displayText.barText = TRB.Options.Druid.RestorationLoadDefaultBarTextSettings()
 					end
 
+					-- Clear core barText defaults before merge to prevent per-index array duplication.
+					-- Only clear if saved vars have entries; otherwise let defaults seed the list.
+					if TwintopInsanityBarSettings.core
+						and TwintopInsanityBarSettings.core.displayText
+						and TwintopInsanityBarSettings.core.displayText.barText
+						and #TwintopInsanityBarSettings.core.displayText.barText > 0 then
+						settings.core.displayText.barText = {}
+					end
 					TRB.Data.settings = TRB.Functions.Table:Merge(settings, TwintopInsanityBarSettings)
 					TRB.Data.settings = TRB.Functions.Settings:CleanupSettings(TRB.Data.settings)
 

--- a/ClassModules/Evoker.lua
+++ b/ClassModules/Evoker.lua
@@ -1097,6 +1097,14 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 						settings.evoker.augmentation.displayText.barText = TRB.Options.Evoker.AugmentationLoadDefaultBarTextSettings()
 					end
 
+					-- Clear core barText defaults before merge to prevent per-index array duplication.
+					-- Only clear if saved vars have entries; otherwise let defaults seed the list.
+					if TwintopInsanityBarSettings.core
+						and TwintopInsanityBarSettings.core.displayText
+						and TwintopInsanityBarSettings.core.displayText.barText
+						and #TwintopInsanityBarSettings.core.displayText.barText > 0 then
+						settings.core.displayText.barText = {}
+					end
 					TRB.Data.settings = TRB.Functions.Table:Merge(settings, TwintopInsanityBarSettings)
 					TRB.Data.settings = TRB.Functions.Settings:CleanupSettings(TRB.Data.settings)
 

--- a/ClassModules/Hunter.lua
+++ b/ClassModules/Hunter.lua
@@ -1475,6 +1475,14 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 						settings.hunter.survival.displayText.barText = TRB.Options.Hunter.SurvivalLoadDefaultBarTextSettings()
 					end
 
+					-- Clear core barText defaults before merge to prevent per-index array duplication.
+					-- Only clear if saved vars have entries; otherwise let defaults seed the list.
+					if TwintopInsanityBarSettings.core
+						and TwintopInsanityBarSettings.core.displayText
+						and TwintopInsanityBarSettings.core.displayText.barText
+						and #TwintopInsanityBarSettings.core.displayText.barText > 0 then
+						settings.core.displayText.barText = {}
+					end
 					TRB.Data.settings = TRB.Functions.Table:Merge(settings, TwintopInsanityBarSettings)
 					TRB.Data.settings = TRB.Functions.Settings:CleanupSettings(TRB.Data.settings)
 

--- a/ClassModules/Mage.lua
+++ b/ClassModules/Mage.lua
@@ -997,6 +997,14 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 						settings.mage.frost.displayText.barText = TRB.Options.Mage.FrostLoadDefaultBarTextSettings()
 					end
 
+					-- Clear core barText defaults before merge to prevent per-index array duplication.
+					-- Only clear if saved vars have entries; otherwise let defaults seed the list.
+					if TwintopInsanityBarSettings.core
+						and TwintopInsanityBarSettings.core.displayText
+						and TwintopInsanityBarSettings.core.displayText.barText
+						and #TwintopInsanityBarSettings.core.displayText.barText > 0 then
+						settings.core.displayText.barText = {}
+					end
 					TRB.Data.settings = TRB.Functions.Table:Merge(settings, TwintopInsanityBarSettings)
 					TRB.Data.settings = TRB.Functions.Settings:CleanupSettings(TRB.Data.settings)
 

--- a/ClassModules/Monk.lua
+++ b/ClassModules/Monk.lua
@@ -1622,6 +1622,14 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 						settings.monk.windwalker.displayText.barText = TRB.Options.Monk.WindwalkerLoadDefaultBarTextSettings()
 					end
 
+					-- Clear core barText defaults before merge to prevent per-index array duplication.
+					-- Only clear if saved vars have entries; otherwise let defaults seed the list.
+					if TwintopInsanityBarSettings.core
+						and TwintopInsanityBarSettings.core.displayText
+						and TwintopInsanityBarSettings.core.displayText.barText
+						and #TwintopInsanityBarSettings.core.displayText.barText > 0 then
+						settings.core.displayText.barText = {}
+					end
 					TRB.Data.settings = TRB.Functions.Table:Merge(settings, TwintopInsanityBarSettings)
 					TRB.Data.settings = TRB.Functions.Settings:CleanupSettings(TRB.Data.settings)
 

--- a/ClassModules/Paladin.lua
+++ b/ClassModules/Paladin.lua
@@ -982,6 +982,14 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 						settings.paladin.retribution.displayText.barText = TRB.Options.Paladin.RetributionLoadDefaultBarTextSettings()
 					end
 
+					-- Clear core barText defaults before merge to prevent per-index array duplication.
+					-- Only clear if saved vars have entries; otherwise let defaults seed the list.
+					if TwintopInsanityBarSettings.core
+						and TwintopInsanityBarSettings.core.displayText
+						and TwintopInsanityBarSettings.core.displayText.barText
+						and #TwintopInsanityBarSettings.core.displayText.barText > 0 then
+						settings.core.displayText.barText = {}
+					end
 					TRB.Data.settings = TRB.Functions.Table:Merge(settings, TwintopInsanityBarSettings)
 					TRB.Data.settings = TRB.Functions.Settings:CleanupSettings(TRB.Data.settings)
 

--- a/ClassModules/Priest.lua
+++ b/ClassModules/Priest.lua
@@ -2266,6 +2266,14 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 						settings.priest.shadow.displayText.barText = TRB.Options.Priest.ShadowLoadDefaultBarTextSettings()
 					end
 
+					-- Clear core barText defaults before merge to prevent per-index array duplication.
+					-- Only clear if saved vars have entries; otherwise let defaults seed the list.
+					if TwintopInsanityBarSettings.core
+						and TwintopInsanityBarSettings.core.displayText
+						and TwintopInsanityBarSettings.core.displayText.barText
+						and #TwintopInsanityBarSettings.core.displayText.barText > 0 then
+						settings.core.displayText.barText = {}
+					end
 					TRB.Data.settings = TRB.Functions.Table:Merge(settings, TwintopInsanityBarSettings)
 					TRB.Data.settings = TRB.Functions.Settings:CleanupSettings(TRB.Data.settings)
 

--- a/ClassModules/Rogue.lua
+++ b/ClassModules/Rogue.lua
@@ -1989,6 +1989,14 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 						settings.rogue.subtlety.displayText.barText = TRB.Options.Rogue.SubtletyLoadDefaultBarTextSettings()
 					end
 
+					-- Clear core barText defaults before merge to prevent per-index array duplication.
+					-- Only clear if saved vars have entries; otherwise let defaults seed the list.
+					if TwintopInsanityBarSettings.core
+						and TwintopInsanityBarSettings.core.displayText
+						and TwintopInsanityBarSettings.core.displayText.barText
+						and #TwintopInsanityBarSettings.core.displayText.barText > 0 then
+						settings.core.displayText.barText = {}
+					end
 					TRB.Data.settings = TRB.Functions.Table:Merge(settings, TwintopInsanityBarSettings)
 					TRB.Data.settings = TRB.Functions.Settings:CleanupSettings(TRB.Data.settings)
 

--- a/ClassModules/Shaman.lua
+++ b/ClassModules/Shaman.lua
@@ -1384,6 +1384,14 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 						settings.shaman.restoration.displayText.barText = TRB.Options.Shaman.RestorationLoadDefaultBarTextSettings()
 					end
 
+					-- Clear core barText defaults before merge to prevent per-index array duplication.
+					-- Only clear if saved vars have entries; otherwise let defaults seed the list.
+					if TwintopInsanityBarSettings.core
+						and TwintopInsanityBarSettings.core.displayText
+						and TwintopInsanityBarSettings.core.displayText.barText
+						and #TwintopInsanityBarSettings.core.displayText.barText > 0 then
+						settings.core.displayText.barText = {}
+					end
 					TRB.Data.settings = TRB.Functions.Table:Merge(settings, TwintopInsanityBarSettings)
 					TRB.Data.settings = TRB.Functions.Settings:CleanupSettings(TRB.Data.settings)
 

--- a/ClassModules/Warlock.lua
+++ b/ClassModules/Warlock.lua
@@ -986,6 +986,14 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 						settings.warlock.destruction.displayText.barText = TRB.Options.Warlock.DestructionLoadDefaultBarTextSettings()
 					end
 
+					-- Clear core barText defaults before merge to prevent per-index array duplication.
+					-- Only clear if saved vars have entries; otherwise let defaults seed the list.
+					if TwintopInsanityBarSettings.core
+						and TwintopInsanityBarSettings.core.displayText
+						and TwintopInsanityBarSettings.core.displayText.barText
+						and #TwintopInsanityBarSettings.core.displayText.barText > 0 then
+						settings.core.displayText.barText = {}
+					end
 					TRB.Data.settings = TRB.Functions.Table:Merge(settings, TwintopInsanityBarSettings)
 					TRB.Data.settings = TRB.Functions.Settings:CleanupSettings(TRB.Data.settings)
 

--- a/ClassModules/Warrior.lua
+++ b/ClassModules/Warrior.lua
@@ -1482,6 +1482,14 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 						settings.warrior.protection.displayText.barText = TRB.Options.Warrior.ProtectionLoadDefaultBarTextSettings()
 					end
 
+					-- Clear core barText defaults before merge to prevent per-index array duplication.
+					-- Only clear if saved vars have entries; otherwise let defaults seed the list.
+					if TwintopInsanityBarSettings.core
+						and TwintopInsanityBarSettings.core.displayText
+						and TwintopInsanityBarSettings.core.displayText.barText
+						and #TwintopInsanityBarSettings.core.displayText.barText > 0 then
+						settings.core.displayText.barText = {}
+					end
 					TRB.Data.settings = TRB.Functions.Table:Merge(settings, TwintopInsanityBarSettings)
 					TRB.Data.settings = TRB.Functions.Settings:CleanupSettings(TRB.Data.settings)
 

--- a/Classes/Settings.lua
+++ b/Classes/Settings.lua
@@ -10,6 +10,7 @@ TRB.Classes.Settings = TRB.Classes.Settings or {}
 ---@field public thresholdIcons boolean
 ---@field public displayBar boolean
 ---@field public displayText boolean
+---@field public globalBarText boolean
 ---@field public textColors boolean
 ---@field public thresholdColors boolean
 ---@field public healthBarColors boolean
@@ -151,6 +152,8 @@ TRB.Classes.Settings = TRB.Classes.Settings or {}
 ---@class TRB.Classes.Settings.DisplayText
 ---@field public default TRB.Classes.Settings.DisplayTextDefault
 ---@field public barText TRB.Classes.Settings.DisplayTextEntry[]
+---@field public globalBarTextCount integer?
+---@field public migrations table?
 
 ---@class TRB.Classes.Settings.DisplayTextDefault
 ---@field public fontFace string

--- a/Functions/BarText.lua
+++ b/Functions/BarText.lua
@@ -1107,8 +1107,8 @@ function TRB.Functions.BarText:UpdateResourceBarText(settings, refreshText)
 	TRB.Functions.BarText:RefreshLookupDataBase(settings)
 	TRB.Functions.RefreshLookupData()
 	
-	--Only parse bar text if we're we need to refresh the text
-	if settings ~= nil and settings.displayText ~= nil and refreshText then
+	--Only parse bar text if we need to refresh the text (or if there are Screen-bound entries)
+	if settings ~= nil and settings.displayText ~= nil then
 		---@type Frame[]
 		local textFrames = TRB.Frames.textFrames
 		local displayText = settings.displayText --[[@as TRB.Classes.Settings.DisplayText]]
@@ -1122,61 +1122,65 @@ function TRB.Functions.BarText:UpdateResourceBarText(settings, refreshText)
 		for i = 1, entries do
 			if displayText.barText[i].enabled then
 				local e = displayText.barText[i]
+				local isScreenText = e.position.relativeToFrame == "UIParent"
 				
-				-- Check if the target frame is visible before doing expensive text processing
-				local _, isEnabled, isVisible = TRB.Functions.Class:GetBarTextFrame(e.position.relativeToFrame)
-				
-				-- UIParent-attached bar text is always considered visible
-				if e.position.relativeToFrame == "UIParent" then
-					isVisible = true
-				end
-				
-				TRB.Data.cache.values.frame["textFrames" .. i] = TRB.Data.cache.values.frame["textFrames" .. i] or {}
-				
-				-- Skip expensive text processing if the target bar is not visible
-				if not isEnabled or not isVisible then
-					TRB.Data.cache.values.frame["textFrames" .. i].text = ""
-				else
-					local color = e.color and e.color.color
+				-- Screen-bound text is always processed; other text only when refreshText is true
+				if refreshText or isScreenText then
+					-- Check if the target frame is visible before doing expensive text processing
+					local _, isEnabled, isVisible = TRB.Functions.Class:GetBarTextFrame(e.position.relativeToFrame)
 					
-					if e.useDefaultFontColor then
-						-- displayText.default.color uses the new table format { color = "..." }
-						local defaultColor = displayText.default and displayText.default.color
-						if type(defaultColor) == "table" then
-							color = defaultColor.color
-						elseif type(defaultColor) == "string" then
-							color = defaultColor
-						end
+					-- UIParent-attached bar text is always considered visible
+					if isScreenText then
+						isVisible = true
 					end
-
-					color = color or "FFFFFFFF"
-
-					local barText = {
-						text = e.text,
-						color = string.format("|c%s", color)
-					}
-
-					local returnText = GetReturnText(barText)
-
-					if textFrames ~= nil and textFrames[i] ~= nil then
-						pcall(TryUpdateText, textFrames[i],  returnText)
+					
+					TRB.Data.cache.values.frame["textFrames" .. i] = TRB.Data.cache.values.frame["textFrames" .. i] or {}
+					
+					-- Skip expensive text processing if the target bar is not visible
+					if not isEnabled or not isVisible then
+						TRB.Data.cache.values.frame["textFrames" .. i].text = ""
 					else
-						-- Frame list is out of sync; rebuild and try once.
-						TRB.Functions.BarText:CreateBarTextFrames()
-						textFrames = TRB.Frames.textFrames
+						local color = e.color and e.color.color
+						
+						if e.useDefaultFontColor then
+							-- displayText.default.color uses the new table format { color = "..." }
+							local defaultColor = displayText.default and displayText.default.color
+							if type(defaultColor) == "table" then
+								color = defaultColor.color
+							elseif type(defaultColor) == "string" then
+								color = defaultColor
+							end
+						end
+
+						color = color or "FFFFFFFF"
+
+						local barText = {
+							text = e.text,
+							color = string.format("|c%s", color)
+						}
+
+						local returnText = GetReturnText(barText)
+
 						if textFrames ~= nil and textFrames[i] ~= nil then
 							pcall(TryUpdateText, textFrames[i],  returnText)
+						else
+							-- Frame list is out of sync; rebuild and try once.
+							TRB.Functions.BarText:CreateBarTextFrames()
+							textFrames = TRB.Frames.textFrames
+							if textFrames ~= nil and textFrames[i] ~= nil then
+								pcall(TryUpdateText, textFrames[i],  returnText)
+							end
 						end
+						TRB.Data.cache.values.frame["textFrames" .. i].text = returnText
 					end
-					TRB.Data.cache.values.frame["textFrames" .. i].text = returnText
-				end
-				
-				if TRB.Data.cache.values.frame["textFrames" .. i].level ~= TRB.Data.settings.core.strata.level then
-					if textFrames ~= nil and textFrames[i] ~= nil then
-						textFrames[i]:SetFrameLevel(TRB.Data.constants.frameLevels.barText)
-						textFrames[i]:SetFrameStrata(TRB.Data.settings.core.strata.level)
+					
+					if TRB.Data.cache.values.frame["textFrames" .. i].level ~= TRB.Data.settings.core.strata.level then
+						if textFrames ~= nil and textFrames[i] ~= nil then
+							textFrames[i]:SetFrameLevel(TRB.Data.constants.frameLevels.barText)
+							textFrames[i]:SetFrameStrata(TRB.Data.settings.core.strata.level)
+						end
+						TRB.Data.cache.values.frame["textFrames" .. i].level = TRB.Data.settings.core.strata.level
 					end
-					TRB.Data.cache.values.frame["textFrames" .. i].level = TRB.Data.settings.core.strata.level
 				end
 			end
 		end
@@ -1330,23 +1334,29 @@ function TRB.Functions.BarText:TimerPrecision(value, positiveOnly)
 	end
 end
 
----Hides all bar text
+---Hides all bar text, except UIParent-bound ("Screen") entries which remain visible
 ---@param settings TRB.Classes.Settings.SpecializationSettingsBase
 function TRB.Functions.BarText:Hide(settings)
-	if 1 == 2 then-- settings ~= nil then
-		local displayText = settings.displayText --[[@as TRB.Classes.Settings.DisplayText]]
-		---@type Frame[]
-		local textFrames = TRB.Frames.textFrames
-		local entries = TRB.Functions.Table:Length(displayText.barText)
-		if entries > 0 then
-			for i = 1, entries do
+	local textFrames = TRB.Frames.textFrames
+	if settings ~= nil and settings.displayText ~= nil then
+		local barText = settings.displayText.barText
+		local entries = barText and TRB.Functions.Table:Length(barText) or 0
+		for i = 1, #textFrames do
+			-- UIParent-attached bar text stays visible even when bars are hidden
+			if i <= entries and barText[i] ~= nil
+				and barText[i].enabled
+				and barText[i].position.relativeToFrame == "UIParent"
+				and not TRB.Functions.Bar:IsRenderTransitionActive() then
+				textFrames[i]:Show()
+				---@diagnostic disable-next-line: undefined-field
+				textFrames[i].font:Show()
+			else
 				textFrames[i]:Hide()
 				---@diagnostic disable-next-line: undefined-field
 				textFrames[i].font:Hide()
 			end
 		end
 	else
-		local textFrames = TRB.Frames.textFrames
 		for i = 1, #textFrames do
 			textFrames[i]:Hide()
 			---@diagnostic disable-next-line: undefined-field

--- a/Functions/Character.lua
+++ b/Functions/Character.lua
@@ -791,9 +791,26 @@ function TRB.Functions.Character:FillSpecializationCacheSettings(className, spec
 		specCache.settings.bars = spec.bars
 	end
 
+	-- Build merged bar text list: global entries first, then spec entries
+	local mergedBarText
+	local globalBarTextCount = 0
+	if s.globalBarText and core.displayText and core.displayText.barText and #core.displayText.barText > 0 then
+		mergedBarText = {}
+		for _, entry in ipairs(core.displayText.barText) do
+			mergedBarText[#mergedBarText + 1] = entry
+		end
+		globalBarTextCount = #mergedBarText
+		for _, entry in ipairs(spec.displayText.barText) do
+			mergedBarText[#mergedBarText + 1] = entry
+		end
+	else
+		mergedBarText = spec.displayText.barText
+	end
+
 ---@diagnostic disable-next-line: missing-fields
 	specCache.settings.displayText = {
-		barText = spec.displayText.barText
+		barText = mergedBarText,
+		globalBarTextCount = globalBarTextCount
 	}
 
 	if s.displayText then

--- a/Functions/Character.lua
+++ b/Functions/Character.lua
@@ -1065,29 +1065,26 @@ local CLASS_OPTIONS_KEY = {
 	warrior = "Warrior",
 }
 
+-- Tracks which classes have had their defaults merged into TRB.Data.settings.
+-- The old .bar sentinel was unreliable: the ADDON_LOADED merge copies saved data
+-- for ALL classes, so a non-active class can have .bar from old saved vars while
+-- still missing newer default fields (e.g., colors.bar.casting).
+local classDefaultsMerged = {}
+
 ---Ensure that default spec settings exist in TRB.Data.settings for the given class.
----If any spec in the class has empty settings (no .bar field), loads defaults from the
----class's options module and merges them with any existing saved values.
+---Loads defaults from the class's options module and merges them (as base) with
+---any existing saved values so that new default fields are always present.
+---Only performs the merge once per class per session.
 ---@param className string Lowercase class name (e.g., "warrior")
 ---@return boolean success Whether settings were successfully ensured
 function TRB.Functions.Character:EnsureSpecSettings(className)
+	if classDefaultsMerged[className] then
+		return true
+	end
+
 	local settings = TRB.Data.settings
 	if not settings or not settings[className] then
 		return false
-	end
-
-	-- Check if defaults have already been loaded by testing a sentinel field (.bar)
-	-- on any spec in this class. If all have .bar, defaults are loaded.
-	local needsDefaults = false
-	for _, specSettings in pairs(settings[className]) do
-		if type(specSettings) == "table" and specSettings.bar == nil then
-			needsDefaults = true
-			break
-		end
-	end
-
-	if not needsDefaults then
-		return true
 	end
 
 	local optionsKey = CLASS_OPTIONS_KEY[className]
@@ -1110,6 +1107,7 @@ function TRB.Functions.Character:EnsureSpecSettings(className)
 		end
 	end
 
+	classDefaultsMerged[className] = true
 	return true
 end
 

--- a/Functions/IO.lua
+++ b/Functions/IO.lua
@@ -818,7 +818,17 @@ local function HandleImport(input)
 
 	local function TableMergeWrapper(existing, config)
 		local newBarText = {}
+		local newCoreBarText = nil
 		
+		-- Extract core displayText.barText before merge (array replacement, not merge)
+		if config.core and config.core.displayText and config.core.displayText.barText then
+			local entryCount = TRB.Functions.Table:Length(config.core.displayText.barText)
+			if entryCount > 0 then
+				newCoreBarText = config.core.displayText.barText
+				config.core.displayText.barText = {}
+			end
+		end
+
 		for className, class in pairs(config) do
 			if className ~= "core" then
 				for specName, spec in pairs(class) do
@@ -832,6 +842,11 @@ local function HandleImport(input)
 		end
 
 		local merged = TRB.Functions.Table:Merge(existing, config)
+
+		-- Re-apply core barText as full replacement
+		if newCoreBarText then
+			merged.core.displayText.barText = newCoreBarText
+		end
 
 		if TRB.Functions.Table:Length(newBarText) > 0 then
 			for className, class in pairs(merged) do
@@ -887,6 +902,21 @@ end
 
 function TRB.Functions.IO:ExportPopup(exportMessage, classId, specId, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText, includeCore)
 	local output = HandleExport(classId, specId, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText, includeCore)
+	StaticPopup_Show("TwintopResourceBar_Export", nil, nil, { message = exportMessage, exportString = output})
+end
+
+---Exports only the global bar text settings (core.displayText.barText).
+---@param exportMessage string
+function TRB.Functions.IO:ExportGlobalBarTextPopup(exportMessage)
+	local configuration = {
+		core = {
+			displayText = {
+				barText = TRB.Data.settings.core.displayText.barText,
+				migrations = TRB.Data.settings.core.displayText.migrations
+			}
+		}
+	}
+	local output = Export(configuration)
 	StaticPopup_Show("TwintopResourceBar_Export", nil, nil, { message = exportMessage, exportString = output})
 end
 

--- a/Functions/News.lua
+++ b/Functions/News.lua
@@ -12,10 +12,10 @@ local content = [====[
 
 ---
 
-# WIP
+# 12.0.1.24-release (2026-03-04)
 ## General
 
-- Added **Global Bar Text** support. You can now configure bar text entries in the Global Options "Bar Text" tab that are shared across all specializations.
+- Added Global Bar Text support. You can now configure bar text entries in the Global Options "Bar Text" tab that are shared across all specializations.
 - Each specialization has a "Use global settings" checkbox on its Bar Text tab to opt in. When enabled, global bar text entries are prepended before the specialization's own entries.
 - Global bar text entries support universal variables like `$resource`, `$resourceMax`, `$casting`, `$comboPoints`, and `$comboPointsMax`, plus all common stat/health variables.
 - Added export/import support for global bar text settings.

--- a/Functions/News.lua
+++ b/Functions/News.lua
@@ -12,6 +12,16 @@ local content = [====[
 
 ---
 
+# WIP
+## General
+
+- Added **Global Bar Text** support. You can now configure bar text entries in the Global Options "Bar Text" tab that are shared across all specializations.
+- Each specialization has a "Use global settings" checkbox on its Bar Text tab to opt in. When enabled, global bar text entries are prepended before the specialization's own entries.
+- Global bar text entries support universal variables like `$resource`, `$resourceMax`, `$casting`, `$comboPoints`, and `$comboPointsMax`, plus all common stat/health variables.
+- Added export/import support for global bar text settings.
+
+---
+
 # 12.0.1.23-release (2026-03-03)
 ## General
 

--- a/Functions/Settings.lua
+++ b/Functions/Settings.lua
@@ -14,7 +14,7 @@ local function NewSpecGlobalDefaults()
 		thresholdIcons = false,
 		displayBar = false,
 		displayText = false,
-		globalBarText = false,
+		globalBarText = true,
 		textColors = false,
 		thresholdColors = false,
 		healthBarColors = false,
@@ -168,8 +168,10 @@ function TRB.Functions.Settings:LoadDefaultSettings(classic)
 						color = "FFFFFFFF"
 					},
 				},
-				barText = {},
-				migrations = {}
+				barText = TRB.Functions.Settings:LoadDefaultGlobalBarTextSettings(classic),
+				migrations = {
+					healthBarText = true
+				}
 			},
 			global = {
 				globalEnable = false,
@@ -4450,12 +4452,175 @@ function TRB.Functions.Settings:PortForwardSettings()
 				if type(classGlobals) == "table" and className ~= "globalEnable" then
 					for specName, specGlobals in pairs(classGlobals) do
 						if type(specGlobals) == "table" and specGlobals.globalBarText == nil then
-							specGlobals.globalBarText = false
+							specGlobals.globalBarText = true
 						end
 					end
 				end
 			end
 		end
+	end
+
+	-- Health bar text migration: extract common health bar text entries to global bar text
+	-- This runs once per user. After migration, specs that shared the most common health bar text
+	-- configuration get globalBarText enabled and their per-spec health entries removed.
+	if TwintopInsanityBarSettings ~= nil and
+		TwintopInsanityBarSettings.core ~= nil and
+		TwintopInsanityBarSettings.core.displayText ~= nil and
+		TwintopInsanityBarSettings.core.displayText.migrations ~= nil and
+		not TwintopInsanityBarSettings.core.displayText.migrations.healthBarText then
+
+		local specsByClass = {
+			deathknight = {"blood", "frost", "unholy"},
+			demonhunter = {"havoc", "vengeance", "devourer"},
+			druid = {"balance", "feral", "guardian", "restoration"},
+			evoker = {"devastation", "preservation", "augmentation"},
+			hunter = {"beastMastery", "marksmanship", "survival"},
+			mage = {"arcane", "fire", "frost"},
+			monk = {"brewmaster", "mistweaver", "windwalker"},
+			paladin = {"holy", "protection", "retribution"},
+			priest = {"discipline", "holy", "shadow"},
+			rogue = {"assassination", "outlaw", "subtlety"},
+			shaman = {"elemental", "enhancement", "restoration"},
+			warlock = {"affliction", "demonology", "destruction"},
+			warrior = {"arms", "fury", "protection"}
+		}
+
+		--- Serialize a bar text entry to a fingerprint string (excluding guid and display-only name fields)
+		local function SerializeEntry(entry)
+			local parts = {}
+			parts[#parts+1] = "t=" .. tostring(entry.text or "")
+			parts[#parts+1] = "e=" .. tostring(entry.enabled)
+			parts[#parts+1] = "fs=" .. tostring(entry.fontSize or 0)
+			parts[#parts+1] = "ff=" .. tostring(entry.fontFace or "")
+			parts[#parts+1] = "jh=" .. tostring(entry.fontJustifyHorizontal or "")
+			parts[#parts+1] = "dfc=" .. tostring(entry.useDefaultFontColor)
+			parts[#parts+1] = "dff=" .. tostring(entry.useDefaultFontFace)
+			parts[#parts+1] = "dfs=" .. tostring(entry.useDefaultFontSize)
+			if entry.color and entry.color.color then
+				parts[#parts+1] = "c=" .. entry.color.color
+			end
+			if entry.position then
+				parts[#parts+1] = "px=" .. tostring(entry.position.xPos or 0)
+				parts[#parts+1] = "py=" .. tostring(entry.position.yPos or 0)
+				parts[#parts+1] = "rt=" .. tostring(entry.position.relativeTo or "")
+				parts[#parts+1] = "rf=" .. tostring(entry.position.relativeToFrame or "")
+			end
+			return table.concat(parts, "|")
+		end
+
+		--- Fingerprint an ordered set of health bar text entries
+		local function FingerprintEntries(entries)
+			local serialized = {}
+			for _, entry in ipairs(entries) do
+				serialized[#serialized+1] = SerializeEntry(entry)
+			end
+			return table.concat(serialized, ";;")
+		end
+
+		local fingerprintCounts = {}  -- fingerprint -> count
+		local fingerprintEntries = {} -- fingerprint -> entries (first occurrence)
+		local specFingerprints = {}   -- "className.specName" -> fingerprint
+
+		for className, specs in pairs(specsByClass) do
+			for _, specName in ipairs(specs) do
+				local specSettings = TwintopInsanityBarSettings[className] and TwintopInsanityBarSettings[className][specName]
+				if specSettings and specSettings.displayText and specSettings.displayText.barText then
+					local healthEntries = {}
+					for _, entry in ipairs(specSettings.displayText.barText) do
+						if entry.position and entry.position.relativeToFrame == "HealthBar" then
+							healthEntries[#healthEntries+1] = entry
+						end
+					end
+
+					if #healthEntries > 0 then
+						local fp = FingerprintEntries(healthEntries)
+						local key = className .. "." .. specName
+						specFingerprints[key] = fp
+						fingerprintCounts[fp] = (fingerprintCounts[fp] or 0) + 1
+						if not fingerprintEntries[fp] then
+							fingerprintEntries[fp] = healthEntries
+						end
+					end
+				end
+			end
+		end
+
+		-- Find the most common fingerprint
+		local bestFp = nil
+		local bestCount = 0
+		for fp, count in pairs(fingerprintCounts) do
+			if count > bestCount then
+				bestFp = fp
+				bestCount = count
+			end
+		end
+
+		-- Only migrate if at least 2 specs share the same health bar text
+		if bestFp and bestCount >= 2 then
+			-- Copy winning entries to global bar text with new GUIDs
+			local sourceEntries = fingerprintEntries[bestFp]
+			for _, entry in ipairs(sourceEntries) do
+				local globalEntry = {
+					useDefaultFontColor = entry.useDefaultFontColor,
+					useDefaultFontFace = entry.useDefaultFontFace,
+					useDefaultFontSize = entry.useDefaultFontSize,
+					enabled = entry.enabled,
+					name = entry.name,
+					guid = TRB.Functions.String:Guid(),
+					text = entry.text,
+					fontFace = entry.fontFace,
+					fontFaceName = entry.fontFaceName,
+					fontJustifyHorizontal = entry.fontJustifyHorizontal,
+					fontJustifyHorizontalName = entry.fontJustifyHorizontalName,
+					fontSize = entry.fontSize,
+					color = { color = entry.color and entry.color.color or "FFFFFFFF" },
+					position = {
+						xPos = entry.position.xPos,
+						yPos = entry.position.yPos,
+						relativeTo = entry.position.relativeTo,
+						relativeToName = entry.position.relativeToName,
+						relativeToFrame = entry.position.relativeToFrame,
+						relativeToFrameName = entry.position.relativeToFrameName
+					}
+				}
+				table.insert(TwintopInsanityBarSettings.core.displayText.barText, globalEntry)
+			end
+
+			-- Enable globalBarText and remove migrated entries for matching specs;
+			-- disable globalBarText for non-matching specs so they keep their unique per-spec entries
+			for key, fp in pairs(specFingerprints) do
+				local className, specName = key:match("^(.+)%.(.+)$")
+				if className and specName then
+					if fp == bestFp then
+						-- Enable global bar text for this spec
+						if TwintopInsanityBarSettings.core.global and
+							TwintopInsanityBarSettings.core.global[className] and
+							TwintopInsanityBarSettings.core.global[className][specName] then
+							TwintopInsanityBarSettings.core.global[className][specName].globalBarText = true
+						end
+
+						-- Remove health bar entries from per-spec list (iterate backwards to preserve indices)
+						local barText = TwintopInsanityBarSettings[className][specName].displayText.barText
+						for i = #barText, 1, -1 do
+							if barText[i].position and barText[i].position.relativeToFrame == "HealthBar" then
+								table.remove(barText, i)
+							end
+						end
+					else
+						-- Spec has health bar text entries that differ from the winning fingerprint.
+						-- Disable globalBarText so they keep their own per-spec entries without also
+						-- showing the global ones (which would cause double health text).
+						if TwintopInsanityBarSettings.core.global and
+							TwintopInsanityBarSettings.core.global[className] and
+							TwintopInsanityBarSettings.core.global[className][specName] then
+							TwintopInsanityBarSettings.core.global[className][specName].globalBarText = false
+						end
+					end
+				end
+			end
+		end
+
+		TwintopInsanityBarSettings.core.displayText.migrations.healthBarText = true
 	end
 end
 
@@ -5177,6 +5342,48 @@ function TRB.Functions.Settings:LoadDefaultHealthBarTextSettings(classic)
 	return textSettings
 end
 
+
+---Returns default global bar text
+---@param classic boolean?
+---@return TRB.Classes.Settings.DisplayTextEntry[]
+function TRB.Functions.Settings:LoadDefaultGlobalBarTextSettings(classic)
+	---@type TRB.Classes.Settings.DisplayTextEntry[]
+	local textSettings = {
+		{
+			enabled = false,
+			fontFace = "Fonts\\FRIZQT__.TTF",
+			useDefaultFontFace = false,
+			guid = TRB.Functions.String:Guid(),
+			fontJustifyHorizontalName = "Center",
+			text = "{$inCombatTime}[$inCombatTime]",
+			useDefaultFontColor = false,
+			fontFaceName = "Friz Quadrata TT",
+			name = "Combat Time",
+			position = {
+				relativeToName = "Center",
+				relativeTo = "CENTER",
+				xPos = -400,
+				relativeToFrameName = "Screen",
+				yPos = -200,
+				relativeToFrame = "UIParent",
+			},
+			fontJustifyHorizontal = "CENTER",
+			useDefaultFontSize = false,
+			color = {
+				color = "fffe7878",
+			},
+			fontSize = 48,
+		},
+	}
+
+	local extraTextSettings = TRB.Functions.Settings:LoadDefaultHealthBarTextSettings(classic)
+
+	for x = 1, #extraTextSettings do
+		table.insert(textSettings, extraTextSettings[x])
+	end
+	return textSettings
+end
+
 ---Returns default bar text for a secondary mana bar (used by DPS casters like Shadow Priest, Balance Druid, Elemental Shaman)
 ---@param classic boolean?
 ---@return TRB.Classes.Settings.DisplayTextEntry[]
@@ -5271,7 +5478,7 @@ end
 ---@return TRB.Classes.Settings.DisplayTextEntry[]
 function TRB.Functions.Settings:GlobalLoadDefaultBarTextSettings(includeResourceType, classic)
 	---@type TRB.Classes.Settings.DisplayTextEntry[]
-	local textSettings = TRB.Functions.Settings:LoadDefaultHealthBarTextSettings(classic)
+	local textSettings = {}
 
 	local relativeToFrame = "Resource"
 	local relativeToFrameName = L["MainResourceBar"]

--- a/Functions/Settings.lua
+++ b/Functions/Settings.lua
@@ -14,6 +14,7 @@ local function NewSpecGlobalDefaults()
 		thresholdIcons = false,
 		displayBar = false,
 		displayText = false,
+		globalBarText = false,
 		textColors = false,
 		thresholdColors = false,
 		healthBarColors = false,
@@ -167,7 +168,8 @@ function TRB.Functions.Settings:LoadDefaultSettings(classic)
 						color = "FFFFFFFF"
 					},
 				},
-				barText = {}
+				barText = {},
+				migrations = {}
 			},
 			global = {
 				globalEnable = false,
@@ -4414,6 +4416,46 @@ function TRB.Functions.Settings:PortForwardSettings()
 		TwintopInsanityBarSettings.demonhunter.havoc.thresholds.thresholdDictionary.abyssalGaze = {
 			enabled = TwintopInsanityBarSettings.demonhunter.havoc.thresholds.thresholdDictionary.eyeBeam.enabled
 		}
+	end
+
+	-- Ensure core.displayText has barText and migrations tables for global bar text feature
+	if TwintopInsanityBarSettings ~= nil and TwintopInsanityBarSettings.core ~= nil then
+		if TwintopInsanityBarSettings.core.displayText == nil then
+			TwintopInsanityBarSettings.core.displayText = {
+				default = {
+					fontFace = TRB.Data.constants.defaultSettings.fonts.fontFace,
+					fontFaceName = TRB.Data.constants.defaultSettings.fonts.fontFaceName,
+					fontJustifyHorizontal = "LEFT",
+					fontJustifyHorizontalName = L["PositionLeft"],
+					fontSize = 18,
+					color = {
+						color = "FFFFFFFF"
+					},
+				},
+				barText = {},
+				migrations = {}
+			}
+		else
+			if TwintopInsanityBarSettings.core.displayText.barText == nil then
+				TwintopInsanityBarSettings.core.displayText.barText = {}
+			end
+			if TwintopInsanityBarSettings.core.displayText.migrations == nil then
+				TwintopInsanityBarSettings.core.displayText.migrations = {}
+			end
+		end
+
+		-- Ensure globalBarText exists in all per-spec global toggle tables
+		if TwintopInsanityBarSettings.core.global ~= nil then
+			for className, classGlobals in pairs(TwintopInsanityBarSettings.core.global) do
+				if type(classGlobals) == "table" and className ~= "globalEnable" then
+					for specName, specGlobals in pairs(classGlobals) do
+						if type(specGlobals) == "table" and specGlobals.globalBarText == nil then
+							specGlobals.globalBarText = false
+						end
+					end
+				end
+			end
+		end
 	end
 end
 

--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -2072,3 +2072,18 @@ L["MonkWindwalkerAudioCheckboxDanceOfChiJiTooltip"] = "Play an audio cue when a 
 L["PaladinHolyPowerColorPickerBase"] = "1st Holy Power"
 L["PaladinHolyPowerColorPickerSecond"] = "2nd Holy Power"
 L["PaladinHolyPowerColorPickerThird"] = "3rd Holy Power"
+
+-- Global Bar Text
+L["CheckboxUseGlobalTooltip_GlobalBarText"] = "This will include any bar text entries configured in the Global Options Bar Text in addition to this specialization's own bar text entries."
+L["GlobalBarTextWarningComboPoints"] = "||n||nWarning: Not available on all specializations. Use in conditionals like {$comboPoints}[show $comboPoints][]."
+L["GlobalBarTextImportExport"] = "Global Bar Text"
+L["GlobalBarTextVariable_resource"] = "Current Primary Resource (varies per spec)"
+L["GlobalBarTextVariable_resourceMax"] = "Maximum Primary Resource (varies per spec)"
+L["GlobalBarTextVariable_casting"] = "Resource from Hardcasting Spells (varies per spec)"
+L["GlobalBarTextVariable_comboPoints"] = "Current Combo Points / Secondary Resource (not all specs)"
+L["GlobalBarTextVariable_comboPointsMax"] = "Maximum Combo Points / Secondary Resource (not all specs)"
+L["GlobalBarTextExportMessage"] = "Global Bar Text settings"
+L["GlobalBarTextBulkToggleLabel"] = "Show Global Bar Text on all specializations"
+L["GlobalBarTextBulkToggleTooltip"] = "When checked, Global Bar Text will be shown on all specializations across all classes in addition to that specialization's own bar text entries. When unchecked, it will be not be included on all specializations."
+L["CheckboxUseGlobalBarText"] = "Include Global Bar Text"
+L["CheckboxUseGlobalTooltip_GlobalBarText"] = "When checked, any bar text entries configured in the Global Options Bar Text will be shown in addition to this specialization's own bar text entries."

--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -2075,7 +2075,7 @@ L["PaladinHolyPowerColorPickerThird"] = "3rd Holy Power"
 
 -- Global Bar Text
 L["CheckboxUseGlobalTooltip_GlobalBarText"] = "This will include any bar text entries configured in the Global Options Bar Text in addition to this specialization's own bar text entries."
-L["GlobalBarTextWarningComboPoints"] = "||n||nWarning: Not available on all specializations. Use in conditionals like {$comboPoints}[show $comboPoints][]."
+L["GlobalBarTextWarningComboPoints"] = "|n|nWarning: Not available on all specializations. Use in conditionals like:|n{$comboPoints}[show $comboPoints][hidden]."
 L["GlobalBarTextImportExport"] = "Global Bar Text"
 L["GlobalBarTextVariable_resource"] = "Current Primary Resource (varies per spec)"
 L["GlobalBarTextVariable_resourceMax"] = "Maximum Primary Resource (varies per spec)"
@@ -2087,3 +2087,8 @@ L["GlobalBarTextBulkToggleLabel"] = "Show Global Bar Text on all specializations
 L["GlobalBarTextBulkToggleTooltip"] = "When checked, Global Bar Text will be shown on all specializations across all classes in addition to that specialization's own bar text entries. When unchecked, it will be not be included on all specializations."
 L["CheckboxUseGlobalBarText"] = "Include Global Bar Text"
 L["CheckboxUseGlobalTooltip_GlobalBarText"] = "When checked, any bar text entries configured in the Global Options Bar Text will be shown in addition to this specialization's own bar text entries."
+
+-- Global Bar Text Reset
+L["ResetGlobalBarTextHeader"] = "Reset Global Bar Text"
+L["ResetGlobalBarText"] = "Reset Global Bar Text to Defaults"
+L["ResetGlobalBarTextDialog"] = "Do you want to reset the Global Bar Text entries back to their default configuration? While this only resets the Global Bar Text entries, it will have an affect on what bar text is shown for all specializations that have Global Bar Text enabled."

--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -2074,7 +2074,6 @@ L["PaladinHolyPowerColorPickerSecond"] = "2nd Holy Power"
 L["PaladinHolyPowerColorPickerThird"] = "3rd Holy Power"
 
 -- Global Bar Text
-L["CheckboxUseGlobalTooltip_GlobalBarText"] = "This will include any bar text entries configured in the Global Options Bar Text in addition to this specialization's own bar text entries."
 L["GlobalBarTextWarningComboPoints"] = "|n|nWarning: Not available on all specializations. Use in conditionals like:|n{$comboPoints}[show $comboPoints][hidden]."
 L["GlobalBarTextImportExport"] = "Global Bar Text"
 L["GlobalBarTextVariable_resource"] = "Current Primary Resource (varies per spec)"
@@ -2084,11 +2083,11 @@ L["GlobalBarTextVariable_comboPoints"] = "Current Combo Points / Secondary Resou
 L["GlobalBarTextVariable_comboPointsMax"] = "Maximum Combo Points / Secondary Resource (not all specs)"
 L["GlobalBarTextExportMessage"] = "Global Bar Text settings"
 L["GlobalBarTextBulkToggleLabel"] = "Show Global Bar Text on all specializations"
-L["GlobalBarTextBulkToggleTooltip"] = "When checked, Global Bar Text will be shown on all specializations across all classes in addition to that specialization's own bar text entries. When unchecked, it will be not be included on all specializations."
+L["GlobalBarTextBulkToggleTooltip"] = "When checked, Global Bar Text will be shown on all specializations across all classes in addition to that specialization's own bar text entries. When unchecked, it will not be included on all specializations."
 L["CheckboxUseGlobalBarText"] = "Include Global Bar Text"
 L["CheckboxUseGlobalTooltip_GlobalBarText"] = "When checked, any bar text entries configured in the Global Options Bar Text will be shown in addition to this specialization's own bar text entries."
 
 -- Global Bar Text Reset
 L["ResetGlobalBarTextHeader"] = "Reset Global Bar Text"
 L["ResetGlobalBarText"] = "Reset Global Bar Text to Defaults"
-L["ResetGlobalBarTextDialog"] = "Do you want to reset the Global Bar Text entries back to their default configuration? While this only resets the Global Bar Text entries, it will have an affect on what bar text is shown for all specializations that have Global Bar Text enabled."
+L["ResetGlobalBarTextDialog"] = "Do you want to reset the Global Bar Text entries back to their default configuration? While this only resets the Global Bar Text entries, it will have an effect on what bar text is shown for all specializations that have Global Bar Text enabled."

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -491,6 +491,19 @@ local function ConstructResetDefaultsPanel(parent)
 		hideOnEscape = true,
 		preferredIndex = 3
 	}
+	StaticPopupDialogs["TwintopResourceBar_ResetGlobalBarText"] = {
+		text = L["ResetGlobalBarTextDialog"],
+		button1 = L["Yes"],
+		button2 = L["No"],
+		OnAccept = function()
+			local newBarText = TRB.Functions.Settings:LoadDefaultGlobalBarTextSettings()
+			controls.barTextFields.ResetTableValues(newBarText)
+		end,
+		timeout = 0,
+		whileDead = true,
+		hideOnEscape = true,
+		preferredIndex = 3
+	}
 
 	controls.textSection = TRB.Functions.OptionsUi:BuildSectionHeader(parent, L["EditModeSettings"], oUi.xCoord, yCoord)
 
@@ -498,6 +511,15 @@ local function ConstructResetDefaultsPanel(parent)
 	controls.buttons.resetEditModeData = TRB.Functions.OptionsUi:BuildButton(parent, L["ResetEditModeDataButton"], oUi.xCoord, yCoord, 200, 30)
 	controls.buttons.resetEditModeData:SetScript("OnClick", function(self, ...)
 		StaticPopup_Show("TwintopResourceBar_ResetEditModeData")
+	end)
+
+	yCoord = yCoord - 40
+	controls.textSection = TRB.Functions.OptionsUi:BuildSectionHeader(parent, L["ResetGlobalBarTextHeader"], oUi.xCoord, yCoord)
+
+	yCoord = yCoord - 30
+	controls.buttons.resetGlobalBarText = TRB.Functions.OptionsUi:BuildButton(parent, L["ResetGlobalBarText"], oUi.xCoord, yCoord, 250, 30)
+	controls.buttons.resetGlobalBarText:SetScript("OnClick", function(self, ...)
+		StaticPopup_Show("TwintopResourceBar_ResetGlobalBarText")
 	end)
 end
 

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -501,6 +501,40 @@ local function ConstructResetDefaultsPanel(parent)
 	end)
 end
 
+local function ConstructGlobalBarTextPanel(parent)
+	if parent == nil then
+		return
+	end
+
+	local interfaceSettingsFrame = TRB.Frames.interfaceSettingsFrameContainer
+	local controls = interfaceSettingsFrame.controls.global
+	local yCoord = 5
+
+	TRB.Functions.OptionsUi:BuildSectionHeader(parent, L["BarDisplayTextCustomizationHeader"], oUi.xCoord, yCoord)
+	controls.buttons.exportButton_Global_BarText = TRB.Functions.OptionsUi:BuildExportButton(parent, L["ExportMessageExportBarText"], yCoord-5)
+	controls.buttons.exportButton_Global_BarText:SetScript("OnClick", function(self, ...)
+		TRB.Functions.IO:ExportGlobalBarTextPopup(L["GlobalBarTextExportMessage"])
+	end)
+
+	yCoord = yCoord - 10
+
+	-- Build a lightweight cache object with global-applicable barTextVariables
+	local globalCache = {
+		barTextVariables = {
+			icons = TRB.Functions.BarText:GetCommonIcons(),
+			values = TRB.Functions.BarText:GetCommonValues({
+				{ variable = "$resource", description = L["GlobalBarTextVariable_resource"], printInSettings = true, color = false },
+				{ variable = "$resourceMax", description = L["GlobalBarTextVariable_resourceMax"], printInSettings = true, color = false },
+				{ variable = "$casting", description = L["GlobalBarTextVariable_casting"], printInSettings = true, color = false },
+				{ variable = "$comboPoints", description = L["GlobalBarTextVariable_comboPoints"] .. " " .. L["GlobalBarTextWarningComboPoints"], printInSettings = true, color = false },
+				{ variable = "$comboPointsMax", description = L["GlobalBarTextVariable_comboPointsMax"] .. " " .. L["GlobalBarTextWarningComboPoints"], printInSettings = true, color = false },
+			}),
+		}
+	}
+
+	TRB.Functions.OptionsUi:GenerateBarTextEditor(parent, controls, TRB.Data.settings.core, nil, nil, yCoord, globalCache)
+end
+
 local function ConstructGlobalOptionsPanel()
 	local interfaceSettingsFrame = TRB.Frames.interfaceSettingsFrameContainer
 	local parent = interfaceSettingsFrame.panel
@@ -520,15 +554,15 @@ local function ConstructGlobalOptionsPanel()
 
 	parent = interfaceSettingsFrame.optionsPanel
 
-	controls.textSection = TRB.Functions.OptionsUi:BuildSectionHeader(parent, L["GlobalOptions"], oUi.xCoord, yCoord-5)
+	controls.textSection = TRB.Functions.OptionsUi:BuildSectionHeader(parent, L["GlobalOptions"], oUi.xCoord, yCoord - 5)
 
-	controls.buttons.importButton = TRB.Functions.OptionsUi:BuildButton(parent, L["Import"], 415, yCoord-10, 90, 20)
+	controls.buttons.importButton = TRB.Functions.OptionsUi:BuildButton(parent, L["Import"], 479, yCoord-10, 90, 20)
 	controls.buttons.importButton:SetFrameLevel(10000)
 	controls.buttons.importButton:SetScript("OnClick", function(self, ...)
 		StaticPopup_Show("TwintopResourceBar_Import")
 	end)
 
-	yCoord = yCoord - 52
+	yCoord = yCoord - 37
 
 	-- Must assign controls before BuildTabGroup, since constructors read interfaceSettingsFrame.controls.global
 	TRB.Frames.interfaceSettingsFrameContainer.controls.global = controls
@@ -541,6 +575,7 @@ local function ConstructGlobalOptionsPanel()
 		{ "barVisibility", L["TabVisibility"], oUi.tabWidth.small, ConstructBarVisibilityPanel },
 		{ "thresholds", L["TabThresholds"], oUi.tabWidth.large, ConstructThresholdPanel },
 		{ "fontText", L["TabFontText"], oUi.tabWidth.medium, ConstructFontAndTextPanel },
+		{ "barText", L["TabBarText"], oUi.tabWidth.small, ConstructGlobalBarTextPanel },
 		{ "miscellaneous", L["TabMiscellaneous"], oUi.tabWidth.medium, ConstructMiscellaneousPanel },
 		{ "resetDefaults", L["TabResetDefaults"], oUi.tabWidth.medium, ConstructResetDefaultsPanel },
 	}

--- a/Options/OptionsUi.lua
+++ b/Options/OptionsUi.lua
@@ -155,7 +155,8 @@ local settingKeyToCheckboxSuffix = {
 	thresholdColors = "thresholdColors",
 	displayText = "displayText",
 	textColors = "textColors",
-	precision = "precision"
+	precision = "precision",
+	globalBarText = "globalBarText"
 }
 
 -- Mapping from lowercase class name to classId for frame name resolution
@@ -318,8 +319,10 @@ end
 ---@param controlKey string # Key to store in controls.checkBoxes
 ---@param settingKey string # The global setting key (e.g., "bar", "comboPoints")
 ---@param yCoord number # Y coordinate for positioning
+---@param customLabel string? # Optional custom label text
+---@param customTooltip string? # Optional custom tooltip text
 ---@return number # Updated Y coordinate
-function TRB.Functions.OptionsUi:BuildBulkGlobalToggleCheckbox(parent, controls, controlKey, settingKey, yCoord)
+function TRB.Functions.OptionsUi:BuildBulkGlobalToggleCheckbox(parent, controls, controlKey, settingKey, yCoord, customLabel, customTooltip)
 	local f = nil
 	
 	yCoord = yCoord - 30
@@ -327,9 +330,9 @@ function TRB.Functions.OptionsUi:BuildBulkGlobalToggleCheckbox(parent, controls,
 	controls.checkBoxes[controlKey] = CreateFrame("CheckButton", "TwintopResourceBar_Global_enableAll_" .. settingKey, parent, "ChatConfigCheckButtonTemplate")
 	f = controls.checkBoxes[controlKey]
 	f:SetPoint("TOPLEFT", oUi.xCoord + oUi.xPadding, yCoord)
-	getglobal(f:GetName() .. 'Text'):SetText(L["CheckboxEnableForAllSpecs"])
+	getglobal(f:GetName() .. 'Text'):SetText(customLabel or L["CheckboxEnableForAllSpecs"])
 	getglobal(f:GetName() .. 'Text'):SetTextColor(GetUseGlobalSettingsColor())
-	f.tooltip = L["CheckboxEnableForAllSpecsTooltip"]
+	f.tooltip = customTooltip or L["CheckboxEnableForAllSpecsTooltip"]
 	
 	-- Set initial tristate based on current values
 	local currentState = GetAllSpecsGlobalState(settingKey)
@@ -1441,8 +1444,13 @@ end
 ---@param specId integer
 ---@param tabKey string The tab key to switch to (e.g., "barText", "barDisplay")
 function TRB.Functions.OptionsUi:SwitchToTabByClassSpec(classId, specId, tabKey)
-	local className, specName = TRB.Functions.Character:GetClassAndSpecializationNames(classId, specId)
-	local namePrefix = className .. "_" .. specName
+	local namePrefix
+	if classId == nil then
+		namePrefix = "Global"
+	else
+		local className, specName = TRB.Functions.Character:GetClassAndSpecializationNames(classId, specId)
+		namePrefix = className .. "_" .. specName
+	end
 	local tab = _G["TwintopResourceBar_Options_" .. namePrefix .. "_Tab_" .. tabKey]
 	if tab then
 		TRB.Functions.OptionsUi:SwitchTab(tab, tab.id)
@@ -6427,7 +6435,40 @@ function TRB.Functions.OptionsUi:GenerateBarTextEditor(parent, controls, spec, c
 	local namePrefix = className .. "_" .. specName .. "_barTextEditor"
 	local title = ""
 	local sanityCheckValues = TRB.Functions.Bar:GetSanityCheckValues(spec)
-	
+
+	-- Per-spec "Use Global Bar Text" checkbox (skip for the global panel itself)
+	if classId ~= nil and specId ~= nil then
+		local lowerClassName = string.lower(className)
+		controls.checkBoxes = controls.checkBoxes or {}
+		controls.checkBoxes.useGlobalBarText = CreateFrame("CheckButton", "TwintopResourceBar_" .. className .. "_" .. specName .. "_useGlobal_globalBarText", parent, "ChatConfigCheckButtonTemplate")
+		local f = controls.checkBoxes.useGlobalBarText
+		f:SetPoint("TOPLEFT", oUi.xCoord + oUi.xPadding, yCoord)
+		getglobal(f:GetName() .. 'Text'):SetText(L["CheckboxUseGlobalBarText"])
+		getglobal(f:GetName() .. 'Text'):SetTextColor(GetUseGlobalSettingsColor())
+		f.tooltip = L["CheckboxUseGlobalTooltip_GlobalBarText"]
+		f:SetChecked(TRB.Data.settings.core.global[lowerClassName][specName].globalBarText)
+		f:SetScript("OnClick", function(self, ...)
+			TRB.Data.settings.core.global[lowerClassName][specName].globalBarText = self:GetChecked()
+			TRB.Functions.Character:FillSpecializationCacheSettings(lowerClassName, specName)
+			TRB.Data.cache.barText = {}
+			TRB.Data.cache.symbols = {}
+			TRB.Data.cache.barTextTree = {}
+			TRB.Functions.BarText:Hide(spec)
+			TRB.Functions.BarText:CreateBarTextFrames(classId, specId)
+			if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
+				C_Timer.After(0, function()
+					TRB.Functions.Class:TriggerResourceBarUpdates()
+				end)
+			end
+			TRB.Functions.OptionsUi:RefreshBulkGlobalToggleCheckbox("globalBarText")
+		end)
+		yCoord = yCoord - 20
+	else
+		yCoord = yCoord + 10 -- Fix offset
+		yCoord = TRB.Functions.OptionsUi:BuildBulkGlobalToggleCheckbox(parent, controls, "enableAllGlobalBarText", "globalBarText", yCoord, L["GlobalBarTextBulkToggleLabel"], L["GlobalBarTextBulkToggleTooltip"])
+		yCoord = yCoord - 20
+	end
+
 	local columns = {
 		{
 			["name"] = "GUID",
@@ -6565,8 +6606,24 @@ function TRB.Functions.OptionsUi:GenerateBarTextEditor(parent, controls, spec, c
 		L["HealthBar"],
 		L["Screen"],
 	}
-	
-	if (classId == 1 and specId == 2) then -- Fury Warrior
+
+	if classId == nil then -- Global Bar Text
+		relativeToFrame[L["ComboPoint1"]] = "ComboPoint_1"
+		relativeToFrame[L["ComboPoint2"]] = "ComboPoint_2"
+		relativeToFrame[L["ComboPoint3"]] = "ComboPoint_3"
+		relativeToFrame[L["ComboPoint4"]] = "ComboPoint_4"
+		relativeToFrame[L["ComboPoint5"]] = "ComboPoint_5"
+		relativeToFrameList = {
+			L["MainResourceBar"],
+			L["ComboPoint1"],
+			L["ComboPoint2"],
+			L["ComboPoint3"],
+			L["ComboPoint4"],
+			L["ComboPoint5"],
+			L["HealthBar"],
+			L["Screen"],
+		}
+	elseif (classId == 1 and specId == 2) then -- Fury Warrior
 		relativeToFrame[L["WhirlwindCharge1"]] = "Whirlwind_Charge_1"
 		relativeToFrame[L["WhirlwindCharge2"]] = "Whirlwind_Charge_2"
 		relativeToFrame[L["WhirlwindCharge3"]] = "Whirlwind_Charge_3"
@@ -7384,7 +7441,20 @@ function TRB.Functions.OptionsUi:GenerateBarTextEditor(parent, controls, spec, c
 		SetTableValues(spec.displayText, barTextTable)
 		_G["TwintopResourceBar_" .. namePrefix .. "_BarTextOptionsFrame"]:Hide()
 		
-		if classId == TRB.Data.character.classId and specId == TRB.Data.character.specId then
+		if classId == nil then
+			-- Global bar text editor: rebuild the active spec if it uses global bar text
+			local charClassName = TRB.Data.character.className
+			local charSpecName = TRB.Data.character.specName
+			if charClassName and charSpecName and TRB.Data.settings.core.global[charClassName] and TRB.Data.settings.core.global[charClassName][charSpecName] and TRB.Data.settings.core.global[charClassName][charSpecName].globalBarText then
+				TRB.Functions.Character:FillSpecializationCacheSettings(charClassName, charSpecName)
+				TRB.Data.cache.barText = {}
+				TRB.Data.cache.symbols = {}
+				TRB.Data.cache.barTextTree = {}
+				TRB.Functions.BarText:Hide(spec)
+				TRB.Functions.BarText:CreateBarTextFrames()
+				TRB.Functions.Class:TriggerResourceBarUpdates()
+			end
+		elseif classId == TRB.Data.character.classId and specId == TRB.Data.character.specId then
 			TRB.Data.cache.barText = {}
 			TRB.Data.cache.symbols = {}
 			TRB.Data.cache.barTextTree = {}

--- a/Options/OptionsUi.lua
+++ b/Options/OptionsUi.lua
@@ -6405,7 +6405,15 @@ StaticPopupDialogs["TwintopResourceBar_ConfirmDeleteBarText"] = {
 		d.btt:SetSelection()
 		table.remove(d.displayText.barText, d.row)
 		d.setTableValues(d.displayText, d.btt)
-		if d.classId == TRB.Data.character.classId and d.specId == TRB.Data.character.specId then
+		-- If editing global bar text, refresh the active spec's merged bar text list
+		if d.classId == nil then
+			local charClassName = TRB.Data.character.className
+			local charSpecName = TRB.Data.character.specName
+			if charClassName and charSpecName and TRB.Data.settings.core.global[charClassName] and TRB.Data.settings.core.global[charClassName][charSpecName] and TRB.Data.settings.core.global[charClassName][charSpecName].globalBarText then
+				TRB.Functions.Character:FillSpecializationCacheSettings(charClassName, charSpecName)
+			end
+		end
+		if d.classId == nil or (d.classId == TRB.Data.character.classId and d.specId == TRB.Data.character.specId) then
 			TRB.Data.cache.barText = {}
 			TRB.Data.cache.symbols = {}
 			TRB.Data.cache.barTextTree = {}
@@ -7368,6 +7376,17 @@ function TRB.Functions.OptionsUi:GenerateBarTextEditor(parent, controls, spec, c
 		table.insert(displayText.barText, newEntry)
 		SetTableValues(displayText, barTextTable)
 		barTextTable:SetSelection(TRB.Functions.Table:Length(displayText.barText))
+		-- If editing global bar text, refresh the active spec's merged bar text list
+		if classId == nil then
+			local charClassName = TRB.Data.character.className
+			local charSpecName = TRB.Data.character.specName
+			if charClassName and charSpecName and TRB.Data.settings.core.global[charClassName] and TRB.Data.settings.core.global[charClassName][charSpecName] and TRB.Data.settings.core.global[charClassName][charSpecName].globalBarText then
+				TRB.Functions.Character:FillSpecializationCacheSettings(charClassName, charSpecName)
+			end
+			TRB.Data.cache.barText = {}
+			TRB.Data.cache.symbols = {}
+			TRB.Data.cache.barTextTree = {}
+		end
 		TRB.Functions.BarText:CreateBarTextFrames(classId, specId)
 		FillBarTextEditorFields(newEntry.guid, displayText)
 	end)

--- a/Options/OptionsUi.lua
+++ b/Options/OptionsUi.lua
@@ -7469,9 +7469,14 @@ function TRB.Functions.OptionsUi:GenerateBarTextEditor(parent, controls, spec, c
 				TRB.Data.cache.barText = {}
 				TRB.Data.cache.symbols = {}
 				TRB.Data.cache.barTextTree = {}
-				TRB.Functions.BarText:Hide(spec)
+				-- Use the active spec's merged settings (not core) so frame indices match the merged barText list
+				local activeCompositeKey = TRB.Functions.Character:GetCompositeKey(charClassName, charSpecName)
+				local activeSettings = TRB.Data.specCache[activeCompositeKey] and TRB.Data.specCache[activeCompositeKey].settings
+				TRB.Functions.BarText:Hide(activeSettings or spec)
 				TRB.Functions.BarText:CreateBarTextFrames()
-				TRB.Functions.Class:TriggerResourceBarUpdates()
+				if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
+					TRB.Functions.Class:TriggerResourceBarUpdates()
+				end
 			end
 		elseif classId == TRB.Data.character.classId and specId == TRB.Data.character.specId then
 			TRB.Data.cache.barText = {}


### PR DESCRIPTION
Adds a shared "Global Bar Text" system that lets users configure bar text entries once and have them apply across all specializations.

### Features
- **Global bar text entries** stored in `core.displayText.barText`, merged at runtime ahead of per-spec entries via `FillSpecializationCacheSettings`
- **Per-spec opt-in toggle** ("Include Global Bar Text" checkbox) on each spec's Bar Text tab, controlled by `core.global.<class>.<spec>.globalBarText`
- **Bulk toggle** on the Global Options Bar Text tab to enable/disable global bar text across all specs at once
- **Global Bar Text editor** in the Global Options panel with full bar text editing (add/delete/reorder), export button, and a variables side panel showing common cross-spec variables (`$resource`, `$casting`, `$comboPoints`, etc.)
- **Reset button** on the Global Options Reset Defaults tab to restore global bar text to defaults

### Migration (existing users)
- **Health bar text migration**: On first load, fingerprints all per-spec `HealthBar`-bound bar text entries, finds the most common configuration, copies it to global bar text, and removes those entries from matching specs. Specs with non-matching health text get `globalBarText = false` so they keep their unique entries without duplication.
- Conditional clearing of default `core.displayText.barText` during ADDON_LOADED — only clears when saved vars already have entries, preserving defaults for users who upgraded during the midnight era.
- `midnightBarTextReset` flags respected per-class to avoid resetting bar text for classes already migrated.

### New installs
- Default global bar text includes a disabled Combat Time entry and left/right health bar text entries.
- All specs default to `globalBarText = true`.

### Bug fixes
- **`EnsureSpecSettings` sentinel fix**: Replaced unreliable `.bar` field sentinel with a `classDefaultsMerged` tracking table so defaults always merge correctly for non-active classes when opening their options panels.
- **Import/export**: `IO.lua` handles global bar text arrays correctly — extracts `core.displayText.barText` before merge and re-applies as full replacement. Dedicated `ExportGlobalBarTextPopup` for global-only export.
- **`BarText.lua` visibility**: Screen-anchored (`UIParent`) bar text entries now respect the bar's show/hide state properly.