### PR TITLE
Show Combo Points in All Shapeshift Forms

### DIFF
--- a/ClassModules/Classes/DruidClasses.lua
+++ b/ClassModules/Classes/DruidClasses.lua
@@ -759,9 +759,16 @@ function TRB.Classes.Druid.BarGroupsFactory:CreateForSpec(specId)
     if druidSettings and druidSettings.displayBar and druidSettings.displayBar.enableFormSwitching == false then
         enableFormSwitching = false
     end
+
+    -- showComboPoints allows specs to display combo points (Feral defaults to true, others to false)
+    local showComboPoints = false
+    if druidSettings and druidSettings.displayBar and druidSettings.displayBar.showComboPoints then
+        showComboPoints = true
+    end
     
-    -- For Feral, always create secondary bar. For others, only if form switching is enabled.
-    local createSecondary = (specId == 2) or enableFormSwitching
+    -- Create secondary bar when showComboPoints is enabled (or not explicitly disabled for Feral),
+    -- or when form switching could require it.
+    local createSecondary = (specId == 2 and showComboPoints ~= false) or enableFormSwitching or showComboPoints
 
     if specId == 1 then -- Balance
         -- Primary Astral Power bar only (1 node)

--- a/ClassModules/Druid.lua
+++ b/ClassModules/Druid.lua
@@ -1386,6 +1386,7 @@ local function UpdateResourceBar()
 	local snapshotData = TRB.Data.snapshotData --[[@as TRB.Classes.SnapshotData]]
 	local snapshots = snapshotData.snapshots
 	local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]
+	local isInEditMode = TRB.Functions.EditMode:IsInEditMode()
 
 	-- Always call HideResourceBar first to ensure visibility is correctly determined
 	-- even if we return early due to missing data
@@ -1599,7 +1600,7 @@ local function UpdateResourceBar()
 		-- consumes the hide. Explicitly hiding here on every frame guarantees the
 		-- secondary bar stays invisible when visibility is "never" or showComboPoints
 		-- is disabled.
-		if barGroups and barGroups.secondary then
+		if barGroups and barGroups.secondary and not isInEditMode then
 			barGroups.secondary:Hide()
 		end
 	end
@@ -1871,7 +1872,7 @@ local function UpdateResourceBar()
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
 				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
-			elseif barGroups and barGroups.health then
+			elseif barGroups and barGroups.health and not isInEditMode then
 				barGroups.health:Hide()
 			end
 
@@ -1888,7 +1889,7 @@ local function UpdateResourceBar()
 					manaNode:SetBorderColor(specSettings.colors.bars.mana.border.color)
 					manaNode:SetBackgroundColorFromString(specSettings.colors.bars.mana.background.color)
 				end
-			elseif barGroups and barGroups.mana then
+			elseif barGroups and barGroups.mana and not isInEditMode then
 				barGroups.mana:Hide()
 			end
 		end
@@ -2250,7 +2251,7 @@ local function UpdateResourceBar()
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
 				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
-			elseif barGroups and barGroups.health then
+			elseif barGroups and barGroups.health and not isInEditMode then
 				barGroups.health:Hide()
 			end
 		end
@@ -2455,7 +2456,7 @@ local function UpdateResourceBar()
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
 				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
-			elseif barGroups and barGroups.health then
+			elseif barGroups and barGroups.health and not isInEditMode then
 				barGroups.health:Hide()
 			end
 		end
@@ -2541,7 +2542,7 @@ local function UpdateResourceBar()
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
 				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
-			elseif barGroups and barGroups.health then
+			elseif barGroups and barGroups.health and not isInEditMode then
 				barGroups.health:Hide()
 			end
 		end

--- a/ClassModules/Druid.lua
+++ b/ClassModules/Druid.lua
@@ -409,6 +409,10 @@ local function UpdateShapeshiftForm()
 		TRB.Data.character.currentShapeshiftForm = "humanoid"
 	end
 
+	-- Form change affects which bars are visible (e.g., combo points only in cat form),
+	-- so mark visibility dirty so HideResourceBar will re-evaluate.
+	TRB.Functions.BarVisibility:MarkDirty()
+
 	-- Trigger resource bar update when form changes
 	if TRB.Functions.Class and TRB.Functions.Class.CheckCharacter then
 		TRB.Functions.Class:CheckCharacter()
@@ -1528,16 +1532,39 @@ local function UpdateResourceBar()
 	end
 
 	local function ConstructComboPointsGeneric()
-		-- Combo points update (when displaying Feral bar configuration)
-		-- Only show combo points when displaySpecId == 2 (Feral), which means form switching is enabled and we're in Cat form
-		-- This ensures formSpecSettings points to Feral settings (which has comboPoints defined)
-		if displaySpecId == 2 and formSpecSettings.displayBar.secondary.visibility ~= "never" then
-			-- Use Feral's combo point settings (formSpecSettings points to Feral when displaySpecId == 2)
-			local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(formSpecSettings.colors.comboPoints.background.color, true)
+		-- Generic combo points rendering for non-native forms. Feral always shows CPs as its
+		-- native secondary resource. Non-Feral specs show CPs when showComboPoints is enabled
+		-- or when in cat form via form switching.
+		local showCp = false
+		local cpSettings = nil
+		local activeSpecName = ({ [1] = "balance", [2] = "feral", [3] = "guardian", [4] = "restoration" })[activeSpecId]
+		local activeSpecSettings = activeSpecName and classSettings[activeSpecName]
+		if activeSpecSettings ~= nil and activeSpecSettings.displayBar ~= nil then
+			if displaySpecId == 2 then
+				-- Cat form (or Feral with form-switching off): CPs are native, always eligible
+				showCp = activeSpecSettings.displayBar.secondary.visibility ~= "never"
+				cpSettings = (activeSpecId == 2) and activeSpecSettings or (classSettings.feral or activeSpecSettings)
+			elseif activeSpecId == 2 then
+				-- Feral in non-cat form: checkbox defaults ON (nil → show)
+				if activeSpecSettings.displayBar.showComboPoints ~= false then
+					showCp = activeSpecSettings.displayBar.secondary.visibility ~= "never"
+					cpSettings = activeSpecSettings
+				end
+			else
+				-- Non-Feral in non-cat form: checkbox defaults OFF (nil → hide)
+				if activeSpecSettings.displayBar.showComboPoints == true then
+					showCp = activeSpecSettings.displayBar.secondary.visibility ~= "never"
+					cpSettings = classSettings.feral or activeSpecSettings
+				end
+			end
+		end
+
+		if showCp and cpSettings then
+			local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(cpSettings.colors.comboPoints.background.color, true)
 			
 			for x = 1, TRB.Data.character.maxComboPoints do
