### PR TITLE
Consolidate bar visibility into a generic rules engine

### DIFF
--- a/ClassModules/DeathKnight.lua
+++ b/ClassModules/DeathKnight.lua
@@ -1398,104 +1398,20 @@ function TRB.Functions.Class:HideResourceBar(force)
 			sharedSettings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 		end
 
+		local entries = {
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.primary, sharedSettings and sharedSettings.displayBar.primary, true, nil, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.secondary, sharedSettings and sharedSettings.displayBar.secondary, true, TRB.Data.character.maxResource2, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.health, sharedSettings and sharedSettings.displayBar.health, true, 1, nil),
+		}
+
 		if sharedSettings ~= nil then
-			local affectingCombat = TRB.Data.character.inCombat
-			local inVehicle = UnitInVehicle("player")
-			local forceHideAll = not TRB.Data.specSupported or force or (TRB.Data.character.advancedFlight and not sharedSettings.displayBar.dragonriding)
-
-			-- Determine primary bar visibility independently
-			local showPrimary = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.primary.visibility == "always" then
-					showPrimary = true
-				elseif sharedSettings.displayBar.primary.visibility == "combat" then
-					showPrimary = affectingCombat or inVehicle
-				end
-				-- "never" means showPrimary stays false
-			end
-
-			-- Determine secondary bar visibility independently
-			local showSecondary = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.secondary.visibility == "always" then
-					showSecondary = true
-				elseif sharedSettings.displayBar.secondary.visibility == "combat" then
-					showSecondary = affectingCombat or inVehicle
-				end
-				-- "never" means showSecondary stays false
-			end
-
-			-- Determine health bar visibility independently
-			local showHealth = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.health.visibility == "always" then
-					showHealth = true
-				elseif sharedSettings.displayBar.health.visibility == "combat" then
-					showHealth = affectingCombat or inVehicle
-				end
-				-- "never" means showHealth stays false
-			end
-
-			-- Apply primary bar visibility
-			if barGroups and barGroups.primary then
-				if showPrimary then
-					barGroups.primary:Show()
-				else
-					barGroups.primary:Hide()
-				end
-			end
-
-			-- Apply secondary bar visibility
-			if barGroups and barGroups.secondary then
-				if showSecondary then
-					barGroups.secondary:Show()
-					barGroups.secondary:ShowNodes(TRB.Data.character.maxResource2)
-				else
-					barGroups.secondary:Hide()
-				end
-			end
-
-			-- Apply health bar visibility
-			if barGroups and barGroups.health then
-				if showHealth then
-					barGroups.health:Show()
-					barGroups.health:ShowNodes(1)
-				else
-					barGroups.health:Hide()
-				end
-			end
-
-			-- Track if either bar is showing
-			snapshotData.attributes.isTracking = showPrimary or showSecondary or showHealth
-			if snapshotData.attributes.isTracking then
-				TRB.Functions.BarText:Show(sharedSettings)
-			else
-				TRB.Functions.BarText:Hide(sharedSettings)
-			end
+			local context = TRB.Classes.BarVisibilityContext:NewFromGameState(force, sharedSettings)
+			TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData, sharedSettings)
 		else
-			if barGroups and barGroups.primary then
-				barGroups.primary:Hide()
-			end
-			if barGroups and barGroups.secondary then
-				barGroups.secondary:Hide()
-			end
-			if barGroups and barGroups.health then
-				barGroups.health:Hide()
-			end
-			TRB.Functions.BarText:Hide(sharedSettings)
-			snapshotData.attributes.isTracking = false
+			TRB.Functions.BarVisibility:HideAllEntries(entries, snapshotData, nil)
 		end
 	else
-		if barGroups and barGroups.primary then
-			barGroups.primary:Hide()
-		end
-		if barGroups and barGroups.secondary then
-			barGroups.secondary:Hide()
-		end
-		if barGroups and barGroups.health then
-			barGroups.health:Hide()
-		end
-		snapshotData.attributes.isTracking = false
+		TRB.Functions.BarVisibility:HideAllBarGroups(snapshotData)
 	end
 end
 

--- a/ClassModules/DemonHunter.lua
+++ b/ClassModules/DemonHunter.lua
@@ -1800,109 +1800,27 @@ function TRB.Functions.Class:HideResourceBar(force)
 			sharedSettings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 		end
 
+		-- Secondary (Soul Fragments) only for Vengeance (2) and Devourer (3)
+		local hasSecondary = TRB.Data.character.specId == 2 or TRB.Data.character.specId == 3
+		local secondaryNodes = nil
+		if hasSecondary then
+			secondaryNodes = TRB.Data.character.specId == 2 and 6 or 1
+		end
+
+		local entries = {
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.primary, sharedSettings and sharedSettings.displayBar.primary, true, nil, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.secondary, sharedSettings and sharedSettings.displayBar.secondary, hasSecondary, secondaryNodes, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.health, sharedSettings and sharedSettings.displayBar.health, true, 1, nil),
+		}
+
 		if sharedSettings ~= nil then
-			local affectingCombat = TRB.Data.character.inCombat
-			local inVehicle = UnitInVehicle("player")
-			local forceHideAll = not TRB.Data.specSupported or force or (TRB.Data.character.advancedFlight and not sharedSettings.displayBar.dragonriding)
-
-			-- Determine primary bar visibility independently
-			local showPrimary = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.primary.visibility == "always" then
-					showPrimary = true
-				elseif sharedSettings.displayBar.primary.visibility == "combat" then
-					showPrimary = affectingCombat or inVehicle
-				end
-				-- "never" means showPrimary stays false
-			end
-
-			-- Determine secondary bar visibility independently
-			-- Vengeance (specId == 2) and Devourer (specId == 3) use the secondary (Soul Fragments) bar
-			local showSecondary = false
-			if not forceHideAll and (TRB.Data.character.specId == 2 or TRB.Data.character.specId == 3) then
-				if sharedSettings.displayBar.secondary.visibility == "always" then
-					showSecondary = true
-				elseif sharedSettings.displayBar.secondary.visibility == "combat" then
-					showSecondary = affectingCombat or inVehicle
-				end
-				-- "never" means showSecondary stays false
-			end
-
-			-- Determine health bar visibility independently
-			local showHealth = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.health.visibility == "always" then
-					showHealth = true
-				elseif sharedSettings.displayBar.health.visibility == "combat" then
-					showHealth = affectingCombat or inVehicle
-				end
-				-- "never" means showHealth stays false
-			end
-
-			-- Apply primary bar visibility
-			if barGroups and barGroups.primary then
-				if showPrimary then
-					barGroups.primary:Show()
-				else
-					barGroups.primary:Hide()
-				end
-			end
-
-			-- Apply secondary bar visibility
-			if barGroups and barGroups.secondary then
-				if showSecondary then
-					barGroups.secondary:Show()
-					if TRB.Data.character.specId == 2 then
-						barGroups.secondary:ShowNodes(6)
-					else
-						barGroups.secondary:ShowNodes(1)
-					end
-				else
-					barGroups.secondary:Hide()
-				end
-			end
-
-			-- Apply health bar visibility
-			if barGroups and barGroups.health then
-				if showHealth then
-					barGroups.health:Show()
-					barGroups.health:ShowNodes(1)
-				else
-					barGroups.health:Hide()
-				end
-			end
-
-			-- Track if any bar is showing
-			snapshotData.attributes.isTracking = showPrimary or showSecondary or showHealth
-			if snapshotData.attributes.isTracking then
-				TRB.Functions.BarText:Show(sharedSettings)
-			else
-				TRB.Functions.BarText:Hide(sharedSettings)
-			end
+			local context = TRB.Classes.BarVisibilityContext:NewFromGameState(force, sharedSettings)
+			TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData, sharedSettings)
 		else
-			if barGroups and barGroups.primary then
-				barGroups.primary:Hide()
-			end
-			if barGroups and barGroups.secondary then
-				barGroups.secondary:Hide()
-			end
-			if barGroups and barGroups.health then
-				barGroups.health:Hide()
-			end
-			TRB.Functions.BarText:Hide(sharedSettings)
-			snapshotData.attributes.isTracking = false
+			TRB.Functions.BarVisibility:HideAllEntries(entries, snapshotData, nil)
 		end
 	else
-		if barGroups and barGroups.primary then
-			barGroups.primary:Hide()
-		end
-		if barGroups and barGroups.secondary then
-			barGroups.secondary:Hide()
-		end
-		if barGroups and barGroups.health then
-			barGroups.health:Hide()
-		end
-		snapshotData.attributes.isTracking = false
+		TRB.Functions.BarVisibility:HideAllBarGroups(snapshotData)
 	end
 end
 

--- a/ClassModules/Druid.lua
+++ b/ClassModules/Druid.lua
@@ -3048,144 +3048,40 @@ function TRB.Functions.Class:HideResourceBar(force)
 			sharedSettings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 		end
 
+		-- Determine form-based display spec for secondary and mana bar routing
+		local currentForm = TRB.Data.character.currentShapeshiftForm or "humanoid"
+		local displaySpecId = GetFormSpecForSettings(TRB.Data.character.specId, currentForm)
+
+		-- Secondary (Combo Points): enabled when displaySpecId is Feral (2)
+		-- Uses Feral's specCache for visibility settings
+		local hasSecondary = displaySpecId == 2
+		local secondaryVisSettings = nil
+		if hasSecondary then
+			local feralSettings = TRB.Data.specCache.druid_feral and TRB.Data.specCache.druid_feral.settings or sharedSettings
+			if feralSettings ~= nil and feralSettings.displayBar ~= nil then
+				secondaryVisSettings = feralSettings.displayBar.secondary
+			end
+		end
+
+		-- Mana bar: Balance (specId == 1) in Balance form (displaySpecId == 1)
+		local hasMana = TRB.Data.character.specId == 1 and displaySpecId == 1
+		local manaVisSettings = (sharedSettings and sharedSettings.displayBar.mana) or nil
+
+		local entries = {
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.primary, sharedSettings and sharedSettings.displayBar.primary, true, nil, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.secondary, secondaryVisSettings, hasSecondary, TRB.Data.character.maxResource2, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.health, sharedSettings and sharedSettings.displayBar.health, true, 1, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.mana, manaVisSettings, hasMana, 1, nil),
+		}
+
 		if sharedSettings ~= nil then
