### PR TITLE
Add Dirty Flag to Bar Visibility to Skip Redundant Re-evaluations

### DIFF
--- a/ClassModules/DeathKnight.lua
+++ b/ClassModules/DeathKnight.lua
@@ -1388,6 +1388,10 @@ function TRB.Functions.Class:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
+	if not TRB.Functions.BarVisibility:IsDirty(force) then
+		return
+	end
+
 	---@type TRB.Classes.SnapshotData
 	local snapshotData = TRB.Data.snapshotData or TRB.Classes.SnapshotData:New()
 	local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]

--- a/ClassModules/DemonHunter.lua
+++ b/ClassModules/DemonHunter.lua
@@ -1790,6 +1790,10 @@ function TRB.Functions.Class:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
+	if not TRB.Functions.BarVisibility:IsDirty(force) then
+		return
+	end
+
 	---@type TRB.Classes.SnapshotData
 	local snapshotData = TRB.Data.snapshotData or TRB.Classes.SnapshotData:New()
 	local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]

--- a/ClassModules/Druid.lua
+++ b/ClassModules/Druid.lua
@@ -3038,6 +3038,10 @@ function TRB.Functions.Class:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
+	if not TRB.Functions.BarVisibility:IsDirty(force) then
+		return
+	end
+
 	---@type TRB.Classes.SnapshotData
 	local snapshotData = TRB.Data.snapshotData or TRB.Classes.SnapshotData:New()
 	local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]

--- a/ClassModules/Evoker.lua
+++ b/ClassModules/Evoker.lua
@@ -1254,6 +1254,10 @@ function TRB.Functions.Class:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
+	if not TRB.Functions.BarVisibility:IsDirty(force) then
+		return
+	end
+
 	---@type TRB.Classes.SnapshotData
 	local snapshotData = TRB.Data.snapshotData or TRB.Classes.SnapshotData:New()
 	local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]

--- a/ClassModules/Hunter.lua
+++ b/ClassModules/Hunter.lua
@@ -1639,6 +1639,10 @@ function TRB.Functions.Class:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
+	if not TRB.Functions.BarVisibility:IsDirty(force) then
+		return
+	end
+
 	---@type TRB.Classes.SnapshotData
 	local snapshotData = TRB.Data.snapshotData or TRB.Classes.SnapshotData:New()
 	local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]

--- a/ClassModules/Mage.lua
+++ b/ClassModules/Mage.lua
@@ -1171,6 +1171,10 @@ function TRB.Functions.Class:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
+	if not TRB.Functions.BarVisibility:IsDirty(force) then
+		return
+	end
+
 	---@type TRB.Classes.SnapshotData
 	local snapshotData = TRB.Data.snapshotData or TRB.Classes.SnapshotData:New()
 	local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]

--- a/ClassModules/Monk.lua
+++ b/ClassModules/Monk.lua
@@ -1831,6 +1831,10 @@ function TRB.Functions.Class:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
+	if not TRB.Functions.BarVisibility:IsDirty(force) then
+		return
+	end
+
 	---@type TRB.Classes.SnapshotData
 	local snapshotData = TRB.Data.snapshotData or TRB.Classes.SnapshotData:New()
 	local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]

--- a/ClassModules/Paladin.lua
+++ b/ClassModules/Paladin.lua
@@ -1136,6 +1136,10 @@ function TRB.Functions.Class:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
+	if not TRB.Functions.BarVisibility:IsDirty(force) then
+		return
+	end
+
 	---@type TRB.Classes.SnapshotData
 	local snapshotData = TRB.Data.snapshotData or TRB.Classes.SnapshotData:New()
 	local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]

--- a/ClassModules/Priest.lua
+++ b/ClassModules/Priest.lua
@@ -2754,6 +2754,10 @@ function TRB.Functions.Class:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
+	if not TRB.Functions.BarVisibility:IsDirty(force) then
+		return
+	end
+
 	---@type TRB.Classes.SnapshotData
 	local snapshotData = TRB.Data.snapshotData or TRB.Classes.SnapshotData:New()
 	local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]

--- a/ClassModules/Rogue.lua
+++ b/ClassModules/Rogue.lua
@@ -2173,6 +2173,10 @@ function TRB.Functions.Class:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
+	if not TRB.Functions.BarVisibility:IsDirty(force) then
+		return
+	end
+
 	---@type TRB.Classes.SnapshotData
 	local snapshotData = TRB.Data.snapshotData or TRB.Classes.SnapshotData:New()
 	local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]