-				local cpBorderColor = formSpecSettings.colors.comboPoints.border.color
-				local cpColor = formSpecSettings.colors.comboPoints.base.color
+				local cpBorderColor = cpSettings.colors.comboPoints.border.color
+				local cpColor = cpSettings.colors.comboPoints.base.color
 				local cpBR = cpBackgroundRed
 				local cpBG = cpBackgroundGreen
 				local cpBB = cpBackgroundBlue
@@ -1547,10 +1574,10 @@ local function UpdateResourceBar()
 					if cpNode then
 						if (snapshotData.attributes.comboPoints or 0) >= x then
 							TRB.Functions.Bar:SetBarNodeValue(formSpecCacheSettings, "comboPoint" .. x, cpNode, 1, 1)
-							if (formSpecSettings.comboPoints.sameColor and snapshotData.attributes.comboPoints == (TRB.Data.character.maxComboPoints - 1)) or (not formSpecSettings.comboPoints.sameColor and x == (TRB.Data.character.maxComboPoints - 1)) then
-								cpColor = formSpecSettings.colors.comboPoints.penultimate.color
-							elseif (formSpecSettings.comboPoints.sameColor and snapshotData.attributes.comboPoints == (TRB.Data.character.maxComboPoints)) or x == TRB.Data.character.maxComboPoints then
-								cpColor = formSpecSettings.colors.comboPoints.final.color
+							if (cpSettings.comboPoints.sameColor and snapshotData.attributes.comboPoints == (TRB.Data.character.maxComboPoints - 1)) or (not cpSettings.comboPoints.sameColor and x == (TRB.Data.character.maxComboPoints - 1)) then
+								cpColor = cpSettings.colors.comboPoints.penultimate.color
+							elseif (cpSettings.comboPoints.sameColor and snapshotData.attributes.comboPoints == (TRB.Data.character.maxComboPoints)) or x == TRB.Data.character.maxComboPoints then
+								cpColor = cpSettings.colors.comboPoints.final.color
 							end
 						else
 							TRB.Functions.Bar:SetBarNodeValue(formSpecCacheSettings, "comboPoint" .. x, cpNode, 0, 1)
@@ -1563,6 +1590,17 @@ local function UpdateResourceBar()
 				end
 			end
 			return true
+		end
+
+		-- Combo points should not render: ensure secondary bar is hidden.
+		-- This is a defensive safeguard: ConstructAnchoredBarGroup (called during
+		-- ApplyBarGroupsLayout) unconditionally Show()s bar groups, and the dirty-
+		-- flag visibility cache may not re-evaluate in time if the render transition
+		-- consumes the hide. Explicitly hiding here on every frame guarantees the
+		-- secondary bar stays invisible when visibility is "never" or showComboPoints
+		-- is disabled.
+		if barGroups and barGroups.secondary then
+			barGroups.secondary:Hide()
 		end
 	end
 	
@@ -1833,10 +1871,12 @@ local function UpdateResourceBar()
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
 				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+			elseif barGroups and barGroups.health then
+				barGroups.health:Hide()
 			end
 
-			-- Mana bar update (Balance only)
-			if specSettings.displayBar.mana ~= nil and specSettings.displayBar.mana.visibility ~= "never" then
+			-- Mana bar update (Balance only, when primary bar is Astral Power — not when primary is already mana)
+			if displaySpecId == 1 and specSettings.displayBar.mana ~= nil and specSettings.displayBar.mana.visibility ~= "never" then
 				refreshText = true
 				local manaNode = barGroups and barGroups.mana and barGroups.mana:GetNode(1)
 				if manaNode then
@@ -1848,6 +1888,8 @@ local function UpdateResourceBar()
 					manaNode:SetBorderColor(specSettings.colors.bars.mana.border.color)
 					manaNode:SetBackgroundColorFromString(specSettings.colors.bars.mana.background.color)
 				end
+			elseif barGroups and barGroups.mana then
+				barGroups.mana:Hide()
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -2140,7 +2182,9 @@ local function UpdateResourceBar()
 				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
-			-- Show combo points when in Cat form, OR when displaySpecId is Feral (enableFormSwitching disabled)
+			-- Show native combo points (with Berserk tick tracking) when in Cat form or
+			-- when displaySpecId is Feral (enableFormSwitching disabled). Other forms with
+			-- form switching ON fall through to ConstructComboPointsGeneric for simplified rendering.
 			if (currentForm == "cat" or displaySpecId == 2) and specSettings.displayBar.secondary.visibility ~= "never" then
 				refreshText = true
 				local spells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Druid.FeralSpells]]
@@ -2188,6 +2232,10 @@ local function UpdateResourceBar()
 						end
 					end
 				end
+			else
+				-- Non-Cat form: use generic combo points handler for showComboPoints
+				local refreshTextFromComboPoints = ConstructComboPointsGeneric()
+				refreshText = refreshText or refreshTextFromComboPoints
 			end
 
 			-- Health bar update
@@ -2202,6 +2250,8 @@ local function UpdateResourceBar()
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
 				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+			elseif barGroups and barGroups.health then
+				barGroups.health:Hide()
 			end
 		end
 
@@ -2405,6 +2455,8 @@ local function UpdateResourceBar()
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
 				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+			elseif barGroups and barGroups.health then
+				barGroups.health:Hide()
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -2489,6 +2541,8 @@ local function UpdateResourceBar()
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
 				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+			elseif barGroups and barGroups.health then
+				barGroups.health:Hide()
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -2878,8 +2932,9 @@ function TRB.Functions.Class:CheckCharacter()
 			local specSettings = TRB.Data.settings.druid[TRB.Data.character.specName]
 			local enableFormSwitching = specSettings == nil or specSettings.displayBar == nil or specSettings.displayBar.enableFormSwitching ~= false
 			
-			-- Only configure combo points for Feral, or for other specs when form switching is enabled
-			if barGroups.secondary and (TRB.Data.character.specId == 2 or enableFormSwitching) then
+			-- Only configure combo points for Feral, or for other specs when form switching or showComboPoints is enabled
+			local showComboPoints = specSettings ~= nil and specSettings.displayBar ~= nil and specSettings.displayBar.showComboPoints
+			if barGroups.secondary and (TRB.Data.character.specId == 2 or enableFormSwitching or showComboPoints) then
 				-- Clear cached node count if combo point max changed, so the new value is used
 				if TRB.Data.character.maxResource2 ~= TRB.Data.character.maxComboPoints then
 					barGroups.secondary.lastRebuildNodeCount = nil