-			local affectingCombat = TRB.Data.character.inCombat
-			local inVehicle = UnitInVehicle("player")
-			local forceHideAll = not TRB.Data.specSupported or force or (TRB.Data.character.advancedFlight and not sharedSettings.displayBar.dragonriding)
-
-			-- Determine primary bar visibility independently
-			local showPrimary = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.primary.visibility == "always" then
-					showPrimary = true
-				elseif sharedSettings.displayBar.primary.visibility == "combat" then
-					showPrimary = affectingCombat or inVehicle
-				end
-				-- "never" means showPrimary stays false
-			end
-
-			-- Determine secondary bar visibility independently
-			-- Combo points should show whenever the energy bar is being shown (Feral spec or Cat form)
-			-- and should respect their visibility setting
-			local showSecondary = false
-			local currentForm = TRB.Data.character.currentShapeshiftForm or "humanoid"
-			local displaySpecId = GetFormSpecForSettings(TRB.Data.character.specId, currentForm)
-			
-			-- Show combo points when displaySpecId is Feral (energy bar is shown)
-			if not forceHideAll and displaySpecId == 2 then
-				-- Use Feral's secondary bar settings for visibility
-				local secondarySettings = TRB.Data.specCache.druid_feral and TRB.Data.specCache.druid_feral.settings or sharedSettings
-				
-				if secondarySettings ~= nil and secondarySettings.displayBar ~= nil then
-					if secondarySettings.displayBar.secondary.visibility == "always" then
-						showSecondary = true
-					elseif secondarySettings.displayBar.secondary.visibility == "combat" then
-						showSecondary = affectingCombat or inVehicle
-					end
-					-- "never" means showSecondary stays false
-				end
-			end
-
-			-- Determine health bar visibility independently
-			local showHealth = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.health.visibility == "always" then
-					showHealth = true
-				elseif sharedSettings.displayBar.health.visibility == "combat" then
-					showHealth = affectingCombat or inVehicle
-				end
-				-- "never" means showHealth stays false
-			end
-
-			-- Determine mana bar visibility independently (Balance only)
-			-- Show mana bar when displaySpecId is Balance (1), not just when in Moonkin form
-			-- This ensures mana bar persists when form switching is disabled
-			local showMana = false
-			if TRB.Data.character.specId == 1 and displaySpecId == 1 and not forceHideAll and sharedSettings.displayBar.mana ~= nil then
-				if sharedSettings.displayBar.mana.visibility == "always" then
-					showMana = true
-				elseif sharedSettings.displayBar.mana.visibility == "combat" then
-					showMana = affectingCombat or inVehicle
-				end
-				-- "never" means showMana stays false
-			end
-
-			-- Apply primary bar visibility
-			if barGroups and barGroups.primary then
-				if showPrimary then
-					barGroups.primary:Show()
-				else
-					barGroups.primary:Hide()
-				end
-			end
-
-			-- Apply secondary bar visibility
-			if barGroups and barGroups.secondary then
-				if showSecondary then
-					barGroups.secondary:Show()
-					barGroups.secondary:ShowNodes(TRB.Data.character.maxResource2)
-				else
-					barGroups.secondary:Hide()
-				end
-			end
-
-			-- Apply health bar visibility
-			if barGroups and barGroups.health then
-				if showHealth then
-					barGroups.health:Show()
-					barGroups.health:ShowNodes(1)
-				else
-					barGroups.health:Hide()
-				end
-			end
-
-			-- Apply mana bar visibility (Balance only)
-			if barGroups and barGroups.mana then
-				if showMana then
-					barGroups.mana:Show()
-					barGroups.mana:ShowNodes(1)
-				else
-					barGroups.mana:Hide()
-				end
-			end
-
-			-- Track if any bar is showing
-			snapshotData.attributes.isTracking = showPrimary or showSecondary or showHealth or showMana
-			if snapshotData.attributes.isTracking then
-				TRB.Functions.BarText:Show(sharedSettings)
-			else
-				TRB.Functions.BarText:Hide(sharedSettings)
-			end
+			local context = TRB.Classes.BarVisibilityContext:NewFromGameState(force, sharedSettings)
+			TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData, sharedSettings)
 		else
-			if barGroups and barGroups.primary then
-				barGroups.primary:Hide()
-			end
-			if barGroups and barGroups.secondary then
-				barGroups.secondary:Hide()
-			end
-			if barGroups and barGroups.health then
-				barGroups.health:Hide()
-			end
-			if barGroups and barGroups.mana then
-				barGroups.mana:Hide()
-			end
-			TRB.Functions.BarText:Hide(sharedSettings)
-			snapshotData.attributes.isTracking = false
+			TRB.Functions.BarVisibility:HideAllEntries(entries, snapshotData, nil)
 		end
 	else
-		if barGroups and barGroups.primary then
-			barGroups.primary:Hide()
-		end
-		if barGroups and barGroups.secondary then
-			barGroups.secondary:Hide()
-		end
-		if barGroups and barGroups.health then
-			barGroups.health:Hide()
-		end
-		if barGroups and barGroups.mana then
-			barGroups.mana:Hide()
-		end
-		snapshotData.attributes.isTracking = false
+		TRB.Functions.BarVisibility:HideAllBarGroups(snapshotData)
 	end
 end
 

--- a/ClassModules/Evoker.lua
+++ b/ClassModules/Evoker.lua
@@ -1264,106 +1264,20 @@ function TRB.Functions.Class:HideResourceBar(force)
 			sharedSettings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 		end
 
+		local entries = {
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.primary, sharedSettings and sharedSettings.displayBar.primary, true, nil, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.secondary, sharedSettings and sharedSettings.displayBar.secondary, true, TRB.Data.character.maxResource2, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.health, sharedSettings and sharedSettings.displayBar.health, true, 1, nil),
+		}
+
 		if sharedSettings ~= nil then
-			local affectingCombat = TRB.Data.character.inCombat
-			local inVehicle = UnitInVehicle("player")
-			local forceHideAll = not TRB.Data.specSupported or force or (TRB.Data.character.advancedFlight and not sharedSettings.displayBar.dragonriding)
-
-			-- Determine primary bar visibility independently
-			local showPrimary = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.primary.visibility == "always" then
-					showPrimary = true
-				elseif sharedSettings.displayBar.primary.visibility == "combat" then
-					showPrimary = affectingCombat or inVehicle
-				end
-				-- "never" means showPrimary stays false
-			end
-
-			-- Determine secondary bar visibility independently
-			-- All Evoker specs use the secondary (Essence) bar
-			local showSecondary = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.secondary.visibility == "always" then
-					showSecondary = true
-				elseif sharedSettings.displayBar.secondary.visibility == "combat" then
-					showSecondary = affectingCombat or inVehicle
-				end
-				-- "never" means showSecondary stays false
-			end
-
-			-- Determine health bar visibility independently
-			local showHealth = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.health.visibility == "always" then
-					showHealth = true
-				elseif sharedSettings.displayBar.health.visibility == "combat" then
-					showHealth = affectingCombat or inVehicle
-				end
-				-- "never" means showHealth stays false
-			end
-
-			-- Apply primary bar visibility
-			if barGroups and barGroups.primary then
-				if showPrimary then
-					barGroups.primary:Show()
-				else
-					barGroups.primary:Hide()
-				end
-			end
-
-			-- Apply secondary bar visibility
-			if barGroups and barGroups.secondary then
-				if showSecondary then
-					barGroups.secondary:Show()
-					barGroups.secondary:ShowNodes(TRB.Data.character.maxResource2)
-				else
-					barGroups.secondary:Hide()
-				end
-			end
-
-			-- Apply health bar visibility
-			if barGroups and barGroups.health then
-				if showHealth then
-					barGroups.health:Show()
-					barGroups.health:ShowNodes(1)
-				else
-					barGroups.health:Hide()
-				end
-			end
-
-			-- Track if either bar is showing
-			snapshotData.attributes.isTracking = showPrimary or showSecondary or showHealth
-			if snapshotData.attributes.isTracking then
-				TRB.Functions.BarText:Show(sharedSettings)
-			else
-				TRB.Functions.BarText:Hide(sharedSettings)
-			end
+			local context = TRB.Classes.BarVisibilityContext:NewFromGameState(force, sharedSettings)
+			TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData, sharedSettings)
 		else
-			-- No settings - hide everything
-			if barGroups and barGroups.primary then
-				barGroups.primary:Hide()
-			end
-			if barGroups and barGroups.secondary then
-				barGroups.secondary:Hide()
-			end
-			if barGroups and barGroups.health then
-				barGroups.health:Hide()
-			end
-			snapshotData.attributes.isTracking = false
+			TRB.Functions.BarVisibility:HideAllEntries(entries, snapshotData, nil)
 		end
 	else
-		-- Unsupported spec - hide everything
-		if barGroups and barGroups.primary then
-			barGroups.primary:Hide()
-		end
-		if barGroups and barGroups.secondary then
-			barGroups.secondary:Hide()
-		end
-		if barGroups and barGroups.health then
-			barGroups.health:Hide()
-		end
-		snapshotData.attributes.isTracking = false
+		TRB.Functions.BarVisibility:HideAllBarGroups(snapshotData)
 	end
 end
 

--- a/ClassModules/Hunter.lua
+++ b/ClassModules/Hunter.lua
@@ -1649,99 +1649,23 @@ function TRB.Functions.Class:HideResourceBar(force)
 			sharedSettings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 		end
 
+		-- Only Survival (3) uses the secondary (Tip of the Spear) bar, and only if talented
+		local hasSecondary = TRB.Data.character.specId == 3 and (TRB.Data.character.maxResource2 or 0) > 0
+
+		local entries = {
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.primary, sharedSettings and sharedSettings.displayBar.primary, true, nil, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.secondary, sharedSettings and sharedSettings.displayBar.secondary, hasSecondary, TRB.Data.character.maxResource2, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.health, sharedSettings and sharedSettings.displayBar.health, true, 1, nil),
+		}
+
 		if sharedSettings ~= nil then
-			local affectingCombat = TRB.Data.character.inCombat
-			local inVehicle = UnitInVehicle("player")
-			local forceHideAll = not TRB.Data.specSupported or force or (TRB.Data.character.advancedFlight and not sharedSettings.displayBar.dragonriding)
-
-			-- Determine primary bar visibility independently
-			local showPrimary = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.primary.visibility == "always" then
-					showPrimary = true
-				elseif sharedSettings.displayBar.primary.visibility == "combat" then
-					showPrimary = affectingCombat or inVehicle
-				end
-				-- "never" means showPrimary stays false
-			end
-
-			-- Determine secondary bar visibility independently
-			-- Only Survival (specId == 3) uses the secondary (Tip of the Spear) bar
-			local showSecondary = false
-			if not forceHideAll and TRB.Data.character.specId == 3 and (TRB.Data.character.maxResource2 or 0) > 0 then
-				if sharedSettings.displayBar.secondary.visibility == "always" then
-					showSecondary = true
-				elseif sharedSettings.displayBar.secondary.visibility == "combat" then
-					showSecondary = affectingCombat or inVehicle
-				end
-				-- "never" means showSecondary stays false
-			end
-
-			-- Determine health bar visibility independently
-			local showHealth = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.health.visibility == "always" then
-					showHealth = true
-				elseif sharedSettings.displayBar.health.visibility == "combat" then
-					showHealth = affectingCombat or inVehicle
-				end
-				-- "never" means showHealth stays false
-			end
-
-			-- Apply primary bar visibility
-			if barGroups and barGroups.primary then
-				if showPrimary then
-					barGroups.primary:Show()
-				else
-					barGroups.primary:Hide()
-				end
-			end
-
-			-- Apply secondary bar visibility
-			if barGroups and barGroups.secondary then
-				if showSecondary then
-					barGroups.secondary:Show()
-					barGroups.secondary:ShowNodes(TRB.Data.character.maxResource2)
-				else
-					barGroups.secondary:Hide()
-				end
-			end
-
-			-- Apply health bar visibility
-			if barGroups and barGroups.health then
-				if showHealth then
-					barGroups.health:Show()
-					barGroups.health:ShowNodes(1)
-				else
-					barGroups.health:Hide()
-				end
-			end
-
-			-- Track if the bar is showing
-			snapshotData.attributes.isTracking = showPrimary or showSecondary or showHealth
-			if snapshotData.attributes.isTracking then
-				TRB.Functions.BarText:Show(sharedSettings)
-			else
-				TRB.Functions.BarText:Hide(sharedSettings)
-			end
+			local context = TRB.Classes.BarVisibilityContext:NewFromGameState(force, sharedSettings)
+			TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData, sharedSettings)
 		else