--- a/ClassModules/Shaman.lua
+++ b/ClassModules/Shaman.lua
@@ -1542,6 +1542,10 @@ function TRB.Functions.Class:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
+	if not TRB.Functions.BarVisibility:IsDirty(force) then
+		return
+	end
+
 	---@type TRB.Classes.SnapshotData
 	local snapshotData = TRB.Data.snapshotData or TRB.Classes.SnapshotData:New()
 	local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]

--- a/ClassModules/Warlock.lua
+++ b/ClassModules/Warlock.lua
@@ -1145,6 +1145,10 @@ function TRB.Functions.Class:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
+	if not TRB.Functions.BarVisibility:IsDirty(force) then
+		return
+	end
+
 	---@type TRB.Classes.SnapshotData
 	local snapshotData = TRB.Data.snapshotData or TRB.Classes.SnapshotData:New()
 	local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]

--- a/ClassModules/Warrior.lua
+++ b/ClassModules/Warrior.lua
@@ -1663,6 +1663,10 @@ function TRB.Functions.Class:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
+	if not TRB.Functions.BarVisibility:IsDirty(force) then
+		return
+	end
+
 	---@type TRB.Classes.SnapshotData
 	local snapshotData = TRB.Data.snapshotData or TRB.Classes.SnapshotData:New()
 	local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]

--- a/Classes/BarVisibility.lua
+++ b/Classes/BarVisibility.lua
@@ -47,7 +47,7 @@ function TRB.Classes.BarVisibilityContext:NewFromGameState(force, settings)
 		TRB.Data.character.advancedFlight or false,
 		dragonridingEnabled,
 		TRB.Data.character.inCombat or false,
-		UnitInVehicle("player") or false
+		TRB.Data.character.inVehicle or false
 	)
 end
 
@@ -79,6 +79,34 @@ end
 
 ---@class TRB.Functions.BarVisibility
 TRB.Functions.BarVisibility = {}
+
+-- Dirty-flag cache: visibility results are deterministic for a given set of inputs.
+-- We skip re-evaluation unless an input has changed (MarkDirty was called).
+TRB.Functions.BarVisibility.dirtyToken = 0
+TRB.Functions.BarVisibility.lastAppliedToken = -1
+
+---Marks visibility state as dirty, forcing the next ProcessBars call to re-evaluate.
+---Call this whenever any input to visibility evaluation changes:
+---  inCombat, inVehicle, advancedFlight, inPetBattle, onTaxi, specSupported,
+---  dragonridingEnabled, per-bar visibility settings, talent gates, maxResource2.
+function TRB.Functions.BarVisibility:MarkDirty()
+	self.dirtyToken = self.dirtyToken + 1
+end
+
+---Returns true if a re-evaluation is needed (inputs have changed since last ProcessBars).
+---@param force boolean|nil # If true, always returns true (bypasses cache)
+---@return boolean
+function TRB.Functions.BarVisibility:IsDirty(force)
+	if force then
+		return true
+	end
+	return self.dirtyToken ~= self.lastAppliedToken
+end
+
+---Marks the cache as up-to-date after a successful ProcessBars evaluation.
+function TRB.Functions.BarVisibility:MarkClean()
+	self.lastAppliedToken = self.dirtyToken
+end
 
 ---Evaluates whether a single bar should be shown. Pure function, no side effects.
 ---@param context TRB.Classes.BarVisibilityContext # The shared environment snapshot
@@ -151,6 +179,7 @@ function TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData,
 		TRB.Functions.BarText:Hide(settings)
 	end
 
+	self:MarkClean()
 	return anyShowing
 end
 