@@ -3056,18 +3111,34 @@ function TRB.Functions.Class:HideResourceBar(force)
 		local currentForm = TRB.Data.character.currentShapeshiftForm or "humanoid"
 		local displaySpecId = GetFormSpecForSettings(TRB.Data.character.specId, currentForm)
 
-		-- Secondary (Combo Points): enabled when displaySpecId is Feral (2)
-		-- Uses Feral's specCache for visibility settings
-		local hasSecondary = displaySpecId == 2
+		-- Secondary (Combo Points): In cat form (displaySpecId == 2), CPs are the native resource
+		-- and always show. In non-cat forms, the showComboPoints checkbox controls visibility
+		-- (defaults ON for Feral, OFF for non-Feral).
+		local hasSecondary = false
 		local secondaryVisSettings = nil
-		if hasSecondary then
-			local feralSettings = TRB.Data.specCache.druid_feral and TRB.Data.specCache.druid_feral.settings or sharedSettings
-			if feralSettings ~= nil and feralSettings.displayBar ~= nil then
-				secondaryVisSettings = feralSettings.displayBar.secondary
+		if sharedSettings ~= nil and sharedSettings.displayBar ~= nil then
+			if displaySpecId == 2 then
+				-- Cat form (or Feral with form-switching off): CPs are native, always eligible
+				hasSecondary = true
+				secondaryVisSettings = sharedSettings.displayBar.secondary
+			elseif TRB.Data.character.specId == 2 then
+				-- Feral in non-cat form: checkbox defaults ON (nil → show)
+				if sharedSettings.displayBar.showComboPoints ~= false then
+					hasSecondary = true
+					secondaryVisSettings = sharedSettings.displayBar.secondary
+				end
+			else
+				-- Non-Feral in non-cat form: checkbox defaults OFF (nil → hide)
+				if sharedSettings.displayBar.showComboPoints == true then
+					hasSecondary = true
+					secondaryVisSettings = sharedSettings.displayBar.secondary
+				end
 			end
 		end
 
-		-- Mana bar: Balance (specId == 1) in Balance form (displaySpecId == 1)
+		-- Mana bar: Balance (specId == 1) only when primary bar is NOT already showing mana.
+		-- When form switching routes to displaySpecId == 4 (Restoration), the primary bar IS mana,
+		-- so the dedicated mana bar would duplicate it. Only show it when displaySpecId == 1 (Astral Power on primary).
 		local hasMana = TRB.Data.character.specId == 1 and displaySpecId == 1
 		local manaVisSettings = (sharedSettings and sharedSettings.displayBar.mana) or nil
 

--- a/ClassModules/Options/DruidOptions.lua
+++ b/ClassModules/Options/DruidOptions.lua
@@ -292,7 +292,8 @@ local function BalanceLoadDefaultSettings(includeBarText, classic)
 			health = { visibility = "always", smooth = true },
 			mana = { visibility = "never", smooth = true },
 			dragonriding = true,
-			enableFormSwitching = true
+			enableFormSwitching = true,
+			showComboPoints = false
 		},
 		endOf = {
 			eclipse = TRB.Functions.Settings:DefaultEndOfSettings("gcd", 2, 3.0, { celestialAlignmentOnly = false })
@@ -627,7 +628,8 @@ local function FeralLoadDefaultSettings(includeBarText, classic)
 			secondary = { visibility = "always", smooth = false },
 			health = { visibility = "always", smooth = true },
 			dragonriding = true,
-			enableFormSwitching = true
+			enableFormSwitching = true,
+			showComboPoints = true
 		},
 		overcap = {
 			mode = "relative",
@@ -809,7 +811,8 @@ local function GuardianLoadDefaultSettings(includeBarText, classic)
 			secondary = { visibility = "always", smooth = false },
 			health = { visibility = "always", smooth = true },
 			dragonriding = true,
-			enableFormSwitching = true
+			enableFormSwitching = true,
+			showComboPoints = false
 		},
 		overcap = {
 			mode = "relative",
@@ -930,7 +933,8 @@ local function RestorationLoadDefaultSettings(includeBarText, classic)
 			secondary = { visibility = "always", smooth = false },
 			health = { visibility = "always", smooth = true },
 			dragonriding = true,
-			enableFormSwitching = true
+			enableFormSwitching = true,
+			showComboPoints = false
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		healthBar = TRB.Functions.Settings:DefaultHealthDimensions(classic),
@@ -1298,7 +1302,7 @@ local function BalanceConstructBarVisibilityPanel(parent)
 	local yCoord = 5
 	local f = nil
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 11, 1, yCoord, L["ResourceAstralPower"], "balance", true, L["DruidBalanceStarsurge"], L["DruidBalanceStarsurge"], false, nil, true, true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 11, 1, yCoord, L["ResourceAstralPower"], "balance", true, L["DruidBalanceStarsurge"], L["DruidBalanceStarsurge"], true, L["ResourceComboPoints"], true, true)
 
 	yCoord = yCoord - 70
 	controls.checkBoxes.enableFormSwitching = CreateFrame("CheckButton", "TwintopResourceBar_Druid_Balance_Checkbox_FormSwitching", parent, "ChatConfigCheckButtonTemplate")
@@ -1316,21 +1320,43 @@ local function BalanceConstructBarVisibilityPanel(parent)
 			TRB.Data.cache.colors.backdrop = {}
 			-- Destroy and recreate bar groups to add/remove secondary bar
 			TRB.Functions.Bar:DestroyBarGroups()
+			TRB.Functions.BarVisibility:MarkDirty()
 			TRB.Frames.barGroups = TRB.Classes.Druid.BarGroupsFactory:CreateForSpec(TRB.Data.character.specId)
 			local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 			TRB.Functions.Bar:ConstructBarGroups(settings, TRB.Frames.barGroups)
-			-- Force re-apply layout and appearance to ensure secondary bar gets Feral settings
-			TRB.Functions.Bar:ApplyBarGroupsLayout(settings, TRB.Frames.barGroups)
-			TRB.Functions.Bar:ApplyBarGroupsAppearance(settings, TRB.Frames.barGroups)
-			if TRB.Functions.Class and TRB.Functions.Class.CheckCharacter then
-				TRB.Functions.Class:CheckCharacter()
-			end
 			if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
 				TRB.Functions.Class:TriggerResourceBarUpdates()
 			end
 			TRB.Functions.Character:ResetColorCaches()
 			TRB.Data.cache.values.frame = {}