-			if barGroups and barGroups.primary then
-				barGroups.primary:Hide()
-			end
-			if barGroups and barGroups.health then
-				barGroups.health:Hide()
-			end
-			TRB.Functions.BarText:Hide(sharedSettings)
-			snapshotData.attributes.isTracking = false
+			TRB.Functions.BarVisibility:HideAllEntries(entries, snapshotData, nil)
 		end
 	else
-		if barGroups and barGroups.primary then
-			barGroups.primary:Hide()
-		end
-		if barGroups and barGroups.health then
-			barGroups.health:Hide()
-		end
-		snapshotData.attributes.isTracking = false
+		TRB.Functions.BarVisibility:HideAllBarGroups(snapshotData)
 	end
 end
 

--- a/ClassModules/Mage.lua
+++ b/ClassModules/Mage.lua
@@ -1181,108 +1181,23 @@ function TRB.Functions.Class:HideResourceBar(force)
 			sharedSettings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 		end
 
+		-- Arcane (1) always has Arcane Charges; Frost (3) has Icicles only if talented (maxResource2 > 0)
+		local hasSecondary = TRB.Data.character.specId == 1 or (TRB.Data.character.specId == 3 and (TRB.Data.character.maxResource2 or 0) > 0)
+
+		local entries = {
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.primary, sharedSettings and sharedSettings.displayBar.primary, true, nil, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.secondary, sharedSettings and sharedSettings.displayBar.secondary, hasSecondary, TRB.Data.character.maxResource2, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.health, sharedSettings and sharedSettings.displayBar.health, true, 1, nil),
+		}
+
 		if sharedSettings ~= nil then
-			local affectingCombat = TRB.Data.character.inCombat
-			local inVehicle = UnitInVehicle("player")
-			local forceHideAll = not TRB.Data.specSupported or force or (TRB.Data.character.advancedFlight and not sharedSettings.displayBar.dragonriding)
-
-			-- Determine primary bar visibility independently
-			local showPrimary = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.primary.visibility == "always" then
-					showPrimary = true
-				elseif sharedSettings.displayBar.primary.visibility == "combat" then
-					showPrimary = affectingCombat or inVehicle
-				end
-				-- "never" means showPrimary stays false
-			end
-
-			-- Determine secondary bar visibility independently
-			-- Arcane (specId == 1) uses Arcane Charges bar; Frost (specId == 3) uses Icicles bar
-			-- If maxResource2 == 0 (Icicles not talented), treat as "never"
-			local showSecondary = false
-			if not forceHideAll and (TRB.Data.character.specId == 1 or (TRB.Data.character.specId == 3 and (TRB.Data.character.maxResource2 or 0) > 0)) then
-				if sharedSettings.displayBar.secondary.visibility == "always" then
-					showSecondary = true
-				elseif sharedSettings.displayBar.secondary.visibility == "combat" then
-					showSecondary = affectingCombat or inVehicle
-				end
-				-- "never" means showSecondary stays false
-			end
-
-			-- Determine health bar visibility independently
-			local showHealth = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.health.visibility == "always" then
-					showHealth = true
-				elseif sharedSettings.displayBar.health.visibility == "combat" then
-					showHealth = affectingCombat or inVehicle
-				end
-				-- "never" means showHealth stays false
-			end
-
-			-- Apply primary bar visibility
-			if barGroups and barGroups.primary then
-				if showPrimary then
-					barGroups.primary:Show()
-				else
-					barGroups.primary:Hide()
-				end
-			end
-
-			-- Apply secondary bar visibility
-			if barGroups and barGroups.secondary then
-				if showSecondary then
-					barGroups.secondary:Show()
-					barGroups.secondary:ShowNodes(TRB.Data.character.maxResource2)
-				else
-					barGroups.secondary:Hide()
-				end
-			end
-
-			-- Apply health bar visibility
-			if barGroups and barGroups.health then
-				if showHealth then
-					barGroups.health:Show()
-					barGroups.health:ShowNodes(1)
-				else
-					barGroups.health:Hide()
-				end
-			end
-
-			-- Track if either bar is showing
-			snapshotData.attributes.isTracking = showPrimary or showSecondary or showHealth
-			if snapshotData.attributes.isTracking then
-				TRB.Functions.BarText:Show(sharedSettings)
-			else
-				TRB.Functions.BarText:Hide(sharedSettings)
-			end
+			local context = TRB.Classes.BarVisibilityContext:NewFromGameState(force, sharedSettings)
+			TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData, sharedSettings)
 		else
-			-- No settings - hide everything
-			if barGroups and barGroups.primary then
-				barGroups.primary:Hide()
-			end
-			if barGroups and barGroups.secondary then
-				barGroups.secondary:Hide()
-			end
-			if barGroups and barGroups.health then
-				barGroups.health:Hide()
-			end
-			TRB.Functions.BarText:Hide(sharedSettings)
-			snapshotData.attributes.isTracking = false
+			TRB.Functions.BarVisibility:HideAllEntries(entries, snapshotData, nil)
 		end
 	else
-		-- Unsupported spec - hide everything
-		if barGroups and barGroups.primary then
-			barGroups.primary:Hide()
-		end
-		if barGroups and barGroups.secondary then
-			barGroups.secondary:Hide()
-		end
-		if barGroups and barGroups.health then
-			barGroups.health:Hide()
-		end
-		snapshotData.attributes.isTracking = false
+		TRB.Functions.BarVisibility:HideAllBarGroups(snapshotData)
 	end
 end
 

--- a/ClassModules/Monk.lua
+++ b/ClassModules/Monk.lua
@@ -1841,132 +1841,25 @@ function TRB.Functions.Class:HideResourceBar(force)
 			sharedSettings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 		end
 
+		-- Brewmaster (1) uses the stagger bar; Windwalker (3) uses the secondary (Chi) bar
+		local hasStagger = TRB.Data.character.specId == 1
+		local hasChi = TRB.Data.character.specId == 3
+
+		local entries = {
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.primary, sharedSettings and sharedSettings.displayBar.primary, true, nil, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.stagger, sharedSettings and sharedSettings.displayBar.stagger, hasStagger, 1, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.secondary, sharedSettings and sharedSettings.displayBar.secondary, hasChi, TRB.Data.character.maxResource2, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.health, sharedSettings and sharedSettings.displayBar.health, true, 1, nil),
+		}
+
 		if sharedSettings ~= nil then
-			local affectingCombat = TRB.Data.character.inCombat
-			local inVehicle = UnitInVehicle("player")
-			local forceHideAll = not TRB.Data.specSupported or force or (TRB.Data.character.advancedFlight and not sharedSettings.displayBar.dragonriding)
-
-			-- Determine primary bar visibility independently
-			local showPrimary = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.primary.visibility == "always" then
-					showPrimary = true
-				elseif sharedSettings.displayBar.primary.visibility == "combat" then
-					showPrimary = affectingCombat or inVehicle
-				end
-				-- "never" means showPrimary stays false
-			end
-
-			-- Determine stagger bar visibility (Brewmaster only)
-			local showStagger = false
-			if not forceHideAll and TRB.Data.character.specId == 1 then
-				local staggerVisibility = sharedSettings.displayBar.stagger.visibility
-				if staggerVisibility == "always" then
-					showStagger = true
-				elseif staggerVisibility == "combat" then
-					showStagger = affectingCombat or inVehicle
-				end
-				-- "never" means showStagger stays false
-			end
-
-			-- Determine secondary bar visibility (Windwalker Chi only)
-			local showSecondary = false
-			if not forceHideAll and TRB.Data.character.specId == 3 then
-				if sharedSettings.displayBar.secondary.visibility == "always" then
-					showSecondary = true
-				elseif sharedSettings.displayBar.secondary.visibility == "combat" then
-					showSecondary = affectingCombat or inVehicle
-				end
-				-- "never" means showSecondary stays false
-			end
-
-			-- Determine health bar visibility independently
-			local showHealth = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.health.visibility == "always" then
-					showHealth = true
-				elseif sharedSettings.displayBar.health.visibility == "combat" then
-					showHealth = affectingCombat or inVehicle
-				end
-				-- "never" means showHealth stays false
-			end
-
-			-- Apply primary bar visibility
-			if barGroups and barGroups.primary then
-				if showPrimary then
-					barGroups.primary:Show()
-				else
-					barGroups.primary:Hide()
-				end
-			end
-
-			-- Apply stagger bar visibility (Brewmaster only)
-			if barGroups and barGroups.stagger then
-				if showStagger then
-					barGroups.stagger:Show()
-					barGroups.stagger:ShowNodes(1)
-				else
-					barGroups.stagger:Hide()
-				end
-			end
-
-			-- Apply secondary bar visibility (Windwalker Chi)
-			if barGroups and barGroups.secondary then
-				if showSecondary then
-					barGroups.secondary:Show()
-					barGroups.secondary:ShowNodes(TRB.Data.character.maxResource2)
-				else
-					barGroups.secondary:Hide()
-				end
-			end
-
-			-- Apply health bar visibility
-			if barGroups and barGroups.health then
-				if showHealth then
-					barGroups.health:Show()
-					barGroups.health:ShowNodes(1)
-				else
-					barGroups.health:Hide()
-				end
-			end
-
-			-- Track if any bar is showing
-			snapshotData.attributes.isTracking = showPrimary or showStagger or showSecondary or showHealth
-			if snapshotData.attributes.isTracking then
-				TRB.Functions.BarText:Show(sharedSettings)
-			else
-				TRB.Functions.BarText:Hide(sharedSettings)
-			end
+			local context = TRB.Classes.BarVisibilityContext:NewFromGameState(force, sharedSettings)
+			TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData, sharedSettings)
 		else
-			if barGroups and barGroups.primary then
-				barGroups.primary:Hide()
-			end
-			if barGroups and barGroups.stagger then
-				barGroups.stagger:Hide()
-			end
-			if barGroups and barGroups.secondary then
-				barGroups.secondary:Hide()
-			end
-			if barGroups and barGroups.health then
-				barGroups.health:Hide()
-			end
-			TRB.Functions.BarText:Hide(sharedSettings)
-			snapshotData.attributes.isTracking = false
+			TRB.Functions.BarVisibility:HideAllEntries(entries, snapshotData, nil)
 		end
 	else