@@ -171,6 +200,8 @@ function TRB.Functions.BarVisibility:HideAllEntries(entries, snapshotData, setti
 	if settings ~= nil then
 		TRB.Functions.BarText:Hide(settings)
 	end
+
+	self:MarkClean()
 end
 
 ---Hides all bar groups in TRB.Frames.barGroups unconditionally. Used when no entries are available.
@@ -185,6 +216,8 @@ function TRB.Functions.BarVisibility:HideAllBarGroups(snapshotData)
 		end
 	end
 	snapshotData.attributes.isTracking = false
+
+	self:MarkClean()
 end
 
 ---Convenience: Builds entries from barGroups for Edit Mode display.

--- a/Functions/Bar.lua
+++ b/Functions/Bar.lua
@@ -272,6 +272,7 @@ function TRB.Functions.Bar:EndRenderTransition(reason)
 		return
 	end
 
+	TRB.Functions.BarVisibility:MarkDirty()
 	TRB.Functions.Bar:HideResourceBar()
 	if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
 		TRB.Functions.Class:TriggerResourceBarUpdates()
@@ -541,6 +542,7 @@ function TRB.Functions.Bar:ConstructBarGroups(settings, barGroups)
 	-- Create bar text frames (essential for bar text display)
 	TRB.Functions.BarText:CreateBarTextFrames()
 	TRB.Functions.BarText:Hide(settings)
+	TRB.Functions.BarVisibility:MarkDirty()
 	TRB.Functions.Class:HideResourceBar()
 
 	if self:IsRenderTransitionActive() then

--- a/Functions/Character.lua
+++ b/Functions/Character.lua
@@ -6,11 +6,13 @@ TRB.Functions.Character = {}
 --TODO: Find a better home for this.
 local function OnAdvFlyEnabled()
 	TRB.Data.character.advancedFlight = true
+	TRB.Functions.BarVisibility:MarkDirty()
 	TRB.Functions.Bar:HideResourceBar()
 end
 
 local function OnAdvFlyDisabled()
 	TRB.Data.character.advancedFlight = false
+	TRB.Functions.BarVisibility:MarkDirty()
 	if TRB.Data.specSupported == true then
 		TRB.Functions.Bar:ShowResourceBar()
 	end
@@ -282,14 +284,22 @@ local function CharacterChange(self, event, ...)
 		C_Timer.After(0, function()
 			C_Timer.After(0.05, function()
 				TRB.Data.character.onTaxi = UnitOnTaxi("player")
+				TRB.Functions.BarVisibility:MarkDirty()
 			end)
 		end)
 	elseif event == "PET_BATTLE_OPENING_START" or event == "PET_BATTLE_CLOSE" then
 		C_Timer.After(0, function()
 			C_Timer.After(0.05, function()
 				TRB.Data.character.inPetBattle = C_PetBattles.IsInBattle()
+				TRB.Functions.BarVisibility:MarkDirty()
 			end)
 		end)
+	elseif event == "UNIT_ENTERED_VEHICLE" or event == "UNIT_EXITED_VEHICLE" then
+		local unitTarget = ...
+		if unitTarget == "player" then
+			TRB.Data.character.inVehicle = UnitInVehicle("player") or false
+			TRB.Functions.BarVisibility:MarkDirty()
+		end
 	elseif event == "PLAYER_ENTERING_WORLD" then
 		TRB.Functions.Character:CheckCharacter()
 	else
@@ -316,6 +326,8 @@ function TRB.Functions.Character:EnableCharacterChange()
 	characterChangeFrame:RegisterEvent("PLAYER_CONTROL_LOST")
 	characterChangeFrame:RegisterEvent("PET_BATTLE_OPENING_START")
 	characterChangeFrame:RegisterEvent("PET_BATTLE_CLOSE")
+	characterChangeFrame:RegisterEvent("UNIT_ENTERED_VEHICLE")
+	characterChangeFrame:RegisterEvent("UNIT_EXITED_VEHICLE")
 	characterChangeFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
 	characterChangeFrame:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
 	characterChangeFrame:RegisterEvent("TRAIT_CONFIG_UPDATED")
@@ -335,6 +347,8 @@ function TRB.Functions.Character:DisableCharacterChange()
 	characterChangeFrame:UnregisterEvent("PLAYER_CONTROL_LOST")
 	characterChangeFrame:UnregisterEvent("PET_BATTLE_OPENING_START")
 	characterChangeFrame:UnregisterEvent("PET_BATTLE_CLOSE")
+	characterChangeFrame:UnregisterEvent("UNIT_ENTERED_VEHICLE")
+	characterChangeFrame:UnregisterEvent("UNIT_EXITED_VEHICLE")
 	characterChangeFrame:UnregisterEvent("PLAYER_ENTERING_WORLD")
 	characterChangeFrame:UnregisterEvent("PLAYER_SPECIALIZATION_CHANGED")
 	characterChangeFrame:UnregisterEvent("TRAIT_CONFIG_UPDATED")
@@ -679,6 +693,8 @@ function TRB.Functions.Character:LoadFromSpecializationCache(cache)
 	TRB.Data.character.specId = GetSpecialization() or TRB.Data.character.specId
 	TRB.Data.character.latency = TRB.Functions.Character:GetLatency()
 	TRB.Data.character.inCombat = InCombatLockdown()
+	TRB.Data.character.inVehicle = UnitInVehicle("player") or false
+	TRB.Data.character.inPetBattle = C_PetBattles.IsInBattle() or false
 	TRB.Data.spellsData = cache.spellsData
 	TRB.Data.talents = cache.talents
 	TRB.Data.barTextVariables.icons = cache.barTextVariables.icons
@@ -686,6 +702,7 @@ function TRB.Functions.Character:LoadFromSpecializationCache(cache)
 	TRB.Data.snapshotData = cache.snapshotData
 	TRB.Data.snapshotData.attributes.isTracking = false
 	TRB.Functions.Character:ResetCaches()
+	TRB.Functions.BarVisibility:MarkDirty()
 end
 
 function TRB.Functions.Character:ResetColorCaches()
@@ -1313,6 +1330,7 @@ function TRB.Functions.Character:EventRegistration()
 
 				TRB.Functions.BarText:CreateBarTextFrames()
 				TRB.Functions.BarText:Hide(specSettings.settings)
+				TRB.Functions.BarVisibility:MarkDirty()
 				TRB.Functions.Class:HideResourceBar()
 			end
 		end
@@ -1348,5 +1366,6 @@ function TRB.Functions.Character:EventRegistration()
 		end
 	end
 
+	TRB.Functions.BarVisibility:MarkDirty()
 	TRB.Functions.Bar:HideResourceBar()
 end

--- a/Functions/EditMode.lua
+++ b/Functions/EditMode.lua
@@ -1356,6 +1356,7 @@ function TRB.Functions.EditMode:OnEditModeExit()
 		TRB.Functions.BarText:CreateBarTextFrames()
 
 		-- Let HideResourceBar determine if the bar should be visible now
+		TRB.Functions.BarVisibility:MarkDirty()
 		TRB.Functions.Class:HideResourceBar()
 	end
 end
@@ -1740,6 +1741,7 @@ local function ReapplyAnchorFrameLayout(layoutName, forceUpdate)
 			if specSettings and specSettings.settings then
 				isReapplyingAnchorLayout = true
 				TRB.Functions.Bar:ApplyBarGroupsLayout(specSettings.settings, TRB.Frames.barGroups)
+				TRB.Functions.BarVisibility:MarkDirty()
 				TRB.Functions.Bar:HideResourceBar()
 				isReapplyingAnchorLayout = false
 			end

--- a/Init.lua
+++ b/Init.lua
@@ -381,6 +381,7 @@ TRB.Frames.combatFrame:SetScript("OnEvent", function(self, event, ...)
 		TRB.Data.character.inCombat = false
 		TRB.Data.character.combatStartTime = nil
 	end
+	TRB.Functions.BarVisibility:MarkDirty()
 	TRB.Functions.Bar:ShowResourceBar()
 end)
 

--- a/Options/OptionsUi.lua
+++ b/Options/OptionsUi.lua
@@ -304,6 +304,7 @@ local function SetAllSpecsGlobalSetting(settingKey, value)
 		local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 		TRB.Functions.Bar:ApplyBarGroupsLayout(settings, TRB.Frames.barGroups)
 		TRB.Functions.Bar:ApplyBarGroupsAppearance(settings, TRB.Frames.barGroups)
+		TRB.Functions.BarVisibility:MarkDirty()
 		TRB.Functions.Bar:HideResourceBar()
 		if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
 			TRB.Functions.Class:TriggerResourceBarUpdates()
@@ -2315,6 +2316,7 @@ function TRB.Functions.OptionsUi:GenerateBarDimensionsOptions(parent, controls, 
 			if TRB.Frames.barGroups ~= nil then
 				TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
 				TRB.Functions.Bar:ApplyBarGroupsAppearance(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
+				TRB.Functions.BarVisibility:MarkDirty()
 				TRB.Functions.Bar:HideResourceBar()
 			end
 			TRB.Functions.Character:ResetCaches()
@@ -2350,6 +2352,7 @@ function TRB.Functions.OptionsUi:GenerateBarDimensionsOptions(parent, controls, 
 			if TRB.Frames.barGroups ~= nil then
 				TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
 				TRB.Functions.Bar:ApplyBarGroupsAppearance(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
+				TRB.Functions.BarVisibility:MarkDirty()
 				TRB.Functions.Bar:HideResourceBar()
 			end
 			TRB.Functions.Character:ResetCaches()
@@ -2381,6 +2384,7 @@ function TRB.Functions.OptionsUi:GenerateBarDimensionsOptions(parent, controls, 
 			if TRB.Frames.barGroups ~= nil then
 				TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
 				TRB.Functions.Bar:ApplyBarGroupsAppearance(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
+				TRB.Functions.BarVisibility:MarkDirty()
 				TRB.Functions.Bar:HideResourceBar()
 			end
 
@@ -2411,6 +2415,7 @@ function TRB.Functions.OptionsUi:GenerateBarDimensionsOptions(parent, controls, 
 			(classId == nil and specId == nil and TRB.Data.settings.core.global[TRB.Data.character.className][TRB.Data.character.specName].bar) then
 			if TRB.Frames.barGroups ~= nil then
 				TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
+				TRB.Functions.BarVisibility:MarkDirty()
 				TRB.Functions.Bar:HideResourceBar()
 			end
 		end
@@ -2430,6 +2435,7 @@ function TRB.Functions.OptionsUi:GenerateBarDimensionsOptions(parent, controls, 
 			(classId == nil and specId == nil and TRB.Data.settings.core.global[TRB.Data.character.className][TRB.Data.character.specName].bar) then
 			if TRB.Frames.barGroups ~= nil then
 				TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
+				TRB.Functions.BarVisibility:MarkDirty()
 				TRB.Functions.Bar:HideResourceBar()
 			end
 		end
@@ -2483,6 +2489,7 @@ function TRB.Functions.OptionsUi:GenerateBarDimensionsOptions(parent, controls, 
 			(classId == nil and specId == nil and TRB.Data.settings.core.global[TRB.Data.character.className][TRB.Data.character.specName].bar) then
 			if TRB.Frames.barGroups ~= nil then
 				TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
+				TRB.Functions.BarVisibility:MarkDirty()
 				TRB.Functions.Bar:HideResourceBar()
 			end
 		end
@@ -2690,6 +2697,7 @@ function TRB.Functions.OptionsUi:GenerateAncillaryBarDimensionsOptions(parent, c
 			TRB.Functions.Character:FillSpecializationCacheSettings(lowerClassName, specName)
 			if TRB.Frames.barGroups ~= nil then
 				TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
+				TRB.Functions.BarVisibility:MarkDirty()
 				TRB.Functions.Bar:HideResourceBar()
 			end
 			TRB.Functions.Character:ResetCaches()
@@ -2731,6 +2739,7 @@ function TRB.Functions.OptionsUi:GenerateAncillaryBarDimensionsOptions(parent, c
 			if TRB.Frames.barGroups ~= nil then
 				TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
 				TRB.Functions.Bar:ApplyBarGroupsAppearance(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
+				TRB.Functions.BarVisibility:MarkDirty()
 				TRB.Functions.Bar:HideResourceBar()
 			end
 		end
@@ -2757,6 +2766,7 @@ function TRB.Functions.OptionsUi:GenerateAncillaryBarDimensionsOptions(parent, c
 			if TRB.Frames.barGroups ~= nil then
 				TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
 				TRB.Functions.Bar:ApplyBarGroupsAppearance(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
+				TRB.Functions.BarVisibility:MarkDirty()
 				TRB.Functions.Bar:HideResourceBar()
 			end
 		end
@@ -2781,6 +2791,7 @@ function TRB.Functions.OptionsUi:GenerateAncillaryBarDimensionsOptions(parent, c
 			if TRB.Frames.barGroups ~= nil then
 				TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
 				TRB.Functions.Bar:ApplyBarGroupsAppearance(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
+				TRB.Functions.BarVisibility:MarkDirty()
 				TRB.Functions.Bar:HideResourceBar()
 			end
 		end
@@ -2801,6 +2812,7 @@ function TRB.Functions.OptionsUi:GenerateAncillaryBarDimensionsOptions(parent, c
 			if TRB.Frames.barGroups ~= nil then
 				TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
 				TRB.Functions.Bar:ApplyBarGroupsAppearance(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
+				TRB.Functions.BarVisibility:MarkDirty()
 				TRB.Functions.Bar:HideResourceBar()
 			end
 		end
@@ -2821,6 +2833,7 @@ function TRB.Functions.OptionsUi:GenerateAncillaryBarDimensionsOptions(parent, c
 			if TRB.Frames.barGroups ~= nil then
 				TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
 				TRB.Functions.Bar:ApplyBarGroupsAppearance(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
+				TRB.Functions.BarVisibility:MarkDirty()
 				TRB.Functions.Bar:HideResourceBar()
 			end
 		end
@@ -2874,6 +2887,7 @@ function TRB.Functions.OptionsUi:GenerateAncillaryBarDimensionsOptions(parent, c
 			(classId == nil and specId == nil and TRB.Data.settings.core.global[TRB.Data.character.className][TRB.Data.character.specName].bar) then
 			if TRB.Frames.barGroups ~= nil then
 				TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
+				TRB.Functions.BarVisibility:MarkDirty()
 				TRB.Functions.Bar:HideResourceBar()
 			end
 		end
@@ -2967,6 +2981,7 @@ function TRB.Functions.OptionsUi:GenerateAncillaryBarDimensionsOptions(parent, c
 			(classId == nil and specId == nil and TRB.Data.settings.core.global[TRB.Data.character.className][TRB.Data.character.specName].bar) then
 			if TRB.Frames.barGroups ~= nil then
 				TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
+				TRB.Functions.BarVisibility:MarkDirty()
 				TRB.Functions.Bar:HideResourceBar()
 			end
 		end
@@ -3832,6 +3847,7 @@ function TRB.Functions.OptionsUi:GenerateBarTexturesOptions(parent, controls, sp
 					local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 					TRB.Functions.Bar:ApplyBarGroupsLayout(settings, TRB.Frames.barGroups)
 					TRB.Functions.Bar:ApplyBarGroupsAppearance(settings, TRB.Frames.barGroups)
+					TRB.Functions.BarVisibility:MarkDirty()
 					TRB.Functions.Bar:HideResourceBar()
 					if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
 						TRB.Functions.Class:TriggerResourceBarUpdates()
@@ -4435,6 +4451,7 @@ function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spe
 					local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 					TRB.Functions.Bar:ApplyBarGroupsLayout(settings, TRB.Frames.barGroups)
 					TRB.Functions.Bar:ApplyBarGroupsAppearance(settings, TRB.Frames.barGroups)
+					TRB.Functions.BarVisibility:MarkDirty()
 					TRB.Functions.Bar:HideResourceBar()
 					if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
 						TRB.Functions.Class:TriggerResourceBarUpdates()
@@ -4497,6 +4514,7 @@ function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spe
 					TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
 					TRB.Functions.EditMode:UpdateWrapperSize(TRB.Data.specCache[TRB.Data.character.compositeKey].settings)
 				end
+				TRB.Functions.BarVisibility:MarkDirty()
 				TRB.Functions.Bar:HideResourceBar()
 			end
 		else
@@ -4510,6 +4528,7 @@ function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spe
 					TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
 					TRB.Functions.EditMode:UpdateWrapperSize(TRB.Data.specCache[TRB.Data.character.compositeKey].settings)
 				end
+				TRB.Functions.BarVisibility:MarkDirty()
 				TRB.Functions.Bar:HideResourceBar()
 			end
 		end
@@ -4548,6 +4567,7 @@ function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spe
 						TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
 						TRB.Functions.EditMode:UpdateWrapperSize(TRB.Data.specCache[TRB.Data.character.compositeKey].settings)
 					end
+					TRB.Functions.BarVisibility:MarkDirty()
 					TRB.Functions.Bar:HideResourceBar()
 				end
 			else
@@ -4561,6 +4581,7 @@ function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spe
 						TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
 						TRB.Functions.EditMode:UpdateWrapperSize(TRB.Data.specCache[TRB.Data.character.compositeKey].settings)
 					end
+					TRB.Functions.BarVisibility:MarkDirty()
 					TRB.Functions.Bar:HideResourceBar()
 				end
 			end
@@ -4719,11 +4740,13 @@ function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spe
 						TRB.Functions.Bar:ApplyBarGroupsLayout(settings, TRB.Frames.barGroups)
 						TRB.Functions.Bar:ApplyBarGroupsAppearance(settings, TRB.Frames.barGroups)
 						TRB.Functions.EditMode:UpdateWrapperSize(settings)
+						TRB.Functions.BarVisibility:MarkDirty()
 						TRB.Functions.Bar:HideResourceBar()
 						if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
 							TRB.Functions.Class:TriggerResourceBarUpdates()
 						end
 					else
+						TRB.Functions.BarVisibility:MarkDirty()
 						TRB.Functions.Bar:HideResourceBar()
 					end
 				end
@@ -4737,6 +4760,7 @@ function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spe
 							TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
 							TRB.Functions.EditMode:UpdateWrapperSize(TRB.Data.specCache[TRB.Data.character.compositeKey].settings)
 						end
+						TRB.Functions.BarVisibility:MarkDirty()
 						TRB.Functions.Bar:HideResourceBar()
 					end
 				else
@@ -4749,6 +4773,7 @@ function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spe
 							TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
 							TRB.Functions.EditMode:UpdateWrapperSize(TRB.Data.specCache[TRB.Data.character.compositeKey].settings)
 						end
+						TRB.Functions.BarVisibility:MarkDirty()
 						TRB.Functions.Bar:HideResourceBar()
 					end
 				end


### PR DESCRIPTION
### Summary

Introduces a lightweight dirty-flag caching mechanism to `TRB.Functions.BarVisibility` that prevents `HideResourceBar()` from performing a full re-evaluation on every call unless the inputs that drive visibility have actually changed.

### Problem

`HideResourceBar()` is called very frequently — on every resource bar update tick — but the visibility decision only changes when specific game state transitions occur (entering/leaving combat, mounting, entering a vehicle, pet battles, taxi, dragonriding, settings changes, etc.). The full evaluation on every tick is wasted work in the vast majority of frames.

### Solution

A monotonically incrementing `dirtyToken` / `lastAppliedToken` pair on `TRB.Functions.BarVisibility`:

- **`MarkDirty()`** — bumps the token. Called at every site where a visibility-relevant input changes.
- **`IsDirty(force)`** — returns `true` only if the token has advanced since the last evaluation (or if `force` is passed).
- **`MarkClean()`** — called at the end of `ProcessBars()`, `HideAllEntries()`, and `HideAllBarGroups()` to record that the current state has been applied.

Each class module's `HideResourceBar(force)` now early-returns if `IsDirty(force)` is `false`, skipping the entire evaluation.

### Changes

| Area | What changed |
|---|---|
| BarVisibility.lua | Added `dirtyToken`, `lastAppliedToken`, `MarkDirty()`, `IsDirty()`, `MarkClean()`. Replaced live `UnitInVehicle("player")` call with cached `TRB.Data.character.inVehicle`. |
| Character.lua | Registered `UNIT_ENTERED_VEHICLE` / `UNIT_EXITED_VEHICLE` events and caches `inVehicle` + `inPetBattle` on `TRB.Data.character`. Calls `MarkDirty()` on all state transitions (combat, taxi, pet battle, vehicle, advanced flight, spec load). |
| Init.lua | `MarkDirty()` call added to combat enter/leave handler. |
| Bar.lua | `MarkDirty()` before `HideResourceBar()` in `EndRenderTransition` and `ConstructBarGroups`. |
| EditMode.lua | `MarkDirty()` on Edit Mode exit and anchor reapply. |
| OptionsUi.lua | `MarkDirty()` before every `HideResourceBar()` call across dimension sliders, texture changes, display toggles, and global settings (~25 sites). |
| All 13 ClassModules | Added early-return guard `if not TRB.Functions.BarVisibility:IsDirty(force) then return end` at the top of each class's `HideResourceBar(force)`. |

### Design Notes

- The dirty flag is intentionally simple (integer comparison) to keep the per-frame cost near zero.
- `force = true` (used by bar construction, settings resets, etc.) always bypasses the cache.
- Vehicle state is now event-driven (`UNIT_ENTERED_VEHICLE` / `UNIT_EXITED_VEHICLE`) and cached on `TRB.Data.character.inVehicle` instead of calling `UnitInVehicle("player")` on every visibility check. This is both a correctness improvement (snapshot consistency) and a minor performance win.