-			TRB.Functions.BarText:CreateBarTextFrames(11, 1)
+		end
+	end)
+
+	yCoord = yCoord - 25
+	controls.checkBoxes.showComboPoints = CreateFrame("CheckButton", "TwintopResourceBar_Druid_Balance_Checkbox_ShowComboPoints", parent, "ChatConfigCheckButtonTemplate")
+	f = controls.checkBoxes.showComboPoints
+	f:SetPoint("TOPLEFT", oUi.xCoord, yCoord)
+	getglobal(f:GetName() .. 'Text'):SetText(L["DruidCheckboxShowComboPoints"])
+	f.tooltip = L["DruidCheckboxShowComboPointsTooltip"]
+	f:SetChecked(spec.displayBar.showComboPoints)
+	f:SetScript("OnClick", function(self, ...)
+		spec.displayBar.showComboPoints = self:GetChecked()
+		if TRB.Functions.OptionsUi:IsEditingActiveSpec(11, 1) then
+			-- Clear all caches before rebuilding
+			TRB.Functions.Character:ResetCaches()
+			TRB.Data.cache.colors.border = {}
+			TRB.Data.cache.colors.backdrop = {}
+			-- Destroy and recreate bar groups to add/remove secondary bar
+			TRB.Functions.Bar:DestroyBarGroups()
+			TRB.Functions.BarVisibility:MarkDirty()
+			TRB.Frames.barGroups = TRB.Classes.Druid.BarGroupsFactory:CreateForSpec(TRB.Data.character.specId)
+			local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
+			TRB.Functions.Bar:ConstructBarGroups(settings, TRB.Frames.barGroups)
+			if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
+				TRB.Functions.Class:TriggerResourceBarUpdates()
+			end
+			TRB.Functions.Character:ResetColorCaches()
+			TRB.Data.cache.values.frame = {}
 		end
 	end)
 end
@@ -1983,21 +2009,43 @@ local function FeralConstructBarVisibilityPanel(parent)
 			TRB.Functions.Character:ResetCaches()
 			-- Destroy and recreate bar groups to add/remove secondary bar
 			TRB.Functions.Bar:DestroyBarGroups()
+			TRB.Functions.BarVisibility:MarkDirty()
 			TRB.Frames.barGroups = TRB.Classes.Druid.BarGroupsFactory:CreateForSpec(TRB.Data.character.specId)
 			local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 			TRB.Functions.Bar:ConstructBarGroups(settings, TRB.Frames.barGroups)
-			-- Force re-apply layout and appearance to ensure secondary bar gets Feral settings
-			TRB.Functions.Bar:ApplyBarGroupsLayout(settings, TRB.Frames.barGroups)
-			TRB.Functions.Bar:ApplyBarGroupsAppearance(settings, TRB.Frames.barGroups)
-			if TRB.Functions.Class and TRB.Functions.Class.CheckCharacter then
-				TRB.Functions.Class:CheckCharacter()
-			end
 			if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
 				TRB.Functions.Class:TriggerResourceBarUpdates()
 			end
 			TRB.Functions.Character:ResetColorCaches()
 			TRB.Data.cache.values.frame = {}
-			TRB.Functions.BarText:CreateBarTextFrames(11, 2)
+		end
+	end)
+
+	yCoord = yCoord - 25
+	controls.checkBoxes.showComboPoints = CreateFrame("CheckButton", "TwintopResourceBar_Druid_Feral_Checkbox_ShowComboPoints", parent, "ChatConfigCheckButtonTemplate")
+	f = controls.checkBoxes.showComboPoints
+	f:SetPoint("TOPLEFT", oUi.xCoord, yCoord)
+	getglobal(f:GetName() .. 'Text'):SetText(L["DruidCheckboxShowComboPoints"])
+	f.tooltip = L["DruidCheckboxShowComboPointsTooltip"]
+	f:SetChecked(spec.displayBar.showComboPoints)
+	f:SetScript("OnClick", function(self, ...)
+		spec.displayBar.showComboPoints = self:GetChecked()
+		if TRB.Functions.OptionsUi:IsEditingActiveSpec(11, 2) then
+			-- Clear all caches before rebuilding
+			TRB.Functions.Character:ResetCaches()
+			TRB.Data.cache.colors.border = {}
+			TRB.Data.cache.colors.backdrop = {}
+			-- Destroy and recreate bar groups to add/remove secondary bar
+			TRB.Functions.Bar:DestroyBarGroups()
+			TRB.Functions.BarVisibility:MarkDirty()
+			TRB.Frames.barGroups = TRB.Classes.Druid.BarGroupsFactory:CreateForSpec(TRB.Data.character.specId)
+			local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
+			TRB.Functions.Bar:ConstructBarGroups(settings, TRB.Frames.barGroups)
+			if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
+				TRB.Functions.Class:TriggerResourceBarUpdates()
+			end
+			TRB.Functions.Character:ResetColorCaches()
+			TRB.Data.cache.values.frame = {}
 		end
 	end)
 end
@@ -2558,7 +2606,7 @@ local function GuardianConstructBarVisibilityPanel(parent)
 	local yCoord = 5
 	local f = nil
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 11, 3, yCoord, L["ResourceRage"], "guardian", false, nil, nil, false, nil, true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 11, 3, yCoord, L["ResourceRage"], "guardian", false, nil, nil, true, L["ResourceComboPoints"], true)
 
 	yCoord = yCoord - 70
 	controls.checkBoxes.enableFormSwitching = CreateFrame("CheckButton", "TwintopResourceBar_Druid_Guardian_Checkbox_FormSwitching", parent, "ChatConfigCheckButtonTemplate")
@@ -2576,21 +2624,43 @@ local function GuardianConstructBarVisibilityPanel(parent)
 			TRB.Data.cache.colors.backdrop = {}
 			-- Destroy and recreate bar groups to add/remove secondary bar
 			TRB.Functions.Bar:DestroyBarGroups()
+			TRB.Functions.BarVisibility:MarkDirty()
 			TRB.Frames.barGroups = TRB.Classes.Druid.BarGroupsFactory:CreateForSpec(TRB.Data.character.specId)
 			local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 			TRB.Functions.Bar:ConstructBarGroups(settings, TRB.Frames.barGroups)
-			-- Force re-apply layout and appearance to ensure secondary bar gets Feral settings
-			TRB.Functions.Bar:ApplyBarGroupsLayout(settings, TRB.Frames.barGroups)
-			TRB.Functions.Bar:ApplyBarGroupsAppearance(settings, TRB.Frames.barGroups)
-			if TRB.Functions.Class and TRB.Functions.Class.CheckCharacter then
-				TRB.Functions.Class:CheckCharacter()
-			end
 			if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
 				TRB.Functions.Class:TriggerResourceBarUpdates()
 			end
 			TRB.Functions.Character:ResetColorCaches()
 			TRB.Data.cache.values.frame = {}