-		if barGroups and barGroups.primary then
-			barGroups.primary:Hide()
-		end
-		if barGroups and barGroups.stagger then
-			barGroups.stagger:Hide()
-		end
-		if barGroups and barGroups.secondary then
-			barGroups.secondary:Hide()
-		end
-		if barGroups and barGroups.health then
-			barGroups.health:Hide()
-		end
-		snapshotData.attributes.isTracking = false
+		TRB.Functions.BarVisibility:HideAllBarGroups(snapshotData)
 	end
 end
 

--- a/ClassModules/Paladin.lua
+++ b/ClassModules/Paladin.lua
@@ -1146,105 +1146,20 @@ function TRB.Functions.Class:HideResourceBar(force)
 			sharedSettings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 		end
 
+		local entries = {
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.primary, sharedSettings and sharedSettings.displayBar.primary, true, nil, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.secondary, sharedSettings and sharedSettings.displayBar.secondary, true, TRB.Data.character.maxResource2, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.health, sharedSettings and sharedSettings.displayBar.health, true, 1, nil),
+		}
+
 		if sharedSettings ~= nil then
-			local affectingCombat = TRB.Data.character.inCombat
-			local inVehicle = UnitInVehicle("player")
-			local forceHideAll = not TRB.Data.specSupported or force or (TRB.Data.character.advancedFlight and not sharedSettings.displayBar.dragonriding)
-
-			-- Determine primary bar visibility independently
-			local showPrimary = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.primary.visibility == "always" then
-					showPrimary = true
-				elseif sharedSettings.displayBar.primary.visibility == "combat" then
-					showPrimary = affectingCombat or inVehicle
-				end
-				-- "never" means showPrimary stays false
-			end
-
-			-- Determine secondary bar visibility independently
-			-- All Paladin specs use the secondary (Holy Power) bar
-			local showSecondary = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.secondary.visibility == "always" then
-					showSecondary = true
-				elseif sharedSettings.displayBar.secondary.visibility == "combat" then
-					showSecondary = affectingCombat or inVehicle
-				end
-				-- "never" means showSecondary stays false
-			end
-
-			-- Determine health bar visibility independently
-			local showHealth = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.health.visibility == "always" then
-					showHealth = true
-				elseif sharedSettings.displayBar.health.visibility == "combat" then
-					showHealth = affectingCombat or inVehicle
-				end
-				-- "never" means showHealth stays false
-			end
-
-			-- Apply primary bar visibility
-			if barGroups and barGroups.primary then
-				if showPrimary then
-					barGroups.primary:Show()
-				else
-					barGroups.primary:Hide()
-				end
-			end
-
-			-- Apply secondary bar visibility
-			if barGroups and barGroups.secondary then
-				if showSecondary then
-					barGroups.secondary:Show()
-					barGroups.secondary:ShowNodes(TRB.Data.character.maxResource2)
-				else
-					barGroups.secondary:Hide()
-				end
-			end
-
-			-- Apply health bar visibility
-			if barGroups and barGroups.health then
-				if showHealth then
-					barGroups.health:Show()
-					barGroups.health:ShowNodes(1)
-				else
-					barGroups.health:Hide()
-				end
-			end
-
-			-- Track if any bar is showing
-			snapshotData.attributes.isTracking = showPrimary or showSecondary or showHealth
-			if snapshotData.attributes.isTracking then
-				TRB.Functions.BarText:Show(sharedSettings)
-			else
-				TRB.Functions.BarText:Hide(sharedSettings)
-			end
+			local context = TRB.Classes.BarVisibilityContext:NewFromGameState(force, sharedSettings)
+			TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData, sharedSettings)
 		else
-			if barGroups and barGroups.primary then
-				barGroups.primary:Hide()
-			end
-			if barGroups and barGroups.secondary then
-				barGroups.secondary:Hide()
-			end
-			if barGroups and barGroups.health then
-				barGroups.health:Hide()
-			end
-			TRB.Functions.BarText:Hide(sharedSettings)
-			snapshotData.attributes.isTracking = false
+			TRB.Functions.BarVisibility:HideAllEntries(entries, snapshotData, nil)
 		end
 	else
-		if barGroups and barGroups.primary then
-			barGroups.primary:Hide()
-		end
-		if barGroups and barGroups.secondary then
-			barGroups.secondary:Hide()
-		end
-		if barGroups and barGroups.health then
-			barGroups.health:Hide()
-		end
-		snapshotData.attributes.isTracking = false
+		TRB.Functions.BarVisibility:HideAllBarGroups(snapshotData)
 	end
 end
 

--- a/ClassModules/Priest.lua
+++ b/ClassModules/Priest.lua
@@ -2764,170 +2764,48 @@ function TRB.Functions.Class:HideResourceBar(force)
 			sharedSettings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 		end
 
+		-- Secondary (Power Words / Holy Words): Discipline (1) and Holy (2) only, gated on maxResource2 > 0
+		local hasSecondary = (TRB.Data.character.specId == 1 or TRB.Data.character.specId == 2)
+			and (TRB.Data.character.maxResource2 or 0) > 0
+		local secondaryVisSettings = (sharedSettings and sharedSettings.displayBar.secondary) or nil
+
+		-- Mana bar: Shadow (3) only
+		local hasMana = TRB.Data.character.specId == 3
+		local manaVisSettings = (sharedSettings and sharedSettings.displayBar.mana) or nil
+
+		-- Utility bar (Angelic Feather): all specs, talent-gated
+		local spells = nil --[[@as TRB.Classes.Priest.HealerSpells|TRB.Classes.Priest.ShadowSpells|nil]]
+		if TRB.Data.spellsData and TRB.Data.spellsData.spells then
+			spells = TRB.Data.spellsData.spells
+		end
+
+		local hasUtility = false
+		local utilityNodes = nil
+		if sharedSettings and sharedSettings.displayBar.utility ~= nil and spells then
+			local specTalents = TRB.Data.specCache[TRB.Data.character.compositeKey] and TRB.Data.specCache[TRB.Data.character.compositeKey].talents
+			if specTalents and specTalents:IsTalentActive(spells.angelicFeather) then
+				hasUtility = true
+				utilityNodes = spells.angelicFeather.attributes.maxCharges
+			end
+		end
+		local utilityVisSettings = (sharedSettings and sharedSettings.displayBar.utility) or nil
+
+		local entries = {
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.primary, sharedSettings and sharedSettings.displayBar.primary, true, nil, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.secondary, secondaryVisSettings, hasSecondary, TRB.Data.character.maxResource2 or 0, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.health, sharedSettings and sharedSettings.displayBar.health, true, 1, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.mana, manaVisSettings, hasMana, 1, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.utility, utilityVisSettings, hasUtility, utilityNodes, nil),
+		}
+
 		if sharedSettings ~= nil then
-			local affectingCombat = TRB.Data.character.inCombat
-			local inVehicle = UnitInVehicle("player")
-			local forceHideAll = not TRB.Data.specSupported or force or (TRB.Data.character.advancedFlight and not sharedSettings.displayBar.dragonriding)
-
-			-- Determine primary bar visibility independently
-			local showPrimary = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.primary.visibility == "always" then
-					showPrimary = true
-				elseif sharedSettings.displayBar.primary.visibility == "combat" then
-					showPrimary = affectingCombat or inVehicle
-				end
-				-- "never" means showPrimary stays false
-			end
-
-			-- Determine secondary bar visibility (Discipline Power Words / Holy Words)
-			-- If all enables are unchecked (maxResource2 == 0), treat as "never"
-			local showSecondary = false
-			if (TRB.Data.character.specId == 1 or TRB.Data.character.specId == 2) and not forceHideAll and sharedSettings.displayBar.secondary ~= nil
-				and (TRB.Data.character.maxResource2 or 0) > 0 then
-				if sharedSettings.displayBar.secondary.visibility == "always" then
-					showSecondary = true
-				elseif sharedSettings.displayBar.secondary.visibility == "combat" then
-					showSecondary = affectingCombat or inVehicle
-				end
-				-- "never" means showSecondary stays false
-			end
-
-			-- Determine health bar visibility independently
-			local showHealth = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.health.visibility == "always" then
-					showHealth = true
-				elseif sharedSettings.displayBar.health.visibility == "combat" then
-					showHealth = affectingCombat or inVehicle
-				end
-				-- "never" means showHealth stays false
-			end
-
-			-- Determine mana bar visibility independently (Shadow only)
-			local showMana = false
-			if TRB.Data.character.specId == 3 and not forceHideAll and sharedSettings.displayBar.mana ~= nil then
-				if sharedSettings.displayBar.mana.visibility == "always" then
-					showMana = true
-				elseif sharedSettings.displayBar.mana.visibility == "combat" then
-					showMana = affectingCombat or inVehicle
-				end
-				-- "never" means showMana stays false
-			end
-			
-			local spells = nil --[[@as TRB.Classes.Priest.HealerSpells|TRB.Classes.Priest.ShadowSpells|nil]]
-
-			if TRB.Data.spellsData and TRB.Data.spellsData.spells then
-				spells = TRB.Data.spellsData.spells
-			end
-
-			-- Determine utility bar visibility (all specs, talent-gated)
-			local showUtility = false
-			if not forceHideAll and sharedSettings.displayBar.utility ~= nil then
-				local specTalents = TRB.Data.specCache[TRB.Data.character.compositeKey] and TRB.Data.specCache[TRB.Data.character.compositeKey].talents
-				if specTalents and spells and specTalents:IsTalentActive(spells.angelicFeather) then
-					if sharedSettings.displayBar.utility.visibility == "always" then
-						showUtility = true
-					elseif sharedSettings.displayBar.utility.visibility == "combat" then
-						showUtility = affectingCombat or inVehicle
-					end
-					-- "never" means showUtility stays false
-				end
-			end
-
-			-- Apply primary bar visibility
-			if barGroups and barGroups.primary then
-				if showPrimary then
-					barGroups.primary:Show()
-				else
-					barGroups.primary:Hide()
-				end
-			end
-
-			-- Apply secondary (Holy Words) bar visibility (Holy only)
-			if barGroups and barGroups.secondary then
-				if showSecondary then
-					barGroups.secondary:Show()
-					barGroups.secondary:ShowNodes(TRB.Data.character.maxResource2 or 0)
-				else
-					barGroups.secondary:Hide()
-				end
-			end
-
-			-- Apply health bar visibility
-			if barGroups and barGroups.health then
-				if showHealth then
-					barGroups.health:Show()
-					barGroups.health:ShowNodes(1)
-				else
-					barGroups.health:Hide()
-				end
-			end
-
-			-- Apply mana bar visibility (Shadow only)
-			if barGroups and barGroups.mana then
-				if showMana then
-					barGroups.mana:Show()
-					barGroups.mana:ShowNodes(1)
-				else
-					barGroups.mana:Hide()
-				end
-			end
-
-			-- Apply utility bar visibility (all specs)
-			if barGroups and barGroups.utility then
-				if showUtility then
-					barGroups.utility:Show()
-					barGroups.utility:ShowNodes(spells.angelicFeather.attributes.maxCharges)
-				else
-					barGroups.utility:Hide()
-				end
-			end
-
-			-- Track if the bar is showing
-			snapshotData.attributes.isTracking = showPrimary or showSecondary or showHealth or showMana or showUtility
-			if snapshotData.attributes.isTracking then
-				TRB.Functions.BarText:Show(sharedSettings)
-			else
-				TRB.Functions.BarText:Hide(sharedSettings)
-			end
+			local context = TRB.Classes.BarVisibilityContext:NewFromGameState(force, sharedSettings)
+			TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData, sharedSettings)
 		else
-			-- No settings - hide everything
-			if barGroups and barGroups.primary then
-				barGroups.primary:Hide()
-			end
-			if barGroups and barGroups.secondary then
-				barGroups.secondary:Hide()
-			end
-			if barGroups and barGroups.health then
-				barGroups.health:Hide()
-			end
-			if barGroups and barGroups.mana then
-				barGroups.mana:Hide()
-			end
-			if barGroups and barGroups.utility then
-				barGroups.utility:Hide()
-			end
-			snapshotData.attributes.isTracking = false
+			TRB.Functions.BarVisibility:HideAllEntries(entries, snapshotData, nil)
 		end
 	else
-		-- Unsupported spec - hide everything
-		if barGroups and barGroups.primary then
-			barGroups.primary:Hide()
-		end
-		if barGroups and barGroups.secondary then
-			barGroups.secondary:Hide()
-		end
-		if barGroups and barGroups.health then
-			barGroups.health:Hide()
-		end
-		if barGroups and barGroups.mana then
-			barGroups.mana:Hide()
-		end
-		if barGroups and barGroups.utility then
-			barGroups.utility:Hide()
-		end
-		snapshotData.attributes.isTracking = false
+		TRB.Functions.BarVisibility:HideAllBarGroups(snapshotData)
 	end
 end
 

--- a/ClassModules/Rogue.lua
+++ b/ClassModules/Rogue.lua
@@ -2183,106 +2183,22 @@ function TRB.Functions.Class:HideResourceBar(force)
 			sharedSettings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 		end
 
+		local healthVisSettings = sharedSettings and sharedSettings.displayBar.health or nil
+
+		local entries = {
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.primary, sharedSettings and sharedSettings.displayBar.primary, true, nil, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.secondary, sharedSettings and sharedSettings.displayBar.secondary, true, TRB.Data.character.maxResource2, TRB.Data.character.maxResource2),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.health, healthVisSettings, true, 1, nil),
+		}
+
 		if sharedSettings ~= nil then
-			local affectingCombat = TRB.Data.character.inCombat
-			local inVehicle = UnitInVehicle("player")
-			local forceHideAll = not TRB.Data.specSupported or force or (TRB.Data.character.advancedFlight and not sharedSettings.displayBar.dragonriding)
-
-			-- Determine primary bar visibility independently
-			local showPrimary = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.primary.visibility == "always" then
-					showPrimary = true
-				elseif sharedSettings.displayBar.primary.visibility == "combat" then
-					showPrimary = affectingCombat or inVehicle
-				end
-				-- "never" means showPrimary stays false
-			end
-
-			-- Determine secondary bar visibility independently
-			-- All Rogue specs use the secondary (Combo Points) bar
-			local showSecondary = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.secondary.visibility == "always" then
-					showSecondary = true
-				elseif sharedSettings.displayBar.secondary.visibility == "combat" then
-					showSecondary = affectingCombat or inVehicle
-				end
-				-- "never" means showSecondary stays false
-			end
-
-			-- Apply primary bar visibility
-			if barGroups and barGroups.primary then
-				if showPrimary then
-					barGroups.primary:Show()
-				else
-					barGroups.primary:Hide()
-				end
-			end
-
-			-- Apply secondary bar visibility
-			if barGroups and barGroups.secondary then
-				if showSecondary then
-					barGroups.secondary:SetMaxNodes(TRB.Data.character.maxResource2)
-					barGroups.secondary:Show()
-					barGroups.secondary:ShowNodes(TRB.Data.character.maxResource2)
-				else
-					barGroups.secondary:Hide()
-				end
-			end
-
-			-- Determine health bar visibility independently
-			local showHealth = false
-			if not forceHideAll and sharedSettings.displayBar.health ~= nil then
-				if sharedSettings.displayBar.health.visibility == "always" then
-					showHealth = true
-				elseif sharedSettings.displayBar.health.visibility == "combat" then
-					showHealth = affectingCombat or inVehicle
-				end
-				-- "never" means showHealth stays false
-			end
-
-			-- Apply health bar visibility
-			if barGroups and barGroups.health then
-				if showHealth then
-					barGroups.health:Show()
-				else
-					barGroups.health:Hide()
-				end
-			end
-
-			-- Track if any bar is showing
-			snapshotData.attributes.isTracking = showPrimary or showSecondary or showHealth
-			if snapshotData.attributes.isTracking then
-				TRB.Functions.BarText:Show(sharedSettings)
-			else
-				TRB.Functions.BarText:Hide(sharedSettings)
-			end
+			local context = TRB.Classes.BarVisibilityContext:NewFromGameState(force, sharedSettings)
+			TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData, sharedSettings)
 		else
-			-- No settings - hide everything
-			if barGroups and barGroups.primary then
-				barGroups.primary:Hide()
-			end
-			if barGroups and barGroups.secondary then
-				barGroups.secondary:Hide()
-			end
-			if barGroups and barGroups.health then
-				barGroups.health:Hide()
-			end
-			snapshotData.attributes.isTracking = false
+			TRB.Functions.BarVisibility:HideAllEntries(entries, snapshotData, nil)
 		end
 	else
-		-- Unsupported spec - hide everything
-		if barGroups and barGroups.primary then
-			barGroups.primary:Hide()
-		end
-		if barGroups and barGroups.secondary then
-			barGroups.secondary:Hide()
-		end
-		if barGroups and barGroups.health then
-			barGroups.health:Hide()
-		end
-		snapshotData.attributes.isTracking = false
+		TRB.Functions.BarVisibility:HideAllBarGroups(snapshotData)
 	end
 end
 

--- a/ClassModules/Shaman.lua
+++ b/ClassModules/Shaman.lua
@@ -1552,136 +1552,37 @@ function TRB.Functions.Class:HideResourceBar(force)
 			sharedSettings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 		end
 
+		-- Enhancement (2) uses the secondary (Maelstrom Weapon) bar
+		local hasSecondary = TRB.Data.character.specId == 2
+		local secondaryNodes = nil
+		if hasSecondary then
+			local maxStacks = TRB.Data.character.maxResource2 or 10
+			secondaryNodes = maxStacks
+			if sharedSettings and sharedSettings.colors and sharedSettings.colors.comboPoints and sharedSettings.colors.comboPoints.compressedView then
+				secondaryNodes = math.ceil(maxStacks / 2)
+			end
+		end
+
+		-- Elemental (1) uses the mana bar
+		local hasMana = TRB.Data.character.specId == 1
+		local manaVisSettings = (sharedSettings and sharedSettings.displayBar.mana) or nil
+		local healthVisSettings = (sharedSettings and sharedSettings.displayBar.health) or nil
+
+		local entries = {
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.primary, sharedSettings and sharedSettings.displayBar.primary, true, nil, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.secondary, sharedSettings and sharedSettings.displayBar.secondary, hasSecondary, secondaryNodes, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.health, healthVisSettings, true, 1, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.mana, manaVisSettings, hasMana, 1, nil),
+		}
+
 		if sharedSettings ~= nil then
-			local affectingCombat = TRB.Data.character.inCombat
-			local inVehicle = UnitInVehicle("player")
-			local forceHideAll = not TRB.Data.specSupported or force or (TRB.Data.character.advancedFlight and not sharedSettings.displayBar.dragonriding)
-
-			-- Determine primary bar visibility independently
-			local showPrimary = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.primary.visibility == "always" then
-					showPrimary = true
-				elseif sharedSettings.displayBar.primary.visibility == "combat" then
-					showPrimary = affectingCombat or inVehicle
-				end
-				-- "never" means showPrimary stays false
-			end
-
-			-- Determine secondary bar visibility independently
-			-- Only Enhancement (specId == 2) uses the secondary (Maelstrom Weapon) bar
-			local showSecondary = false
-			if not forceHideAll and TRB.Data.character.specId == 2 then
-				if sharedSettings.displayBar.secondary.visibility == "always" then
-					showSecondary = true
-				elseif sharedSettings.displayBar.secondary.visibility == "combat" then
-					showSecondary = affectingCombat or inVehicle
-				end
-				-- "never" means showSecondary stays false
-			end
-
-			-- Apply primary bar visibility
-			if barGroups and barGroups.primary then
-				if showPrimary then
-					barGroups.primary:Show()
-				else
-					barGroups.primary:Hide()
-				end
-			end
-
-			-- Apply secondary bar visibility
-			if barGroups and barGroups.secondary then
-				if showSecondary then
-					barGroups.secondary:Show()
-					-- Respect compressed view setting for node count
-					local maxStacks = TRB.Data.character.maxResource2 or 10
-					local displayNodes = maxStacks
-					if sharedSettings.colors and sharedSettings.colors.comboPoints and sharedSettings.colors.comboPoints.compressedView then
-						displayNodes = math.ceil(maxStacks / 2)
-					end
-					barGroups.secondary:ShowNodes(displayNodes)
-				else
-					barGroups.secondary:Hide()
-				end
-			end
-
-			-- Determine health bar visibility independently
-			local showHealth = false
-			if not forceHideAll and sharedSettings.displayBar.health ~= nil then
-				if sharedSettings.displayBar.health.visibility == "always" then
-					showHealth = true
-				elseif sharedSettings.displayBar.health.visibility == "combat" then
-					showHealth = affectingCombat or inVehicle
-				end
-				-- "never" means showHealth stays false
-			end
-
-			-- Apply health bar visibility
-			if barGroups and barGroups.health then
-				if showHealth then
-					barGroups.health:Show()
-				else
-					barGroups.health:Hide()
-				end
-			end
-
-			-- Determine mana bar visibility independently (Elemental only)
-			local showMana = false
-			if not forceHideAll and TRB.Data.character.specId == 1 and sharedSettings.displayBar.mana ~= nil then
-				if sharedSettings.displayBar.mana.visibility == "always" then
-					showMana = true
-				elseif sharedSettings.displayBar.mana.visibility == "combat" then
-					showMana = affectingCombat or inVehicle
-				end
-				-- "never" means showMana stays false
-			end
-
-			-- Apply mana bar visibility
-			if barGroups and barGroups.mana then
-				if showMana then
-					barGroups.mana:Show()
-				else
-					barGroups.mana:Hide()
-				end
-			end
-
-			-- Track if any bar is showing
-			snapshotData.attributes.isTracking = showPrimary or showSecondary or showHealth or showMana
-			if snapshotData.attributes.isTracking then
-				TRB.Functions.BarText:Show(sharedSettings)
-			else
-				TRB.Functions.BarText:Hide(sharedSettings)
-			end
+			local context = TRB.Classes.BarVisibilityContext:NewFromGameState(force, sharedSettings)
+			TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData, sharedSettings)
 		else