-			TRB.Functions.BarText:CreateBarTextFrames(11, 3)
+		end
+	end)
+
+	yCoord = yCoord - 25
+	controls.checkBoxes.showComboPoints = CreateFrame("CheckButton", "TwintopResourceBar_Druid_Guardian_Checkbox_ShowComboPoints", parent, "ChatConfigCheckButtonTemplate")
+	f = controls.checkBoxes.showComboPoints
+	f:SetPoint("TOPLEFT", oUi.xCoord, yCoord)
+	getglobal(f:GetName() .. 'Text'):SetText(L["DruidCheckboxShowComboPoints"])
+	f.tooltip = L["DruidCheckboxShowComboPointsTooltip"]
+	f:SetChecked(spec.displayBar.showComboPoints)
+	f:SetScript("OnClick", function(self, ...)
+		spec.displayBar.showComboPoints = self:GetChecked()
+		if TRB.Functions.OptionsUi:IsEditingActiveSpec(11, 3) then
+			-- Clear all caches before rebuilding
+			TRB.Functions.Character:ResetCaches()
+			TRB.Data.cache.colors.border = {}
+			TRB.Data.cache.colors.backdrop = {}
+			-- Destroy and recreate bar groups to add/remove secondary bar
+			TRB.Functions.Bar:DestroyBarGroups()
+			TRB.Functions.BarVisibility:MarkDirty()
+			TRB.Frames.barGroups = TRB.Classes.Druid.BarGroupsFactory:CreateForSpec(TRB.Data.character.specId)
+			local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
+			TRB.Functions.Bar:ConstructBarGroups(settings, TRB.Frames.barGroups)
+			if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
+				TRB.Functions.Class:TriggerResourceBarUpdates()
+			end
+			TRB.Functions.Character:ResetColorCaches()
+			TRB.Data.cache.values.frame = {}
 		end
 	end)
 end
@@ -3038,7 +3108,7 @@ local function RestorationConstructBarVisibilityPanel(parent)
 	local yCoord = 5
 	local f = nil
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 11, 4, yCoord, L["ResourceMana"], "notFull", false, nil, nil, false, nil, true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 11, 4, yCoord, L["ResourceMana"], "notFull", false, nil, nil, true, L["ResourceComboPoints"], true)
 
 	yCoord = yCoord - 70
 	controls.checkBoxes.enableFormSwitching = CreateFrame("CheckButton", "TwintopResourceBar_Druid_Restoration_Checkbox_FormSwitching", parent, "ChatConfigCheckButtonTemplate")
@@ -3056,21 +3126,43 @@ local function RestorationConstructBarVisibilityPanel(parent)
 			TRB.Data.cache.colors.backdrop = {}
 			-- Destroy and recreate bar groups to add/remove secondary bar
 			TRB.Functions.Bar:DestroyBarGroups()
+			TRB.Functions.BarVisibility:MarkDirty()
 			TRB.Frames.barGroups = TRB.Classes.Druid.BarGroupsFactory:CreateForSpec(TRB.Data.character.specId)
 			local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
 			TRB.Functions.Bar:ConstructBarGroups(settings, TRB.Frames.barGroups)
-			-- Force re-apply layout and appearance to ensure secondary bar gets Feral settings
-			TRB.Functions.Bar:ApplyBarGroupsLayout(settings, TRB.Frames.barGroups)
-			TRB.Functions.Bar:ApplyBarGroupsAppearance(settings, TRB.Frames.barGroups)
-			if TRB.Functions.Class and TRB.Functions.Class.CheckCharacter then
-				TRB.Functions.Class:CheckCharacter()
-			end
 			if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
 				TRB.Functions.Class:TriggerResourceBarUpdates()
 			end
 			TRB.Functions.Character:ResetColorCaches()
 			TRB.Data.cache.values.frame = {}
-			TRB.Functions.BarText:CreateBarTextFrames(11, 4)
+		end
+	end)
+
+	yCoord = yCoord - 25
+	controls.checkBoxes.showComboPoints = CreateFrame("CheckButton", "TwintopResourceBar_Druid_Restoration_Checkbox_ShowComboPoints", parent, "ChatConfigCheckButtonTemplate")
+	f = controls.checkBoxes.showComboPoints
+	f:SetPoint("TOPLEFT", oUi.xCoord, yCoord)
+	getglobal(f:GetName() .. 'Text'):SetText(L["DruidCheckboxShowComboPoints"])
+	f.tooltip = L["DruidCheckboxShowComboPointsTooltip"]
+	f:SetChecked(spec.displayBar.showComboPoints)
+	f:SetScript("OnClick", function(self, ...)
+		spec.displayBar.showComboPoints = self:GetChecked()
+		if TRB.Functions.OptionsUi:IsEditingActiveSpec(11, 4) then
+			-- Clear all caches before rebuilding
+			TRB.Functions.Character:ResetCaches()
+			TRB.Data.cache.colors.border = {}
+			TRB.Data.cache.colors.backdrop = {}
+			-- Destroy and recreate bar groups to add/remove secondary bar
+			TRB.Functions.Bar:DestroyBarGroups()
+			TRB.Functions.BarVisibility:MarkDirty()
+			TRB.Frames.barGroups = TRB.Classes.Druid.BarGroupsFactory:CreateForSpec(TRB.Data.character.specId)
+			local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
+			TRB.Functions.Bar:ConstructBarGroups(settings, TRB.Frames.barGroups)
+			if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
+				TRB.Functions.Class:TriggerResourceBarUpdates()
+			end
+			TRB.Functions.Character:ResetColorCaches()
+			TRB.Data.cache.values.frame = {}
 		end
 	end)
 end

--- a/Classes/Bar.lua
+++ b/Classes/Bar.lua
@@ -262,6 +262,13 @@ function TRB.Classes.BarNode:SetTextures(resourceTexture, borderTexture, backgro
 	}
 	self.frame:ApplyBackdrop()
 
+	-- ApplyBackdrop resets border/background colors to white, and SetStatusBarTexture may
+	-- reset the fill vertex color. Invalidate color caches so the next SetColor/SetBorderColor/
+	-- SetBackgroundColor calls aren't skipped as no-ops.
+	TRB.Data.cache.colors.bar[self.name .. "_resource"] = nil
+	TRB.Data.cache.colors.border[self.name .. "_border"] = nil
+	TRB.Data.cache.colors.backdrop[self.name .. "_background"] = nil
+
 	-- Re-anchor all overlay slots (border insets and fill texture reference may have changed)
 	for _, slot in pairs(self.overlaySlots) do
 		slot:Reanchor()

--- a/Functions/Bar.lua
+++ b/Functions/Bar.lua
@@ -575,10 +575,11 @@ function TRB.Functions.Bar:ApplyBarGroupsLayout(settings, barGroups)
 	local frameLevels = TRB.Data.constants.frameLevels
 
 	-- ========================
-	-- DRUID SPECIAL CASE: Non-Feral Druids ALWAYS use Feral's combo point settings
+	-- DRUID SPECIAL CASE: Non-Feral Druids use Feral's combo point settings
 	-- for layout purposes (anchor, dimensions, textures, colors). This must happen
 	-- BEFORE building the anchor forest so the correct anchor config (e.g.,
 	-- barKey="screen" for CDM binding) is used for tree construction.
+	-- Triggers when form switching OR showComboPoints is enabled.
 	-- ========================
 	local layoutSettings = settings
 	if TRB.Data.character.classId == 11 and TRB.Data.character.specId ~= 2 and barGroups.secondary then
@@ -588,8 +589,9 @@ function TRB.Functions.Bar:ApplyBarGroupsLayout(settings, barGroups)
 		if druidSettings and druidSettings.displayBar and druidSettings.displayBar.enableFormSwitching == false then
 			enableFormSwitching = false
 		end
+		local showComboPoints = druidSettings and druidSettings.displayBar and druidSettings.displayBar.showComboPoints
 
-		if enableFormSwitching then
+		if enableFormSwitching or showComboPoints then
 			local feralSettings = TRB.Data.specCache and TRB.Data.specCache.druid_feral and TRB.Data.specCache.druid_feral.settings
 			if not feralSettings then
 				feralSettings = TRB.Data.settings.druid and TRB.Data.settings.druid.feral
@@ -1118,7 +1120,7 @@ function TRB.Functions.Bar:RefreshWrapperPositioning()
 
 	local editModeLayoutEnabled = TRB.Functions.EditMode:IsLayoutEnabled()
 
-	-- DRUID SPECIAL CASE: Non-Feral Druids ALWAYS use Feral's comboPoints for forest building
+	-- DRUID SPECIAL CASE: Non-Feral Druids use Feral's comboPoints for forest building
 	local layoutSettings = settings
 	if TRB.Data.character.classId == 11 and TRB.Data.character.specId ~= 2 and barGroups.secondary then
 		local specName = TRB.Data.character.specName
@@ -1127,7 +1129,8 @@ function TRB.Functions.Bar:RefreshWrapperPositioning()
 		if druidSettings and druidSettings.displayBar and druidSettings.displayBar.enableFormSwitching == false then
 			enableFormSwitching = false
 		end
-		if enableFormSwitching then
+		local showComboPoints = druidSettings and druidSettings.displayBar and druidSettings.displayBar.showComboPoints
+		if enableFormSwitching or showComboPoints then
 			local feralSettings = TRB.Data.specCache and TRB.Data.specCache.druid_feral and TRB.Data.specCache.druid_feral.settings
 			if not feralSettings then
 				feralSettings = TRB.Data.settings.druid and TRB.Data.settings.druid.feral

--- a/Functions/Bar.lua
+++ b/Functions/Bar.lua
@@ -913,18 +913,18 @@ function TRB.Functions.Bar:ApplyBarGroupsLayout(settings, barGroups)
 	-- Configure health bar group (apply appearance immediately to ensure textures are set)
 	if barGroups.health and settings.healthBar then
 		-- Resolve anchor group for health bar from settings
-		local healthAnchor = self:GetBarAnchor(settings, "health")
+		local healthAnchor = self:GetBarAnchor(layoutSettings, "health")
 		local healthAnchorKey = (healthAnchor and healthAnchor.barKey) or "primary"
 		local healthAnchorGroup
 		if healthAnchorKey ~= "screen" then
 			healthAnchorGroup = barGroups[healthAnchorKey] or barGroups.primary
 		end
 		-- healthAnchorGroup may be nil if barKey="screen"; ConstructAnchoredBarGroup handles this
-		self:ConstructHealthBarGroup(settings, healthAnchorGroup, barGroups.health, true)
+		self:ConstructHealthBarGroup(layoutSettings, healthAnchorGroup, barGroups.health, true)
 	end
 
 	-- Configure custom bar groups from the registry (stagger, defensives, mana, etc.)
-	self:ApplyCustomBarGroupsLayout(settings, barGroups)
+	self:ApplyCustomBarGroupsLayout(layoutSettings, barGroups)
 
 	-- Apply per-bar smooth animation settings from displayBar
 	if settings.displayBar then
@@ -1928,7 +1928,14 @@ end
 function TRB.Functions.Bar:GetAllBarKeysFromSettings(settings)
 	local keys = {}
 	if settings.bar then table.insert(keys, "primary") end
-	if settings.comboPoints then table.insert(keys, "secondary") end
+	if settings.comboPoints then
+		table.insert(keys, "secondary")
+	elseif settings.displayBar and settings.displayBar.enableFormSwitching ~= nil then
+		-- Druid: non-Feral specs don't have comboPoints in their settings (they inherit
+		-- Feral's at runtime), but "secondary" must still be available as an anchor target
+		-- so users can anchor other bars to combo points.
+		table.insert(keys, "secondary")
+	end
 	if settings.healthBar then table.insert(keys, "health") end
 
 	-- Custom bars from BarTypeRegistry that have settings