-			if barGroups and barGroups.primary then
-				barGroups.primary:Hide()
-			end
-			if barGroups and barGroups.secondary then
-				barGroups.secondary:Hide()
-			end
-			if barGroups and barGroups.health then
-				barGroups.health:Hide()
-			end
-			if barGroups and barGroups.mana then
-				barGroups.mana:Hide()
-			end
-			TRB.Functions.BarText:Hide(sharedSettings)
-			snapshotData.attributes.isTracking = false
+			TRB.Functions.BarVisibility:HideAllEntries(entries, snapshotData, nil)
 		end
 	else
-		if barGroups and barGroups.primary then
-			barGroups.primary:Hide()
-		end
-		if barGroups and barGroups.secondary then
-			barGroups.secondary:Hide()
-		end
-		if barGroups and barGroups.health then
-			barGroups.health:Hide()
-		end
-		if barGroups and barGroups.mana then
-			barGroups.mana:Hide()
-		end
-		snapshotData.attributes.isTracking = false
+		TRB.Functions.BarVisibility:HideAllBarGroups(snapshotData)
 	end
 end
 

--- a/ClassModules/Warlock.lua
+++ b/ClassModules/Warlock.lua
@@ -1155,104 +1155,20 @@ function TRB.Functions.Class:HideResourceBar(force)
 			sharedSettings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 		end
 
+		local entries = {
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.primary, sharedSettings and sharedSettings.displayBar.primary, true, nil, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.secondary, sharedSettings and sharedSettings.displayBar.secondary, true, TRB.Data.character.maxResource2, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.health, sharedSettings and sharedSettings.displayBar.health, true, 1, nil),
+		}
+
 		if sharedSettings ~= nil then
-			local affectingCombat = TRB.Data.character.inCombat
-			local inVehicle = UnitInVehicle("player")
-			local forceHideAll = not TRB.Data.specSupported or force or (TRB.Data.character.advancedFlight and not sharedSettings.displayBar.dragonriding)
-
-			-- Determine primary bar visibility independently
-			local showPrimary = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.primary.visibility == "always" then
-					showPrimary = true
-				elseif sharedSettings.displayBar.primary.visibility == "combat" then
-					showPrimary = affectingCombat or inVehicle
-				end
-				-- "never" means showPrimary stays false
-			end
-
-			-- Determine secondary bar visibility independently
-			-- All Warlock specs use the secondary (Soul Shards) bar
-			local showSecondary = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.secondary.visibility == "always" then
-					showSecondary = true
-				elseif sharedSettings.displayBar.secondary.visibility == "combat" then
-					showSecondary = affectingCombat or inVehicle
-				end
-				-- "never" means showSecondary stays false
-			end
-
-			-- Determine health bar visibility independently
-			local showHealth = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.health.visibility == "always" then
-					showHealth = true
-				elseif sharedSettings.displayBar.health.visibility == "combat" then
-					showHealth = affectingCombat or inVehicle
-				end
-				-- "never" means showHealth stays false
-			end
-
-			-- Apply primary bar visibility
-			if barGroups and barGroups.primary then
-				if showPrimary then
-					barGroups.primary:Show()
-				else
-					barGroups.primary:Hide()
-				end
-			end
-
-			-- Apply secondary bar visibility
-			if barGroups and barGroups.secondary then
-				if showSecondary then
-					barGroups.secondary:Show()
-					barGroups.secondary:ShowNodes(TRB.Data.character.maxResource2)
-				else
-					barGroups.secondary:Hide()
-				end
-			end
-
-			-- Apply health bar visibility
-			if barGroups and barGroups.health then
-				if showHealth then
-					barGroups.health:Show()
-				else
-					barGroups.health:Hide()
-				end
-			end
-
-			-- Track if any bar is showing
-			snapshotData.attributes.isTracking = showPrimary or showSecondary or showHealth
-			if snapshotData.attributes.isTracking then
-				TRB.Functions.BarText:Show(sharedSettings)
-			else
-				TRB.Functions.BarText:Hide(sharedSettings)
-			end
+			local context = TRB.Classes.BarVisibilityContext:NewFromGameState(force, sharedSettings)
+			TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData, sharedSettings)
 		else
-			if barGroups and barGroups.primary then
-				barGroups.primary:Hide()
-			end
-			if barGroups and barGroups.secondary then
-				barGroups.secondary:Hide()
-			end
-			if barGroups and barGroups.health then
-				barGroups.health:Hide()
-			end
-			TRB.Functions.BarText:Hide(sharedSettings)
-			snapshotData.attributes.isTracking = false
+			TRB.Functions.BarVisibility:HideAllEntries(entries, snapshotData, nil)
 		end
 	else
-		if barGroups and barGroups.primary then
-			barGroups.primary:Hide()
-		end
-		if barGroups and barGroups.secondary then
-			barGroups.secondary:Hide()
-		end
-		if barGroups and barGroups.health then
-			barGroups.health:Hide()
-		end
-		snapshotData.attributes.isTracking = false
+		TRB.Functions.BarVisibility:HideAllBarGroups(snapshotData)
 	end
 end
 

--- a/ClassModules/Warrior.lua
+++ b/ClassModules/Warrior.lua
@@ -1673,129 +1673,26 @@ function TRB.Functions.Class:HideResourceBar(force)
 			sharedSettings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 		end
 
+		-- Protection (3) uses the defensives bar; Fury (2) uses the secondary/whirlwind bar (talent-gated)
+		local hasDefensives = TRB.Data.character.specId == 3
+		local hasWhirlwind = TRB.Data.character.specId == 2 and (TRB.Data.character.maxResource2 or 0) > 0
+		local secondaryVisSettings = (sharedSettings and sharedSettings.displayBar.secondary) or nil
+
+		local entries = {
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.primary, sharedSettings and sharedSettings.displayBar.primary, true, nil, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.defensives, sharedSettings and sharedSettings.displayBar.defensives, hasDefensives, TRB.Data.character.maxResource2, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.secondary, secondaryVisSettings, hasWhirlwind, TRB.Data.character.maxResource2 or 0, nil),
+			TRB.Classes.BarVisibilityEntry:New(barGroups and barGroups.health, sharedSettings and sharedSettings.displayBar.health, true, nil, nil),
+		}
+
 		if sharedSettings ~= nil then
-			local affectingCombat = TRB.Data.character.inCombat
-			local inVehicle = UnitInVehicle("player")
-			local forceHideAll = not TRB.Data.specSupported or force or (TRB.Data.character.advancedFlight and not sharedSettings.displayBar.dragonriding)
-
-			-- Determine primary bar visibility independently
-			local showPrimary = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.primary.visibility == "always" then
-					showPrimary = true
-				elseif sharedSettings.displayBar.primary.visibility == "combat" then
-					showPrimary = affectingCombat or inVehicle
-				end
-				-- "never" means showPrimary stays false
-			end
-
-			-- Determine secondary bar visibility independently
-			-- Protection (specId == 3) uses defensives; Fury (specId == 2) uses whirlwind
-			local showSecondary = false
-			if not forceHideAll and TRB.Data.character.specId == 3 then
-				if sharedSettings.displayBar.defensives.visibility == "always" then
-					showSecondary = true
-				elseif sharedSettings.displayBar.defensives.visibility == "combat" then
-					showSecondary = affectingCombat or inVehicle
-				end
-			end
-			-- Whirlwind bar uses secondary bar visibility (always / combat / never)
-			-- If maxResource2 == 0 (Improved Whirlwind not talented), treat as "never"
-			local showWhirlwind = false
-			if not forceHideAll and TRB.Data.character.specId == 2
-				and sharedSettings.displayBar.secondary ~= nil
-				and (TRB.Data.character.maxResource2 or 0) > 0 then
-				if sharedSettings.displayBar.secondary.visibility == "always" then
-					showWhirlwind = true
-				elseif sharedSettings.displayBar.secondary.visibility == "combat" then
-					showWhirlwind = affectingCombat or inVehicle
-				end
-			end
-
-			-- Determine health bar visibility independently
-			local showHealth = false
-			if not forceHideAll then
-				if sharedSettings.displayBar.health.visibility == "always" then
-					showHealth = true
-				elseif sharedSettings.displayBar.health.visibility == "combat" then
-					showHealth = affectingCombat or inVehicle
-				end
-				-- "never" means showHealth stays false
-			end
-
-			-- Apply primary bar visibility
-			if barGroups and barGroups.primary then
-				if showPrimary then
-					barGroups.primary:Show()
-				else
-					barGroups.primary:Hide()
-				end
-			end
-
-			-- Apply secondary bar visibility
-			if barGroups and barGroups.defensives then
-				if showSecondary then
-					barGroups.defensives:Show()
-					barGroups.defensives:ShowNodes(TRB.Data.character.maxResource2)
-				else
-					barGroups.defensives:Hide()
-				end
-			end
-			if barGroups and barGroups.secondary then
-				if showWhirlwind then
-					barGroups.secondary:Show()
-					barGroups.secondary:ShowNodes(TRB.Data.character.maxResource2 or 0)
-				else
-					barGroups.secondary:Hide()
-				end
-			end
-
-			-- Apply health bar visibility
-			if barGroups and barGroups.health then
-				if showHealth then
-					barGroups.health:Show()
-				else
-					barGroups.health:Hide()
-				end
-			end
-
-			-- Track if any bar is showing
-			snapshotData.attributes.isTracking = showPrimary or showSecondary or showWhirlwind or showHealth
-			if snapshotData.attributes.isTracking then
-				TRB.Functions.BarText:Show(sharedSettings)
-			else
-				TRB.Functions.BarText:Hide(sharedSettings)
-			end
+			local context = TRB.Classes.BarVisibilityContext:NewFromGameState(force, sharedSettings)
+			TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData, sharedSettings)
 		else
-			if barGroups and barGroups.primary then
-				barGroups.primary:Hide()
-			end
-			if barGroups and barGroups.defensives then
-				barGroups.defensives:Hide()
-			end
-			if barGroups and barGroups.secondary then
-				barGroups.secondary:Hide()
-			end
-			if barGroups and barGroups.health then
-				barGroups.health:Hide()
-			end
-			TRB.Functions.BarText:Hide(sharedSettings)
-			snapshotData.attributes.isTracking = false
+			TRB.Functions.BarVisibility:HideAllEntries(entries, snapshotData, nil)
 		end
 	else
-		if barGroups and barGroups.primary then
-			barGroups.primary:Hide()
-		end
-		if barGroups and barGroups.defensives then
-			barGroups.defensives:Hide()
-		end
-		if barGroups and barGroups.secondary then
-			barGroups.secondary:Hide()
-		end
-		if barGroups and barGroups.health then
-			barGroups.health:Hide()
-		end
-		snapshotData.attributes.isTracking = false
+		TRB.Functions.BarVisibility:HideAllBarGroups(snapshotData)
 	end
 end
 

--- a/Classes/BarVisibility.lua
+++ b/Classes/BarVisibility.lua
@@ -190,45 +190,42 @@ function TRB.Functions.BarVisibility:HideAllBarGroups(snapshotData)
 end
 
 ---Convenience: Builds entries from barGroups for Edit Mode display.
----Shows all bars except those set to "never". Primary always shows.
+---Shows ALL bars unconditionally so they can be previewed and repositioned.
 ---@param barGroups table # TRB.Frames.barGroups
----@param displayBar table|nil # The displayBar settings table
+---@param displayBar table|nil # The displayBar settings table (unused; kept for API compat)
 ---@param maxResource2 number|nil # Max secondary resource count (for ShowNodes)
 ---@return TRB.Classes.BarVisibilityEntry[]
 function TRB.Functions.BarVisibility:BuildEditModeEntries(barGroups, displayBar, maxResource2)
 	local entries = {}
+	local alwaysVis = { visibility = "always" }
 
 	-- Primary always shows in Edit Mode
 	if barGroups.primary then
 		entries[#entries + 1] = TRB.Classes.BarVisibilityEntry:New(
 			barGroups.primary,
-			{ visibility = "always" }, -- Override: always show in Edit Mode
+			alwaysVis,
 			true,
 			nil,
 			nil
 		)
 	end
 
-	-- Secondary: show unless "never", needs nodes
+	-- Secondary: always show in Edit Mode if nodes exist
 	if barGroups.secondary and (maxResource2 or 0) > 0 then
-		local vis = (displayBar and displayBar.secondary) or { visibility = "always" }
-		local show = vis.visibility ~= "never"
 		entries[#entries + 1] = TRB.Classes.BarVisibilityEntry:New(
 			barGroups.secondary,
-			show and { visibility = "always" } or { visibility = "never" },
+			alwaysVis,
 			true,
 			maxResource2,
 			nil
 		)
 	end
 
-	-- Health: show unless "never"
+	-- Health: always show in Edit Mode
 	if barGroups.health then