--- a/Functions/Character.lua
+++ b/Functions/Character.lua
@@ -1038,9 +1038,12 @@ function TRB.Functions.Character:FillSpecializationCacheSettings(className, spec
 		end
 		
 		-- Override with spec-specific custom bar visibility settings
-		-- These are always spec-specific (mana, stagger, defensives, etc.)
+		-- These are always spec-specific (mana, stagger, defensives, secondary/combo points, etc.)
 		if spec.displayBar and spec.displayBar.mana ~= nil then
 			specCache.settings.displayBar.mana = spec.displayBar.mana
+		end
+		if spec.displayBar and spec.displayBar.secondary ~= nil then
+			specCache.settings.displayBar.secondary = spec.displayBar.secondary
 		end
 		if spec.displayBar and spec.displayBar.stagger ~= nil then
 			specCache.settings.displayBar.stagger = spec.displayBar.stagger
@@ -1052,6 +1055,9 @@ function TRB.Functions.Character:FillSpecializationCacheSettings(className, spec
 		if spec.displayBar then
 			if spec.displayBar.enableFormSwitching ~= nil then
 				specCache.settings.displayBar.enableFormSwitching = spec.displayBar.enableFormSwitching
+			end
+			if spec.displayBar.showComboPoints ~= nil then
+				specCache.settings.displayBar.showComboPoints = spec.displayBar.showComboPoints
 			end
 		end
 	else

--- a/Functions/EditMode.lua
+++ b/Functions/EditMode.lua
@@ -285,8 +285,46 @@ function TRB.Functions.EditMode:RefreshDruidWrapperVisibility(settings, forest)
 	end
 
 	local currentForm = TRB.Data.character.currentShapeshiftForm or "humanoid"
-	local shouldShowSecondary = (currentForm == "cat")
-	local shouldShowMana = (currentForm == "moonkin" and TRB.Data.character.specId == 1)
+	local specId = TRB.Data.character.specId
+
+	-- Determine displaySpecId (mirrors GetFormSpecForSettings in Druid.lua)
+	local enableFormSwitching = true
+	if settings and settings.displayBar and settings.displayBar.enableFormSwitching == false then
+		enableFormSwitching = false
+	end
+	local displaySpecId = specId
+	if enableFormSwitching then
+		if currentForm == "cat" then displaySpecId = 2
+		elseif currentForm == "bear" then displaySpecId = 3
+		elseif currentForm == "moonkin" then
+			displaySpecId = (specId == 1) and 1 or 4
+		else displaySpecId = 4 end
+	end
+
+	-- Secondary (Combo Points): In cat form (displaySpecId == 2), CPs are the native resource
+	-- and always show. In non-cat forms, the showComboPoints checkbox controls visibility
+	-- (defaults ON for Feral, OFF for non-Feral).
+	local shouldShowSecondary
+	local secondaryVis = settings and settings.displayBar and settings.displayBar.secondary
+	local secondaryNotNever = not secondaryVis or secondaryVis.visibility ~= "never"
+	if displaySpecId == 2 then
+		-- Cat form (or Feral with form-switching off): CPs are native, always eligible
+		shouldShowSecondary = secondaryNotNever
+	elseif specId == 2 then
+		-- Feral in non-cat form: checkbox defaults ON (nil → show)
+		local showCP = settings and settings.displayBar and settings.displayBar.showComboPoints
+		shouldShowSecondary = (showCP ~= false) and secondaryNotNever
+	else
+		-- Non-Feral in non-cat form: checkbox defaults OFF (nil → hide)
+		local showCP = settings and settings.displayBar and settings.displayBar.showComboPoints
+		shouldShowSecondary = (showCP == true) and secondaryNotNever
+	end
+
+	-- Mana bar: eligible when specId == 1 (Balance) and displaySpecId == 1 (primary shows Astral Power,
+	-- not Mana). This matches HideResourceBar, UpdateResourceBar, and GetBarTextFrame.
+	-- When form switching is OFF, displaySpecId == specId == 1, so mana wrapper always shows.
+	-- When form switching is ON, only moonkin gives displaySpecId == 1.
+	local shouldShowMana = (specId == 1 and displaySpecId == 1)
 
 	-- Check if secondary is its own tree root (has a wrapper)
 	local secondaryWrapper = editModeWrapperFrames["secondary"]
@@ -377,10 +415,45 @@ function TRB.Functions.EditMode:CalculateWrapperLayout(settings, includeHidden, 
 	local treeSettings = settings
 	if TRB.Data.character.classId == 11 and not includeHidden then
 		local currentForm = TRB.Data.character.currentShapeshiftForm or "humanoid"
-		local shouldIncludeComboPoints = (currentForm == "cat")
-		local shouldIncludeMana = (currentForm == "moonkin" and TRB.Data.character.specId == 1)
+		local specId = TRB.Data.character.specId
 
-		local isNonFeralDruid = (TRB.Data.character.specId ~= 2)
+		-- Compute displaySpecId (mirrors GetFormSpecForSettings / RefreshDruidWrapperVisibility)
+		local enableFormSwitching = true
+		if settings.displayBar and settings.displayBar.enableFormSwitching == false then
+			enableFormSwitching = false
+		end
+		local displaySpecId = specId
+		if enableFormSwitching then
+			if currentForm == "cat" then displaySpecId = 2
+			elseif currentForm == "bear" then displaySpecId = 3
+			elseif currentForm == "moonkin" then
+				displaySpecId = (specId == 1) and 1 or 4
+			else displaySpecId = 4 end
+		end
+
+		-- Secondary (Combo Points): In cat form (displaySpecId == 2), CPs are the native resource
+		-- and always show. In non-cat forms, the showComboPoints checkbox controls visibility
+		-- (defaults ON for Feral, OFF for non-Feral).
+		local shouldIncludeComboPoints
+		local secondaryVis = settings.displayBar and settings.displayBar.secondary
+		local secondaryNotNever = not secondaryVis or secondaryVis.visibility ~= "never"
+		if displaySpecId == 2 then
+			-- Cat form (or Feral with form-switching off): CPs are native, always eligible
+			shouldIncludeComboPoints = secondaryNotNever
+		elseif specId == 2 then
+			-- Feral in non-cat form: checkbox defaults ON (nil → show)
+			local showCP = settings.displayBar and settings.displayBar.showComboPoints
+			shouldIncludeComboPoints = (showCP ~= false) and secondaryNotNever
+		else
+			-- Non-Feral in non-cat form: checkbox defaults OFF (nil → hide)
+			local showCP = settings.displayBar and settings.displayBar.showComboPoints
+			shouldIncludeComboPoints = (showCP == true) and secondaryNotNever
+		end
+
+		-- Mana bar: eligible when Balance (specId==1) and displaySpecId==1
+		local shouldIncludeMana = (specId == 1 and displaySpecId == 1)
+
+		local isNonFeralDruid = (specId ~= 2)
 		local feralSettings = TRB.Data.specCache and TRB.Data.specCache.druid_feral and TRB.Data.specCache.druid_feral.settings
 
 		-- Determine which tree "secondary" belongs to, so we only inject/strip when
@@ -757,7 +830,8 @@ function TRB.Functions.EditMode:RegisterAllTreeRoots()
 		if druidSettings and druidSettings.displayBar and druidSettings.displayBar.enableFormSwitching == false then
 			enableFormSwitching = false
 		end
-		if enableFormSwitching then
+		local showComboPoints = druidSettings and druidSettings.displayBar and druidSettings.displayBar.showComboPoints
+		if enableFormSwitching or showComboPoints then
 			local feralSettings = TRB.Data.specCache and TRB.Data.specCache.druid_feral and TRB.Data.specCache.druid_feral.settings
 			if not feralSettings then
 				feralSettings = TRB.Data.settings.druid and TRB.Data.settings.druid.feral

--- a/Functions/News.lua
+++ b/Functions/News.lua
@@ -12,6 +12,14 @@ local content = [====[
 
 ---
 
+# 12.0.1.26-release (2026-03-06)
+## Druid
+
+- [#560](#560) Allow Combo Points to be shown in all shapeshift forms instead of just Cat Form. This is controlled by a new checkbox option in the Druid options.
+- [#560](#560) Added a per-specialization visibility option for Combo Points.
+
+---
+
 # 12.0.1.25-release (2026-03-05)
 ## General
 ### Behind the Scenes

--- a/Functions/News.lua
+++ b/Functions/News.lua
@@ -17,6 +17,7 @@ local content = [====[
 
 - [#560](#560) Allow Combo Points to be shown in all shapeshift forms instead of just Cat Form. This is controlled by a new checkbox option in the Druid options.
 - [#560](#560) Added a per-specialization visibility option for Combo Points.
+- [#677](#677) Fix an issue where Combo Points were appearing when they shouldn't be and without the correct colors/textures.
 
 ---
 

--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -2106,3 +2106,7 @@ L["PriestBarTextNameAFCharge1"] = "AF Charge 1"
 L["PriestBarTextNameAFCharge2"] = "AF Charge 2"
 L["PriestBarTextNameAFCharge3"] = "AF Charge 3"
 L["ResourceAngelicFeather"] = "Angelic Feather"
+
+-- Druid Combo Points outside Cat Form
+L["DruidCheckboxShowComboPoints"] = "Show Combo Points in every shapeshift form"
+L["DruidCheckboxShowComboPointsTooltip"] = "When checked, the Combo Points bar will be displayed regardless of current shapeshift form. When unchecked, the Combo Points bar will only be shown in Cat Form. The Combo Points visibility dropdown above will still control when the Combo Points bar appears in general."

--- a/Options/OptionsUi.lua
+++ b/Options/OptionsUi.lua
@@ -4752,7 +4752,10 @@ function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spe
 				end
 			else
 				if classId ~= nil and specId ~= nil then
-					if isMana and TRB.Data.specCache[TRB.Data.character.compositeKey] and TRB.Data.specCache[TRB.Data.character.compositeKey].settings and TRB.Data.specCache[TRB.Data.character.compositeKey].settings.displayBar then
+					-- Also update specCache directly: when global displayBar is active,
+					-- specCache.settings.displayBar is a deep copy of core.displayBar,
+					-- so the spec.displayBar update above doesn't flow through.
+					if TRB.Data.specCache[TRB.Data.character.compositeKey] and TRB.Data.specCache[TRB.Data.character.compositeKey].settings and TRB.Data.specCache[TRB.Data.character.compositeKey].settings.displayBar and TRB.Data.specCache[TRB.Data.character.compositeKey].settings.displayBar[displayBarKey] then
 						TRB.Data.specCache[TRB.Data.character.compositeKey].settings.displayBar[displayBarKey].visibility = newValue
 					end
 					if TRB.Functions.OptionsUi:IsEditingActiveSpec(classId, specId) then

--- a/Options/OptionsUi.lua
+++ b/Options/OptionsUi.lua
@@ -4752,13 +4752,13 @@ function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spe
 				end
 			else
 				if classId ~= nil and specId ~= nil then
-					-- Also update specCache directly: when global displayBar is active,
-					-- specCache.settings.displayBar is a deep copy of core.displayBar,
-					-- so the spec.displayBar update above doesn't flow through.
-					if TRB.Data.specCache[TRB.Data.character.compositeKey] and TRB.Data.specCache[TRB.Data.character.compositeKey].settings and TRB.Data.specCache[TRB.Data.character.compositeKey].settings.displayBar and TRB.Data.specCache[TRB.Data.character.compositeKey].settings.displayBar[displayBarKey] then
-						TRB.Data.specCache[TRB.Data.character.compositeKey].settings.displayBar[displayBarKey].visibility = newValue
-					end
 					if TRB.Functions.OptionsUi:IsEditingActiveSpec(classId, specId) then
+						-- Also update specCache directly: when global displayBar is active,
+						-- specCache.settings.displayBar is a deep copy of core.displayBar,
+						-- so the spec.displayBar update above doesn't flow through.
+						if TRB.Data.specCache[TRB.Data.character.compositeKey] and TRB.Data.specCache[TRB.Data.character.compositeKey].settings and TRB.Data.specCache[TRB.Data.character.compositeKey].settings.displayBar and TRB.Data.specCache[TRB.Data.character.compositeKey].settings.displayBar[displayBarKey] then
+							TRB.Data.specCache[TRB.Data.character.compositeKey].settings.displayBar[displayBarKey].visibility = newValue
+						end
 						if TRB.Frames.barGroups ~= nil then
 							TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
 							TRB.Functions.EditMode:UpdateWrapperSize(TRB.Data.specCache[TRB.Data.character.compositeKey].settings)


### PR DESCRIPTION
Adds a per-specialization option for Druids to display Combo Points outside of Cat Form. Previously, Combo Points were only visible when in Cat Form (or when Feral with form switching disabled). Now each Druid spec has an independent "Show Combo Points in every shapeshift form" checkbox.

## New Feature

- **Show Combo Points checkbox** added to the Bar Visibility panel for all four Druid specs (Balance, Feral, Guardian, Restoration).
- Feral defaults to **on** (preserving existing behavior); all other specs default to **off**.
- Combo Points are rendered using Feral's color/texture settings when displayed by a non-Feral spec, consistent with how form switching already works.
- The existing Combo Points visibility dropdown (`always` / `combat` / `never`) still applies on top of the new checkbox.

## Bug Fixes

- **#677**: Fixed Combo Points appearing unexpectedly with incorrect colors/textures in certain form-switching scenarios.
- Fixed the Balance Druid mana bar rendering when form-switched into Restoration (moonkin → caster): the dedicated mana bar now correctly hides when the primary bar is already showing Mana.
- Fixed health and mana bar groups not being explicitly hidden when their visibility conditions aren't met, preventing stale frames from lingering after form switches.

## Infrastructure Changes

- `BarNode:SetTextures` now invalidates the color cache for its resource, border, and background entries so re-applied textures pick up correct colors immediately.
- `BarVisibility:MarkDirty()` is called on shapeshift form changes and when toggling form-switching or combo point checkboxes in options, ensuring visibility is re-evaluated promptly.
- `GenerateBarDisplayOptions` visibility dropdown now also updates `specCache.settings.displayBar` directly when the global displayBar is active, fixing a stale-cache issue where dropdown changes weren't reflected at runtime.
- Edit Mode wrapper visibility and layout calculations now respect the `showComboPoints` setting and correctly mirror the runtime `displaySpecId` logic for all forms.
- `GetAllBarKeysFromSettings` now includes `"secondary"` as a valid anchor target for Druid specs with `enableFormSwitching`, even when the spec's own settings don't define `comboPoints`.
- `FillSpecializationCacheSettings` now preserves spec-specific `secondary` and `showComboPoints` display bar overrides into the composite specCache.