-		local vis = (displayBar and displayBar.health) or { visibility = "always" }
-		local show = vis.visibility ~= "never"
 		entries[#entries + 1] = TRB.Classes.BarVisibilityEntry:New(
 			barGroups.health,
-			show and { visibility = "always" } or { visibility = "never" },
+			alwaysVis,
 			true,
 			1,
 			nil
@@ -236,15 +233,13 @@ function TRB.Functions.BarVisibility:BuildEditModeEntries(barGroups, displayBar,
 	end
 
 	-- Iterate remaining bar groups (custom bar types: mana, stagger, defensives, utility, etc.)
+	-- All shown unconditionally in Edit Mode
 	for key, group in pairs(barGroups) do
 		if type(group) == "table" and group.Hide and key ~= "primary" and key ~= "secondary" and key ~= "health" then
-			local vis = (displayBar and displayBar[key]) or { visibility = "always" }
-			local show = vis.visibility ~= "never"
-			-- Determine node count: single-node bars use 1, multi-node use maxNodes from the group
 			local nodeCount = group.maxNodes or 1
 			entries[#entries + 1] = TRB.Classes.BarVisibilityEntry:New(
 				group,
-				show and { visibility = "always" } or { visibility = "never" },
+				alwaysVis,
 				true,
 				nodeCount,
 				nil

--- a/Classes/BarVisibility.lua
+++ b/Classes/BarVisibility.lua
@@ -145,12 +145,10 @@ function TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData,
 	end
 
 	snapshotData.attributes.isTracking = anyShowing
-	if anyShowing then
+	if anyShowing and settings ~= nil then
 		TRB.Functions.BarText:Show(settings)
 	else
-		if settings ~= nil then
-			TRB.Functions.BarText:Hide(settings)
-		end
+		TRB.Functions.BarText:Hide(settings)
 	end
 
 	return anyShowing

--- a/Classes/BarVisibility.lua
+++ b/Classes/BarVisibility.lua
@@ -1,0 +1,256 @@
+local _, TRB = ...
+TRB.Classes = TRB.Classes or {}
+TRB.Functions = TRB.Functions or {}
+
+---@class TRB.Classes.BarVisibilityContext
+---@field force boolean # Whether to force-hide all bars (e.g., spec switch, pet battle)
+---@field specSupported boolean # Whether the current spec is enabled in addon settings
+---@field advancedFlight boolean # Whether the player is in advanced (dragon) flight
+---@field dragonridingEnabled boolean # Whether the user wants bars shown during dragonriding
+---@field inCombat boolean # Whether the player is currently in combat
+---@field inVehicle boolean # Whether the player is currently in a vehicle
+TRB.Classes.BarVisibilityContext = {}
+TRB.Classes.BarVisibilityContext.__index = TRB.Classes.BarVisibilityContext
+
+---Creates a new BarVisibilityContext with explicit values.
+---@param force boolean
+---@param specSupported boolean
+---@param advancedFlight boolean
+---@param dragonridingEnabled boolean
+---@param inCombat boolean
+---@param inVehicle boolean
+---@return TRB.Classes.BarVisibilityContext
+function TRB.Classes.BarVisibilityContext:New(force, specSupported, advancedFlight, dragonridingEnabled, inCombat, inVehicle)
+	local self = setmetatable({}, TRB.Classes.BarVisibilityContext)
+	self.force = force or false
+	self.specSupported = specSupported
+	self.advancedFlight = advancedFlight or false
+	self.dragonridingEnabled = dragonridingEnabled or false
+	self.inCombat = inCombat or false
+	self.inVehicle = inVehicle or false
+	return self
+end
+
+---Convenience constructor that reads current game state into a context.
+---@param force boolean # Force-hide flag from the caller
+---@param settings table|nil # The spec's settings table (must have displayBar.dragonriding)
+---@return TRB.Classes.BarVisibilityContext
+function TRB.Classes.BarVisibilityContext:NewFromGameState(force, settings)
+	local dragonridingEnabled = false
+	if settings and settings.displayBar then
+		dragonridingEnabled = settings.displayBar.dragonriding or false
+	end
+
+	return TRB.Classes.BarVisibilityContext:New(
+		force or false,
+		TRB.Data.specSupported or false,
+		TRB.Data.character.advancedFlight or false,
+		dragonridingEnabled,
+		TRB.Data.character.inCombat or false,
+		UnitInVehicle("player") or false
+	)
+end
+
+---@class TRB.Classes.BarVisibilityEntry
+---@field barGroup TRB.Classes.BarGroup|nil # The BarGroup to show/hide (nil = skip)
+---@field visibilitySettings table|nil # The displayBar sub-table for this bar (must have .visibility string), or nil to force-hide
+---@field enabled boolean # Class-level precondition (false = always hide regardless of settings)
+---@field showNodesCount number|nil # If set, calls :ShowNodes(n) when showing the bar
+---@field setMaxNodes number|nil # If set, calls :SetMaxNodes(n) before showing the bar
+TRB.Classes.BarVisibilityEntry = {}
+TRB.Classes.BarVisibilityEntry.__index = TRB.Classes.BarVisibilityEntry
+
+---Creates a new BarVisibilityEntry.
+---@param barGroup TRB.Classes.BarGroup|nil # The bar group to control
+---@param visibilitySettings table|nil # The displayBar.<key> settings sub-table (must have .visibility), or nil
+---@param enabled boolean # Whether this bar is active for the current spec/state
+---@param showNodesCount number|nil # Node count to pass to :ShowNodes() when visible
+---@param setMaxNodes number|nil # If set, calls :SetMaxNodes() before Show
+---@return TRB.Classes.BarVisibilityEntry
+function TRB.Classes.BarVisibilityEntry:New(barGroup, visibilitySettings, enabled, showNodesCount, setMaxNodes)
+	local self = setmetatable({}, TRB.Classes.BarVisibilityEntry)
+	self.barGroup = barGroup
+	self.visibilitySettings = visibilitySettings
+	self.enabled = enabled
+	self.showNodesCount = showNodesCount
+	self.setMaxNodes = setMaxNodes
+	return self
+end
+
+---@class TRB.Functions.BarVisibility
+TRB.Functions.BarVisibility = {}
+
+---Evaluates whether a single bar should be shown. Pure function, no side effects.
+---@param context TRB.Classes.BarVisibilityContext # The shared environment snapshot
+---@param entry TRB.Classes.BarVisibilityEntry # The bar entry to evaluate
+---@return boolean # true if the bar should be shown, false if it should be hidden
+function TRB.Functions.BarVisibility:ShouldShowBar(context, entry)
+	-- No bar group or disabled by class-level precondition
+	if entry.barGroup == nil or not entry.enabled then
+		return false
+	end
+
+	-- No visibility settings available (no settings loaded yet)
+	if entry.visibilitySettings == nil then
+		return false
+	end
+
+	-- Global force-hide conditions
+	if context.force or not context.specSupported then
+		return false
+	end
+
+	-- Dragonriding hide
+	if context.advancedFlight and not context.dragonridingEnabled then
+		return false
+	end
+
+	-- Evaluate the visibility setting
+	local visibility = entry.visibilitySettings.visibility
+	if visibility == "always" then
+		return true
+	elseif visibility == "combat" then
+		return context.inCombat or context.inVehicle
+	end
+
+	-- "never" or any unrecognized value
+	return false
+end
+
+---Evaluates and applies visibility for all bar entries. Sets isTracking and controls BarText.
+---@param context TRB.Classes.BarVisibilityContext # The shared environment snapshot
+---@param entries TRB.Classes.BarVisibilityEntry[] # Array of bar entries to process
+---@param snapshotData TRB.Classes.SnapshotData # The snapshot data to update isTracking on
+---@param settings table|nil # The spec settings, passed to BarText:Show/Hide
+---@return boolean # Whether any bar is showing (isTracking value)
+function TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData, settings)
+	local anyShowing = false
+
+	for _, entry in ipairs(entries) do
+		if entry.barGroup ~= nil then
+			local show = self:ShouldShowBar(context, entry)
+			if show then
+				anyShowing = true
+				if entry.setMaxNodes then
+					entry.barGroup:SetMaxNodes(entry.setMaxNodes)
+				end
+				entry.barGroup:Show()
+				if entry.showNodesCount then
+					entry.barGroup:ShowNodes(entry.showNodesCount)
+				end
+			else
+				entry.barGroup:Hide()
+			end
+		end
+	end
+
+	snapshotData.attributes.isTracking = anyShowing
+	if anyShowing then
+		TRB.Functions.BarText:Show(settings)
+	else
+		if settings ~= nil then
+			TRB.Functions.BarText:Hide(settings)
+		end
+	end
+
+	return anyShowing
+end
+
+---Hides all bars in the entries list unconditionally. Used for fallback paths (no settings, unsupported spec).
+---@param entries TRB.Classes.BarVisibilityEntry[]|nil # Array of bar entries, or nil
+---@param snapshotData TRB.Classes.SnapshotData # The snapshot data to update
+---@param settings table|nil # Settings to pass to BarText:Hide, may be nil
+function TRB.Functions.BarVisibility:HideAllEntries(entries, snapshotData, settings)
+	if entries then
+		for _, entry in ipairs(entries) do
+			if entry.barGroup ~= nil then
+				entry.barGroup:Hide()
+			end
+		end
+	end
+
+	snapshotData.attributes.isTracking = false
+	if settings ~= nil then
+		TRB.Functions.BarText:Hide(settings)
+	end
+end
+
+---Hides all bar groups in TRB.Frames.barGroups unconditionally. Used when no entries are available.
+---@param snapshotData TRB.Classes.SnapshotData # The snapshot data to update
+function TRB.Functions.BarVisibility:HideAllBarGroups(snapshotData)
+	local barGroups = TRB.Frames.barGroups
+	if barGroups then
+		for _, group in pairs(barGroups) do
+			if type(group) == "table" and group.Hide then
+				group:Hide()
+			end
+		end
+	end
+	snapshotData.attributes.isTracking = false
+end
+
+---Convenience: Builds entries from barGroups for Edit Mode display.
+---Shows all bars except those set to "never". Primary always shows.
+---@param barGroups table # TRB.Frames.barGroups
+---@param displayBar table|nil # The displayBar settings table
+---@param maxResource2 number|nil # Max secondary resource count (for ShowNodes)
+---@return TRB.Classes.BarVisibilityEntry[]
+function TRB.Functions.BarVisibility:BuildEditModeEntries(barGroups, displayBar, maxResource2)
+	local entries = {}
+
+	-- Primary always shows in Edit Mode
+	if barGroups.primary then
+		entries[#entries + 1] = TRB.Classes.BarVisibilityEntry:New(
+			barGroups.primary,
+			{ visibility = "always" }, -- Override: always show in Edit Mode
+			true,
+			nil,
+			nil
+		)
+	end
+
+	-- Secondary: show unless "never", needs nodes
+	if barGroups.secondary and (maxResource2 or 0) > 0 then
+		local vis = (displayBar and displayBar.secondary) or { visibility = "always" }
+		local show = vis.visibility ~= "never"
+		entries[#entries + 1] = TRB.Classes.BarVisibilityEntry:New(
+			barGroups.secondary,
+			show and { visibility = "always" } or { visibility = "never" },
+			true,
+			maxResource2,
+			nil
+		)
+	end
+
+	-- Health: show unless "never"
+	if barGroups.health then
+		local vis = (displayBar and displayBar.health) or { visibility = "always" }
+		local show = vis.visibility ~= "never"
+		entries[#entries + 1] = TRB.Classes.BarVisibilityEntry:New(
+			barGroups.health,
+			show and { visibility = "always" } or { visibility = "never" },
+			true,
+			1,
+			nil
+		)
+	end
+
+	-- Iterate remaining bar groups (custom bar types: mana, stagger, defensives, utility, etc.)
+	for key, group in pairs(barGroups) do
+		if type(group) == "table" and group.Hide and key ~= "primary" and key ~= "secondary" and key ~= "health" then
+			local vis = (displayBar and displayBar[key]) or { visibility = "always" }
+			local show = vis.visibility ~= "never"
+			-- Determine node count: single-node bars use 1, multi-node use maxNodes from the group
+			local nodeCount = group.maxNodes or 1
+			entries[#entries + 1] = TRB.Classes.BarVisibilityEntry:New(
+				group,
+				show and { visibility = "always" } or { visibility = "never" },
+				true,
+				nodeCount,
+				nil
+			)
+		end
+	end
+
+	return entries
+end

--- a/Functions/Bar.lua
+++ b/Functions/Bar.lua
@@ -305,45 +305,27 @@ function TRB.Functions.Bar:HideResourceBar(force)
 	if TRB.Functions.EditMode and TRB.Functions.EditMode:IsInEditMode() then
 		local barGroups = TRB.Frames.barGroups
 		local displayBar = nil
-		if TRB.Data.specCache and TRB.Data.character.specName then
-			local specSettings = TRB.Data.specCache[TRB.Data.character.compositeKey]
+		local specSettings = nil
+		if TRB.Data.specCache and TRB.Data.character.compositeKey then
+			specSettings = TRB.Data.specCache[TRB.Data.character.compositeKey]
 			if specSettings and specSettings.settings then
 				displayBar = specSettings.settings.displayBar
 			end
 		end
 
 		if barGroups then
-			-- Primary bar ALWAYS shows - it's required for positioning
-			if barGroups.primary then
-				barGroups.primary:Show()
-			end
-			-- Show secondary bar (combo points, etc.) unless set to "never" or has 0 nodes
-			if barGroups.secondary and (displayBar == nil or displayBar.secondary.visibility ~= "never")
-				and (TRB.Data.character.maxResource2 or 0) > 0 then
-				barGroups.secondary:Show()
-				local maxNodes = TRB.Data.character.maxResource2 or barGroups.secondary.maxNodes or 5
-				barGroups.secondary:ShowNodes(maxNodes)
-			end
-			-- Show health bar unless set to "never"
-			if barGroups.health and (displayBar == nil or displayBar.health.visibility ~= "never") then
-				barGroups.health:Show()
-			end
-			-- Show mana bar (Balance Druid, Shadow Priest, Elemental Shaman) unless set to "never"
-			if barGroups.mana and (displayBar == nil or displayBar.mana.visibility ~= "never") then
-				barGroups.mana:Show()
-			end
-			-- Show stagger bar (Brewmaster Monk) unless set to "never"
-			if barGroups.stagger and (displayBar == nil or displayBar.stagger.visibility ~= "never") then
-				barGroups.stagger:Show()
-			end
-			-- Show defensives bar (Protection Warrior) unless set to "never"
-			if barGroups.defensives and (displayBar == nil or displayBar.defensives.visibility ~= "never") then
-				barGroups.defensives:Show()
-			end
-		end
-		-- Set isTracking to true so bar text updates
-		if TRB.Data.snapshotData and TRB.Data.snapshotData.attributes then
-			TRB.Data.snapshotData.attributes.isTracking = true
+			-- Build Edit Mode entries using the visibility engine
+			local editContext = TRB.Classes.BarVisibilityContext:New(
+				false, true, false, true, true, false
+			)
+			local entries = TRB.Functions.BarVisibility:BuildEditModeEntries(
+				barGroups, displayBar, TRB.Data.character.maxResource2
+			)
+			local snapshotData = TRB.Data.snapshotData or TRB.Classes.SnapshotData:New()
+			TRB.Functions.BarVisibility:ProcessBars(
+				editContext, entries, snapshotData,
+				(specSettings and specSettings.settings) or nil
+			)
 		end
 		return
 	end

--- a/Functions/News.lua
+++ b/Functions/News.lua
@@ -13,6 +13,11 @@ local content = [====[
 ---
 
 # 12.0.1.25-release (2026-03-05)
+## General
+### Behind the Scenes
+
+- Refactor how individual bars handle their visibility to be more consistent and generic. This is precursor work to adding more visibility options.
+
 ## Demon Hunter
 ### Vengeance
 

--- a/TwintopInsanityBar.toc
+++ b/TwintopInsanityBar.toc
@@ -100,6 +100,7 @@ Functions\Table.lua
 Functions\Aura.lua
 Functions\Bar.lua
 Functions\BarText.lua
+Classes\BarVisibility.lua
 Functions\Character.lua
 Functions\Color.lua
 Functions\EditMode.lua


### PR DESCRIPTION
# Summary

Introduces a unified, bar-agnostic visibility rules engine (`TRB.Functions.BarVisibility`) and refactors every class module's `HideResourceBar` to delegate to it. Previously, each of the 13 class modules contained its own copy of the same visibility evaluation logic — repeated per-bar `if/elseif` chains checking `"always"`, `"combat"`, `"never"`, force-hide, dragonriding, and combat state — then per-bar `Show()`/`Hide()`/`ShowNodes()` calls, then per-bar fallback paths for no-settings and unsupported-spec cases. This PR replaces all of that with a declarative adapter pattern.

# New file: BarVisibility.lua

Three components, all with zero class/spec/bar-type knowledge:

## `BarVisibilityContext`
An immutable snapshot of the environment: `force`, `specSupported`, `advancedFlight`, `dragonridingEnabled`, `inCombat`, `inVehicle`. Has both an explicit constructor and a `NewFromGameState(force, settings)` convenience constructor.

## `BarVisibilityEntry`
A per-bar descriptor: `barGroup` (the BarGroup to control), `visibilitySettings` (the `displayBar.<key>` sub-table with `.visibility`), `enabled` (class-level precondition), `showNodesCount`, and `setMaxNodes`.

## `TRB.Functions.BarVisibility`
The engine itself:
  - `ShouldShowBar(context, entry)` — Pure evaluation function, no side effects. Checks enabled → visibilitySettings → force/specSupported → dragonriding → visibility setting.
  - `ProcessBars(context, entries, snapshotData, settings)` — Iterates entries, applies Show/Hide/ShowNodes/SetMaxNodes, computes and sets `isTracking`, manages BarText.
  - `HideAllEntries(entries, snapshotData, settings)` — Unconditional hide for the no-settings fallback.
  - `HideAllBarGroups(snapshotData)` — Iterates all barGroups keys generically for the unsupported-spec fallback.
  - `BuildEditModeEntries(barGroups, displayBar, maxResource2)` — Builds entries for Edit Mode where everything shows except "never" bars.

# Refactored: All 13 class modules

Each class's `HideResourceBar` is now a thin adapter that:
1. Computes class-specific preconditions (which bars are active for this spec/talent/form)
2. Builds an `entries` array of `BarVisibilityEntry` objects
3. Delegates to `ProcessBars` / `HideAllEntries` / `HideAllBarGroups`

Typical reduction: ~100–170 lines → ~25–45 lines per class.

Class-specific adapter highlights:
| Class | Bars | Notable adapter logic |
|-------|------|----------------------|
| Death Knight, Evoker, Paladin, Warlock | 3 (primary, secondary, health) | Simplest — all bars always enabled |
| Demon Hunter | 3 | Secondary gated on specId (Vengeance=6 nodes, Devourer=1) |
| Mage | 3 | Secondary gated on specId (Arcane always, Frost only if Icicles talented) |
| Hunter | 3 | Secondary gated on Survival + Tip of the Spear talented |
| Rogue | 3 | `setMaxNodes` for dynamic combo point count |
| Monk | 4 | Stagger bar for Brewmaster, Chi secondary for Windwalker |
| Shaman | 4 | Compressed view computed `showNodesCount` for Maelstrom Weapon; mana bar for Elemental |
| Warrior | 4 | Dual secondary pattern (defensives for Protection, whirlwind for Fury) |
| Priest | 5 | Talent-gated utility bar (Angelic Feather); mana bar for Shadow; secondary for Disc/Holy |
| Druid | 4 | Form-based routing via `GetFormSpecForSettings()`; secondary uses Feral's specCache settings |

## Refactored: Edit Mode handler (Bar.lua)

The Edit Mode handler previously had hardcoded per-key `if barGroups.mana` / `if barGroups.stagger` / `if barGroups.defensives` checks. Now uses `BuildEditModeEntries()` + `ProcessBars()`, making it automatically handle any bar type present in `barGroups` without code changes.

# Behavioral fixes (side effects of normalization)

## Hunter
Old fallback paths didn't hide `barGroups.secondary`; now handled generically by `HideAllEntries`/`HideAllBarGroups`.

## Warlock
Health bar now consistently calls `ShowNodes(1)` when visible (previously omitted).

# Load order

`Classes/BarVisibility.lua` is loaded after `FBarText.lua` in the `.toc` since it references `TRB.Functions.BarText` at runtime, and uses `local _, TRB = ...` for the addon table (consistent with all other files).