### PR TITLE
Performance: Non-bar-text runtime optimizations (hot-path GC pressure, dead code, memoization)

### DIFF
--- a/ClassModules/DeathKnight.lua
+++ b/ClassModules/DeathKnight.lua
@@ -10,6 +10,7 @@ local Threshold = TRB.Functions.Threshold
 local Bar = TRB.Functions.Bar
 local Color = TRB.Functions.Color
 local Character = TRB.Functions.Character
+local frameLevels = TRB.Data.constants.frameLevels
 
 local targetsTimerFrame = TRB.Frames.targetsTimerFrame
 

--- a/ClassModules/DeathKnight.lua
+++ b/ClassModules/DeathKnight.lua
@@ -6,6 +6,10 @@ end
 local L = TRB.Localization
 TRB.Functions.Class = TRB.Functions.Class or {}
 local lookupChanged = TRB.Functions.BarText.LookupChanged
+local Threshold = TRB.Functions.Threshold
+local Bar = TRB.Functions.Bar
+local Color = TRB.Functions.Color
+local Character = TRB.Functions.Character
 
 local targetsTimerFrame = TRB.Frames.targetsTimerFrame
 
@@ -189,12 +193,12 @@ local function FillSpecializationCache()
 end
 
 local function Setup_Blood()
-	TRB.Functions.Character:FillSpecializationCacheSettings("deathknight", "blood", true)
+	Character:FillSpecializationCacheSettings("deathknight", "blood", true)
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	-- (guards against redundant delayed SwitchSpec calls that would orphan initialized bars)
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "deathknight_blood" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.DeathKnight.BarGroupsFactory:CreateForSpec(1, UIParent)
 	end
 end
@@ -208,11 +212,11 @@ local function FillSpellData_Blood()
 end
 
 local function Setup_Frost()
-	TRB.Functions.Character:FillSpecializationCacheSettings("deathknight", "frost")
+	Character:FillSpecializationCacheSettings("deathknight", "frost")
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "deathknight_frost" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.DeathKnight.BarGroupsFactory:CreateForSpec(2, UIParent)
 	end
 end
@@ -226,11 +230,11 @@ local function FillSpellData_Frost()
 end
 
 local function Setup_Unholy()
-	TRB.Functions.Character:FillSpecializationCacheSettings("deathknight", "unholy")
+	Character:FillSpecializationCacheSettings("deathknight", "unholy")
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "deathknight_unholy" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.DeathKnight.BarGroupsFactory:CreateForSpec(3, UIParent)
 	end
 end
@@ -292,12 +296,12 @@ local function ConstructResourceBar(settings)
 			primaryNode:ClearThresholds()
 			for _ = 1, #TRB.Data.cache.thresholdSpells do
 				local thresholdFrame = CreateFrame("Frame", nil, primaryNode:GetFrame())
-				TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, settings, true)
+				Threshold:ResetThresholdLine(thresholdFrame, settings, true)
 				primaryNode:RegisterThreshold(thresholdFrame)
 			end
 		end
 
-		TRB.Functions.Bar:ConstructBarGroups(settings, barGroups)
+		Bar:ConstructBarGroups(settings, barGroups)
 	end
 
 	-- Death Knight always uses the secondary bar for runes (always 6)
@@ -343,7 +347,7 @@ local function RefreshLookupData_Blood()
 		if lookupChanged(prevState, "$runicPower", resourceAbbrevFormatted, currentRunicPowerColor) then
 			local rp
 			if sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentRunicPowerColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentRunicPowerColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				rp = textColorResult:WrapTextInColorCode(resourceAbbrevFormatted)
 			else
@@ -413,7 +417,7 @@ local function RefreshLookupData_Frost()
 		if lookupChanged(prevState, "$runicPower", resourceAbbrevFormatted, currentRunicPowerColor) then
 			local rp
 			if sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentRunicPowerColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentRunicPowerColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				rp = textColorResult:WrapTextInColorCode(resourceAbbrevFormatted)
 			else
@@ -483,7 +487,7 @@ local function RefreshLookupData_Unholy()
 		if lookupChanged(prevState, "$runicPower", resourceAbbrevFormatted, currentRunicPowerColor) then
 			local rp
 			if sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentRunicPowerColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentRunicPowerColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				rp = textColorResult:WrapTextInColorCode(resourceAbbrevFormatted)
 			else
@@ -575,7 +579,7 @@ function TRB.Functions.Class:SpellCast(event, spellId)
 end
 
 local function UpdateSnapshot()
-	TRB.Functions.Character:UpdateSnapshot()
+	Character:UpdateSnapshot()
 	--local currentTime = GetTime()
 
 	for x = 1, TRB.Data.character.maxResource2 do
@@ -616,7 +620,7 @@ end
 ---@param specSettings table
 ---@param specCacheSettings TRB.Classes.Settings.SpecializationSettingsBase
 local function UpdateRunes(specSettings, specCacheSettings)
-	local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
+	local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
 
 	local runes = TRB.Data.character.runes
 	local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]
@@ -652,7 +656,7 @@ local function UpdateRunes(specSettings, specCacheSettings)
 		if barGroups and barGroups.secondary then
 			local runeNode = barGroups.secondary:GetNode(x)
 			if runeNode then
-				TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "rune" .. x, runeNode, rune.percentage, 1)
+				Bar:SetBarNodeValue(specCacheSettings, "rune" .. x, runeNode, rune.percentage, 1)
 				runeNode:SetBorderColor(cpBorderColor)
 				runeNode:SetColor(cpColor)
 				runeNode:SetBackgroundColor(cpBR, cpBG, cpBB, cpBackgroundAlpha)
@@ -670,7 +674,7 @@ local function UpdateResourceBar()
 
 	-- Always call HideResourceBar first to ensure visibility is correctly determined
 	-- even if we return early due to missing data
-	TRB.Functions.Bar:HideResourceBar()
+	Bar:HideResourceBar()
 
 	if not (barGroups and barGroups.primary) then
 		return
@@ -705,7 +709,7 @@ local function UpdateResourceBar()
 
 				-- Apply overcap border color if enabled
 				if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
-					local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+					local overcapBorderCurve = Color:BuildResourceThresholdCurve(specSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 					local borderColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapBorderCurve)
 					primaryNode:SetBorderColorCurve(borderColorResult)
 				else
@@ -717,7 +721,7 @@ local function UpdateResourceBar()
 					maxPrimaryBarResourceUnnormalized = math.min(specCacheSettings.maxResource.value, maxPrimaryBarResourceUnnormalized)
 				end
 
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
@@ -727,7 +731,7 @@ local function UpdateResourceBar()
 					local thresholds = primaryNode:GetThresholds()
 					if thresholds[thresholdId] == nil then
 						local thresholdFrame = CreateFrame("Frame", nil, primaryResourceFrame)
-						TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
+						Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
 						primaryNode:RegisterThreshold(thresholdFrame)
 						thresholds = primaryNode:GetThresholds()
 					end
@@ -737,7 +741,7 @@ local function UpdateResourceBar()
 					local isUsable = spell:IsUsable()
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
-					local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+					local frameLevel = frameLevels.thresholdOver
 					local snapshot = snapshots[spell.id]
 
 					if spell.isSnowflake then
@@ -750,19 +754,19 @@ local function UpdateResourceBar()
 					elseif spell.hasCooldown then
 						if snapshotData.snapshots[spell.id].cooldown:IsUnusable() then
 							thresholdColor = specCacheSettings.colors.threshold.unusable.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+							frameLevel = frameLevels.thresholdUnusable
 						elseif isUsable then
 							thresholdColor = specCacheSettings.colors.threshold.over.color
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					else
 						if isUsable then
 							thresholdColor = specCacheSettings.colors.threshold.over.color
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					end
 
@@ -771,10 +775,10 @@ local function UpdateResourceBar()
 					end
 
 					local thresholdFrame = thresholds[thresholdId]
-					local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholdFrame, showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-					TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholdFrame, showThreshold and isDrawn, primaryResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
+					local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholdFrame, showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+					Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholdFrame, showThreshold and isDrawn, primaryResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
 				end
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			if specSettings.displayBar.secondary.visibility ~= "never" then
@@ -792,7 +796,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -810,7 +814,7 @@ local function UpdateResourceBar()
 
 				-- Apply overcap border color if enabled
 				if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
-					local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+					local overcapBorderCurve = Color:BuildResourceThresholdCurve(specSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 					local borderColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapBorderCurve)
 					primaryNode:SetBorderColorCurve(borderColorResult)
 				else
@@ -822,7 +826,7 @@ local function UpdateResourceBar()
 					maxPrimaryBarResourceUnnormalized = math.min(specCacheSettings.maxResource.value, maxPrimaryBarResourceUnnormalized)
 				end
 
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
@@ -832,7 +836,7 @@ local function UpdateResourceBar()
 					local thresholds = primaryNode:GetThresholds()
 					if thresholds[thresholdId] == nil then
 						local thresholdFrame = CreateFrame("Frame", nil, primaryResourceFrame)
-						TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
+						Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
 						primaryNode:RegisterThreshold(thresholdFrame)
 						thresholds = primaryNode:GetThresholds()
 					end
@@ -842,7 +846,7 @@ local function UpdateResourceBar()
 					local isUsable = spell:IsUsable()
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
-					local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+					local frameLevel = frameLevels.thresholdOver
 					local snapshot = snapshots[spell.id]
 
 					if spell.isSnowflake then
@@ -855,19 +859,19 @@ local function UpdateResourceBar()
 					elseif spell.hasCooldown then
 						if snapshotData.snapshots[spell.id].cooldown:IsUnusable() then
 							thresholdColor = specCacheSettings.colors.threshold.unusable.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+							frameLevel = frameLevels.thresholdUnusable
 						elseif isUsable then
 							thresholdColor = specCacheSettings.colors.threshold.over.color
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					else
 						if isUsable then
 							thresholdColor = specCacheSettings.colors.threshold.over.color
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					end
 
@@ -876,10 +880,10 @@ local function UpdateResourceBar()
 					end
 
 					local thresholdFrame = thresholds[thresholdId]
-					local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholdFrame, showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-					TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholdFrame, showThreshold and isDrawn, primaryResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
+					local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholdFrame, showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+					Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholdFrame, showThreshold and isDrawn, primaryResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
 				end
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			if specSettings.displayBar.secondary.visibility ~= "never" then
@@ -897,7 +901,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -915,7 +919,7 @@ local function UpdateResourceBar()
 
 				-- Apply overcap border color if enabled
 				if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
-					local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+					local overcapBorderCurve = Color:BuildResourceThresholdCurve(specSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 					local borderColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapBorderCurve)
 					primaryNode:SetBorderColorCurve(borderColorResult)
 				else
@@ -927,7 +931,7 @@ local function UpdateResourceBar()
 					maxPrimaryBarResourceUnnormalized = math.min(specCacheSettings.maxResource.value, maxPrimaryBarResourceUnnormalized)
 				end
 
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
@@ -937,7 +941,7 @@ local function UpdateResourceBar()
 					local thresholds = primaryNode:GetThresholds()
 					if thresholds[thresholdId] == nil then
 						local thresholdFrame = CreateFrame("Frame", nil, primaryResourceFrame)
-						TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
+						Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
 						primaryNode:RegisterThreshold(thresholdFrame)
 						thresholds = primaryNode:GetThresholds()
 					end
@@ -947,7 +951,7 @@ local function UpdateResourceBar()
 					local isUsable = spell:IsUsable()
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
-					local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+					local frameLevel = frameLevels.thresholdOver
 					local snapshot = snapshots[spell.id]
 
 					if spell.isSnowflake then
@@ -960,19 +964,19 @@ local function UpdateResourceBar()
 					elseif spell.hasCooldown then
 						if snapshotData.snapshots[spell.id].cooldown:IsUnusable() then
 							thresholdColor = specCacheSettings.colors.threshold.unusable.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+							frameLevel = frameLevels.thresholdUnusable
 						elseif isUsable then
 							thresholdColor = specCacheSettings.colors.threshold.over.color
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					else
 						if isUsable then
 							thresholdColor = specCacheSettings.colors.threshold.over.color
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					end
 
@@ -981,10 +985,10 @@ local function UpdateResourceBar()
 					end
 
 					local thresholdFrame = thresholds[thresholdId]
-					local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholdFrame, showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-					TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholdFrame, showThreshold and isDrawn, primaryResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
+					local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholdFrame, showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+					Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholdFrame, showThreshold and isDrawn, primaryResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
 				end
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			if specSettings.displayBar.secondary.visibility ~= "never" then
@@ -1002,7 +1006,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1022,17 +1026,17 @@ local function SwitchSpec()
 	TRB.Data.prevLookupState = {}
 	TRB.Data.lookupDirty = true
 	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+		Bar:QueueRenderTransition("switchSpec", 0.8)
 	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 	end
-	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
+	Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 	
 	if TRB.Data.character.specId == 1 then
 		specCache.deathknight_blood.talents:GetTalents()
 		FillSpellData_Blood()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.deathknight_blood)
+		Character:LoadFromSpecializationCache(specCache.deathknight_blood)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.DeathKnight.BloodSpells]]
@@ -1040,7 +1044,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Blood
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.deathknight_blood.settings)
+		Bar:UpdateSanityCheckValues(specCache.deathknight_blood.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		TRB.Data.lookup = lookup
@@ -1054,7 +1058,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 2 then
 		specCache.deathknight_frost.talents:GetTalents()
 		FillSpellData_Frost()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.deathknight_frost)
+		Character:LoadFromSpecializationCache(specCache.deathknight_frost)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.DeathKnight.FrostSpells]]
@@ -1062,7 +1066,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Frost
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.deathknight_frost.settings)
+		Bar:UpdateSanityCheckValues(specCache.deathknight_frost.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		TRB.Data.lookup = lookup
@@ -1076,7 +1080,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 3 then
 		specCache.deathknight_unholy.talents:GetTalents()
 		FillSpellData_Unholy()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.deathknight_unholy)
+		Character:LoadFromSpecializationCache(specCache.deathknight_unholy)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.DeathKnight.UnholySpells]]
@@ -1084,7 +1088,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Unholy
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.deathknight_unholy.settings)
+		Bar:UpdateSanityCheckValues(specCache.deathknight_unholy.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		TRB.Data.lookup = lookup
@@ -1109,9 +1113,9 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				TRB.Functions.Character:ResetCaches()
+				Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
-				TRB.Functions.Character:UpdateHealthValues()
+				Character:UpdateHealthValues()
 				TRB.Functions.Class:TriggerResourceBarUpdates()
 			end
 		end)
@@ -1239,9 +1243,9 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
 				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+					Bar:QueueRenderTransition("eventPreSwitch", 0.8)
 				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-					TRB.Functions.Bar:HideResourceBar(true)
+					Bar:HideResourceBar(true)
 				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
@@ -1258,7 +1262,7 @@ function TRB.Functions.Class:CheckCharacter()
 	if specId ~= TRB.Data.character.specId then
 		SwitchSpec()
 	end
-	TRB.Functions.Character:CheckCharacter()
+	Character:CheckCharacter()
 	TRB.Data.character.className = "deathknight"
 	TRB.Data.character.maxResource = UnitPowerMax("player", Enum.PowerType.RunicPower, true)
 	TRB.Data.character.maxResourceUnmodified = UnitPowerMax("player", Enum.PowerType.RunicPower, false)
@@ -1309,7 +1313,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.specSupported = false
 	end
 
-	TRB.Functions.Character:EventRegistration()
+	Character:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
@@ -1446,8 +1450,8 @@ function TRB.Functions.Class:HasActiveTimers()
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
-	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
-		TRB.Functions.Bar:HideResourceBar(true)
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and Bar:IsRenderTransitionActive() then
+		Bar:HideResourceBar(true)
 		return
 	end
 
@@ -1455,7 +1459,7 @@ function TRB.Functions.Class:TriggerResourceBarUpdates()
 		return
 	end
 	if (TRB.Data.character.specId ~= 1 and TRB.Data.character.specId ~= 2 and TRB.Data.character.specId ~= 3) then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 		return
 	end
 

--- a/ClassModules/DemonHunter.lua
+++ b/ClassModules/DemonHunter.lua
@@ -6,6 +6,11 @@ end
 local L = TRB.Localization
 TRB.Functions.Class = TRB.Functions.Class or {}
 local lookupChanged = TRB.Functions.BarText.LookupChanged
+local Threshold = TRB.Functions.Threshold
+local Bar = TRB.Functions.Bar
+local Color = TRB.Functions.Color
+local Character = TRB.Functions.Character
+local frameLevels = TRB.Data.constants.frameLevels
 
 local targetsTimerFrame = TRB.Frames.targetsTimerFrame
 
@@ -163,11 +168,11 @@ local function FillSpecializationCache()
 end
 
 local function Setup_Havoc()
-	TRB.Functions.Character:FillSpecializationCacheSettings("demonhunter", "havoc")
+	Character:FillSpecializationCacheSettings("demonhunter", "havoc")
 
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "demonhunter_havoc" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.DemonHunter.BarGroupsFactory:CreateForSpec(1, UIParent)
 	end
 end
@@ -181,11 +186,11 @@ local function FillSpellData_Havoc()
 end
 
 local function Setup_Vengeance()
-	TRB.Functions.Character:FillSpecializationCacheSettings("demonhunter", "vengeance")
+	Character:FillSpecializationCacheSettings("demonhunter", "vengeance")
 
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "demonhunter_vengeance" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.DemonHunter.BarGroupsFactory:CreateForSpec(2, UIParent)
 	end
 end
@@ -199,11 +204,11 @@ local function FillSpellData_Vengeance()
 end
 
 local function Setup_Devourer()
-	TRB.Functions.Character:FillSpecializationCacheSettings("demonhunter", "devourer")
+	Character:FillSpecializationCacheSettings("demonhunter", "devourer")
 
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "demonhunter_devourer" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.DemonHunter.BarGroupsFactory:CreateForSpec(3, UIParent)
 	end
 end
@@ -243,13 +248,13 @@ local function ConstructResourceBar(settings)
 			-- Create new threshold frames parented to the BarNode's resourceFrame
 			for thresholdId = 1, #TRB.Data.cache.thresholdSpells do
 				local thresholdFrame = CreateFrame("Frame", nil, primaryNode:GetFrame())
-				TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, settings, true)
+				Threshold:ResetThresholdLine(thresholdFrame, settings, true)
 				primaryNode:RegisterThreshold(thresholdFrame)
 			end
 		end
 
 		-- Construct the bar groups (sets dimensions, colors, textures, positioning)
-		TRB.Functions.Bar:ConstructBarGroups(settings, barGroups)
+		Bar:ConstructBarGroups(settings, barGroups)
 	end
 
 	-- Show/hide secondary bar based on spec (using BarGroups, not legacy frames)
@@ -263,10 +268,10 @@ local function ConstructResourceBar(settings)
 
 			barGroups.secondary:SetMaxNodes(maxSoulFragments)
 			barGroups.secondary:SetNodeCount(maxSoulFragments)
-			barGroups.secondary:SetLayout(settings.comboPoints.spacing, TRB.Functions.Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
+			barGroups.secondary:SetLayout(settings.comboPoints.spacing, Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
 			barGroups.secondary:Show()
 
-			local effectiveWidth, cdmForced = TRB.Functions.Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
+			local effectiveWidth, cdmForced = Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
 			if cdmForced then
 				barGroups.secondary.fullWidth = true
 			end
@@ -309,7 +314,7 @@ local function ConstructResourceBar(settings)
 				-- Create 1 threshold for Collapsing Star
 				sfNode:ClearThresholds()
 				local thresholdFrame = CreateFrame("Frame", nil, sfNode:GetFrame())
-				TRB.Functions.Threshold:ResetThresholdLineComboPoint(thresholdFrame, settings)
+				Threshold:ResetThresholdLineComboPoint(thresholdFrame, settings)
 				sfNode:RegisterThreshold(thresholdFrame)
 			end
 		end
@@ -317,7 +322,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	-- TRB.Functions.Bar:HideResourceBar()
+	-- Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -372,7 +377,7 @@ local function RefreshLookupData_Havoc()
 			local currentFury
 			local castingFury
 			if sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentFuryColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentFuryColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				currentFury = textColorResult:WrapTextInColorCode(resourceFormatted)
 				castingFury = textColorResult:WrapTextInColorCode(string.format("%.0f", TRB.Functions.Number:RoundTo(_castingFury, resourcePrecision, "floor")))
@@ -463,7 +468,7 @@ local function RefreshLookupData_Vengeance()
 			local currentFury
 			local castingFury
 			if sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentFuryColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentFuryColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				currentFury = textColorResult:WrapTextInColorCode(resourceFormatted)
 				castingFury = textColorResult:WrapTextInColorCode(string.format("%.0f", TRB.Functions.Number:RoundTo(_castingFury, resourcePrecision, "floor")))
@@ -574,7 +579,7 @@ local function RefreshLookupData_Devourer()
 			local currentFury
 			local castingFury
 			if sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentFuryColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentFuryColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				currentFury = textColorResult:WrapTextInColorCode(resourceFormatted)
 				castingFury = textColorResult:WrapTextInColorCode(string.format("%.0f", TRB.Functions.Number:RoundTo(_castingFury, resourcePrecision, "floor")))
@@ -889,7 +894,7 @@ local spellEventFrame = CreateFrame("Frame")
 spellEventFrame:SetScript("OnEvent", DemonHunterEvent)
 
 local function UpdateSnapshot()
-	TRB.Functions.Character:UpdateSnapshot()
+	Character:UpdateSnapshot()
 	local currentTime = GetTime()
 	local spells = TRB.Data.spellsData.spells --[[@as TRB.Classes.DemonHunter.HavocSpells|TRB.Classes.DemonHunter.VengeanceSpells|TRB.Classes.DemonHunter.DevourerSpells]]
 	local snapshotData = TRB.Data.snapshotData --[[@as TRB.Classes.SnapshotData]]
@@ -986,7 +991,7 @@ local function UpdateResourceBar()
 
 	-- Always call HideResourceBar first to ensure visibility is correctly determined
 	-- even if we return early due to missing data
-	TRB.Functions.Bar:HideResourceBar()
+	Bar:HideResourceBar()
 
 	if TRB.Data.character.maxResource == nil then
 		return
@@ -1014,7 +1019,7 @@ local function UpdateResourceBar()
 				end
 
 				if primaryNode then
-					TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+					Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 					local resourceFrame = primaryNode:GetFrame()
 					local thresholds = primaryNode:GetThresholds()
 
@@ -1025,7 +1030,7 @@ local function UpdateResourceBar()
 						local isUsable = spell:IsUsable()
 						local showThreshold = true
 						local thresholdColor = specCacheSettings.colors.threshold.over.color
-						local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+						local frameLevel = frameLevels.thresholdOver
 						local snapshot = snapshots[spell.id]
 
 						if metaTime > 0 and (spell.attributes.demonForm ~= nil and spell.attributes.demonForm == false) then
@@ -1042,17 +1047,17 @@ local function UpdateResourceBar()
 									thresholdColor = specCacheSettings.colors.threshold.over.color
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							elseif spell.id == spells.bladeDance.id or spell.id == spells.deathSweep.id then
 								if snapshots[spell.id].cooldown:IsUnusable() then
 									thresholdColor = specCacheSettings.colors.threshold.unusable.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+									frameLevel = frameLevels.thresholdUnusable
 								elseif isUsable then
 									thresholdColor = specCacheSettings.colors.threshold.over.color
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							elseif spell.id == spells.eyeBeam.id or spell.id == spells.abyssalGaze.id then
 								if spell.id == spells.eyeBeam.id and snapshotData.attributes.eyeBeamOverride then
@@ -1062,12 +1067,12 @@ local function UpdateResourceBar()
 								else
 									if snapshots[spell.id].cooldown:IsUnusable() then
 										thresholdColor = specCacheSettings.colors.threshold.unusable.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+										frameLevel = frameLevels.thresholdUnusable
 									elseif isUsable then
 										thresholdColor = specCacheSettings.colors.threshold.over.color
 									else
 										thresholdColor = specCacheSettings.colors.threshold.under.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+										frameLevel = frameLevels.thresholdUnder
 									end
 								end
 							end
@@ -1076,19 +1081,19 @@ local function UpdateResourceBar()
 						elseif spell.hasCooldown then
 							if snapshots[spell.id].cooldown:IsUnusable() then
 								thresholdColor = specCacheSettings.colors.threshold.unusable.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+								frameLevel = frameLevels.thresholdUnusable
 							elseif isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						else -- This is an active/available/normal spell threshold
 							if isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						end
 						
@@ -1097,8 +1102,8 @@ local function UpdateResourceBar()
 						end
 
 						if thresholds[thresholdId] then
-							local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-							TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, resourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
+							local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+							Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, resourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
 						end
 					end
 					
@@ -1110,7 +1115,7 @@ local function UpdateResourceBar()
 						if specSettings.endOf.metamorphosis.enabled then
 							useEndOfMetamorphosisColor = true
 							if specSettings.endOf.metamorphosis.mode == "gcd" then
-								local gcd = TRB.Functions.Character:GetCurrentGCDTime()
+								local gcd = Character:GetCurrentGCDTime()
 								timeThreshold = gcd * specSettings.endOf.metamorphosis.gcdsMax
 							elseif specSettings.endOf.metamorphosis.mode == "time" then
 								timeThreshold = specSettings.endOf.metamorphosis.timeMax
@@ -1129,7 +1134,7 @@ local function UpdateResourceBar()
 					barGroups.primary:GetContainerFrame():SetAlpha(1.0)
 					-- Apply overcap border color if enabled
 					if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
-						local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+						local overcapBorderCurve = Color:BuildResourceThresholdCurve(specSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 						local borderColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapBorderCurve)
 						primaryNode:SetBorderColorCurve(borderColorResult)
 					else
@@ -1137,7 +1142,7 @@ local function UpdateResourceBar()
 					end
 					primaryNode:SetColor(barColor)
 					primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-					TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+					Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 				end
 			end
 
@@ -1151,7 +1156,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1175,7 +1180,7 @@ local function UpdateResourceBar()
 				end
 				
 				if primaryNode then
-					TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+					Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 					local resourceFrame = primaryNode:GetFrame()
 					local thresholds = primaryNode:GetThresholds()
 
@@ -1186,7 +1191,7 @@ local function UpdateResourceBar()
 						local isUsable = spell:IsUsable()
 						local showThreshold = true
 						local thresholdColor = specCacheSettings.colors.threshold.over.color
-						local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+						local frameLevel = frameLevels.thresholdOver
 						local snapshot = snapshots[spell.id]
 						if spell.isTalent and not talents:IsTalentActive(spell) then -- Talent not selected
 							showThreshold = false
@@ -1198,7 +1203,7 @@ local function UpdateResourceBar()
 									thresholdColor = specCacheSettings.colors.threshold.over.color
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							end
 						elseif resourceAmount == 0 then
@@ -1208,14 +1213,14 @@ local function UpdateResourceBar()
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						else -- This is an active/available/normal spell threshold
 							if isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						end
 
@@ -1226,8 +1231,8 @@ local function UpdateResourceBar()
 						end
 
 						if thresholds[thresholdId] then
-							local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-							TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, resourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
+							local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+							Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, resourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
 						end
 					end
 					
@@ -1239,7 +1244,7 @@ local function UpdateResourceBar()
 						if specSettings.endOf.metamorphosis.enabled then
 							useEndOfMetamorphosisColor = true
 							if specSettings.endOf.metamorphosis.mode == "gcd" then
-								local gcd = TRB.Functions.Character:GetCurrentGCDTime()
+								local gcd = Character:GetCurrentGCDTime()
 								timeThreshold = gcd * specSettings.endOf.metamorphosis.gcdsMax
 							elseif specSettings.endOf.metamorphosis.mode == "time" then
 								timeThreshold = specSettings.endOf.metamorphosis.timeMax
@@ -1258,7 +1263,7 @@ local function UpdateResourceBar()
 					barGroups.primary:GetContainerFrame():SetAlpha(1.0)
 					-- Apply overcap border color if enabled
 					if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
-						local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+						local overcapBorderCurve = Color:BuildResourceThresholdCurve(specSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 						local borderColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapBorderCurve)
 						primaryNode:SetBorderColorCurve(borderColorResult)
 					else
@@ -1266,7 +1271,7 @@ local function UpdateResourceBar()
 					end
 					primaryNode:SetColor(barColor)
 					primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-					TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+					Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 				end
 			end
 
@@ -1277,7 +1282,7 @@ local function UpdateResourceBar()
 				local soulFragments = snapshotData.attributes.resource2 or 0
 				local maxSoulFragments = TRB.Data.character.maxResource2 or 6
 				
-				local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
+				local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
 				local cpBorderColor = specSettings.colors.comboPoints.border.color
 
 				-- Update all 6 Soul Fragment nodes with positional coloring
@@ -1287,7 +1292,7 @@ local function UpdateResourceBar()
 						if cpNode then
 							-- All nodes get the same raw secret value; each node's stepped
 							-- SetMinMax(x-1, x) handles fill via StatusBar clamping
-							TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "soulFragment" .. x, cpNode, soulFragments)
+							Bar:SetBarNodeValue(specCacheSettings, "soulFragment" .. x, cpNode, soulFragments)
 							cpNode:SetBorderColor(cpBorderColor)
 							cpNode:SetBackgroundColor(cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha)
 
@@ -1314,7 +1319,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1340,7 +1345,7 @@ local function UpdateResourceBar()
 				end
 
 				if primaryNode then
-					TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+					Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 					local resourceFrame = primaryNode:GetFrame()
 					local thresholds = primaryNode:GetThresholds()
 
@@ -1351,7 +1356,7 @@ local function UpdateResourceBar()
 						local isUsable = spell:IsUsable()
 						local showThreshold = true
 						local thresholdColor = specCacheSettings.colors.threshold.over.color
-						local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+						local frameLevel = frameLevels.thresholdOver
 						local snapshot = snapshots[spell.id]
 
 						if spell.isTalent and not talents:IsTalentActive(spell) then -- Talent not selected
@@ -1367,12 +1372,12 @@ local function UpdateResourceBar()
 									
 									if snapshotData.casting.spellId == spells.voidRay.id or snapshots[spell.id].cooldown:IsUnusable() then
 										thresholdColor = specCacheSettings.colors.threshold.unusable.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+										frameLevel = frameLevels.thresholdUnusable
 									elseif isUsable then
 										thresholdColor = specCacheSettings.colors.threshold.over.color
 									else
 										thresholdColor = specCacheSettings.colors.threshold.under.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+										frameLevel = frameLevels.thresholdUnder
 									end
 								end
 							end
@@ -1381,19 +1386,19 @@ local function UpdateResourceBar()
 						elseif spell.hasCooldown then
 							if snapshots[spell.id].cooldown:IsUnusable() then
 								thresholdColor = specCacheSettings.colors.threshold.unusable.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+								frameLevel = frameLevels.thresholdUnusable
 							elseif isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						else -- This is an active/available/normal spell threshold
 							if isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						end
 						
@@ -1402,8 +1407,8 @@ local function UpdateResourceBar()
 						end
 
 						if thresholds[thresholdId] then
-							local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-							TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, resourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
+							local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+							Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, resourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
 						end
 					end
 					
@@ -1417,7 +1422,7 @@ local function UpdateResourceBar()
 					barGroups.primary:GetContainerFrame():SetAlpha(1.0)
 					-- Apply overcap border color if enabled
 					if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
-						local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+						local overcapBorderCurve = Color:BuildResourceThresholdCurve(specSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 						local borderColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapBorderCurve)
 						primaryNode:SetBorderColorCurve(borderColorResult)
 					else
@@ -1425,7 +1430,7 @@ local function UpdateResourceBar()
 					end
 					primaryNode:SetColor(barColor)
 					primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-					TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+					Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 				end
 			end
 
@@ -1440,7 +1445,7 @@ local function UpdateResourceBar()
 					max = TRB.Data.character.maxResource2Value or 50
 				end
 				
-				local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
+				local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
 				local cpBorderColor = specSettings.colors.comboPoints.border.color
 				local cpColor = specSettings.colors.comboPoints.base.color
 
@@ -1477,7 +1482,7 @@ local function UpdateResourceBar()
 						if thresholds[1] and specCacheSettings.thresholds.thresholdDictionary[spell.settingKey].enabled then
 							local showThreshold = false
 							local thresholdColor = specCacheSettings.colors.threshold.over.color
-							local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+							local frameLevel = frameLevels.thresholdOver
 							
 							if metaActive and talents:IsTalentActive(spells.collapsingStar) then
 								showThreshold = true
@@ -1487,19 +1492,19 @@ local function UpdateResourceBar()
 								-- Determine usability based on buff applications
 								if collapsingStarSnapshot.buff.applications >= resourceAmount then
 									thresholdColor = specCacheSettings.colors.threshold.over.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+									frameLevel = frameLevels.thresholdOver
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 								
 								thresholds[1]:SetFrameLevel(frameLevel)
 								thresholds[1]:Show()
 								
 								-- Set the threshold color using the proper method
-								TRB.Functions.Color:SetThresholdColor(thresholds[1], thresholdColor, true)
+								Color:SetThresholdColor(thresholds[1], thresholdColor, true)
 								
-								TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[1], showThreshold, sfResourceFrame, resourceAmount, max)
+								Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[1], showThreshold, sfResourceFrame, resourceAmount, max)
 							else
 								thresholds[1]:Hide()
 							end
@@ -1518,7 +1523,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1538,11 +1543,11 @@ local function SwitchSpec()
 	TRB.Data.prevLookupState = {}
 	TRB.Data.lookupDirty = true
 	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+		Bar:QueueRenderTransition("switchSpec", 0.8)
 	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 	end
-	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
+	Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 	spellEventFrame:UnregisterEvent("SPELL_UPDATE_USES")
 	spellEventFrame:UnregisterEvent("SPELL_ACTIVATION_OVERLAY_GLOW_SHOW")
@@ -1552,7 +1557,7 @@ local function SwitchSpec()
 	if TRB.Data.character.specId == 1 then
 		specCache.demonhunter_havoc.talents:GetTalents()
 		FillSpellData_Havoc()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.demonhunter_havoc)
+		Character:LoadFromSpecializationCache(specCache.demonhunter_havoc)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.DemonHunter.HavocSpells]]
@@ -1560,7 +1565,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Havoc
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.demonhunter_havoc.settings)
+		Bar:UpdateSanityCheckValues(specCache.demonhunter_havoc.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#annihilation"] = spells.annihilation.icon
@@ -1588,7 +1593,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 2 then
 		specCache.demonhunter_vengeance.talents:GetTalents()
 		FillSpellData_Vengeance()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.demonhunter_vengeance)
+		Character:LoadFromSpecializationCache(specCache.demonhunter_vengeance)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.DemonHunter.VengeanceSpells]]
@@ -1596,7 +1601,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Vengeance
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.demonhunter_vengeance.settings)
+		Bar:UpdateSanityCheckValues(specCache.demonhunter_vengeance.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#metamorphosis"] = spells.metamorphosis.icon
@@ -1621,7 +1626,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 3 then
 		specCache.demonhunter_devourer.talents:GetTalents()
 		FillSpellData_Devourer()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.demonhunter_devourer)
+		Character:LoadFromSpecializationCache(specCache.demonhunter_devourer)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.DemonHunter.DevourerSpells]]
@@ -1630,7 +1635,7 @@ local function SwitchSpec()
 		snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Devourer
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.demonhunter_devourer.settings)
+		Bar:UpdateSanityCheckValues(specCache.demonhunter_devourer.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#collapsingStar"] = spells.collapsingStar.icon
@@ -1671,9 +1676,9 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				TRB.Functions.Character:ResetCaches()
+				Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
-				TRB.Functions.Character:UpdateHealthValues()
+				Character:UpdateHealthValues()
 				TRB.Functions.Class:TriggerResourceBarUpdates()
 			end
 		end)
@@ -1801,9 +1806,9 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
 				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+					Bar:QueueRenderTransition("eventPreSwitch", 0.8)
 				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-					TRB.Functions.Bar:HideResourceBar(true)
+					Bar:HideResourceBar(true)
 				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
@@ -1820,7 +1825,7 @@ function TRB.Functions.Class:CheckCharacter()
 	if specId ~= TRB.Data.character.specId then
 		SwitchSpec()
 	end
-	TRB.Functions.Character:CheckCharacter()
+	Character:CheckCharacter()
 	TRB.Data.character.className = "demonhunter"
 	
 	TRB.Data.character.maxResource = UnitPowerMax("player", Enum.PowerType.Fury, true)
@@ -1848,7 +1853,7 @@ function TRB.Functions.Class:CheckCharacter()
 				TRB.Data.character.maxResource2 = maxComboPoints
 				if TRB.Frames.barGroups ~= nil then
 					local barGroups = TRB.Frames.barGroups
-					TRB.Functions.Bar:ApplyBarGroupsLayout(sharedSettings, barGroups)
+					Bar:ApplyBarGroupsLayout(sharedSettings, barGroups)
 					-- Rebuild secondary nodes with stepped min/max
 					if barGroups.secondary then
 						barGroups.secondary:SetMaxNodes(maxComboPoints)
@@ -1886,7 +1891,7 @@ function TRB.Functions.Class:CheckCharacter()
 			if maxComboPoints ~= TRB.Data.character.maxResource2 then
 				TRB.Data.character.maxResource2 = maxComboPoints
 				if TRB.Frames.barGroups ~= nil then
-					TRB.Functions.Bar:ApplyBarGroupsLayout(sharedSettings, TRB.Frames.barGroups)
+					Bar:ApplyBarGroupsLayout(sharedSettings, TRB.Frames.barGroups)
 				end
 			end
 		end
@@ -1919,7 +1924,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.specSupported = false
 	end
 
-	TRB.Functions.Character:EventRegistration()
+	Character:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
@@ -2106,7 +2111,7 @@ function TRB.Functions.Class:RecreateThresholds(settings, barGroups)
 				primaryNode:ClearThresholds()
 				for _ = 1, #thresholdSpells do
 					local thresholdFrame = CreateFrame("Frame", nil, primaryNode:GetFrame())
-					TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, settings, true)
+					Threshold:ResetThresholdLine(thresholdFrame, settings, true)
 					primaryNode:RegisterThreshold(thresholdFrame)
 				end
 			end
@@ -2146,7 +2151,7 @@ function TRB.Functions.Class:RecreateThresholds(settings, barGroups)
 			if not existingThresholds or #existingThresholds ~= 1 then
 				sfNode:ClearThresholds()
 				local thresholdFrame = CreateFrame("Frame", nil, sfNode:GetFrame())
-				TRB.Functions.Threshold:ResetThresholdLineComboPoint(thresholdFrame, settings)
+				Threshold:ResetThresholdLineComboPoint(thresholdFrame, settings)
 				sfNode:RegisterThreshold(thresholdFrame)
 			end
 		end
@@ -2172,8 +2177,8 @@ function TRB.Functions.Class:HasActiveTimers()
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
-	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
-		TRB.Functions.Bar:HideResourceBar(true)
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and Bar:IsRenderTransitionActive() then
+		Bar:HideResourceBar(true)
 		return
 	end
 
@@ -2181,7 +2186,7 @@ function TRB.Functions.Class:TriggerResourceBarUpdates()
 		return
 	end
 	if TRB.Data.character.specId ~= 1 and TRB.Data.character.specId ~= 2 and TRB.Data.character.specId ~= 3 then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 		return
 	end
 

--- a/ClassModules/Druid.lua
+++ b/ClassModules/Druid.lua
@@ -11,6 +11,11 @@ local MANA_RESOURCE_FACTOR = 1
 local L = TRB.Localization
 TRB.Functions.Class = TRB.Functions.Class or {}
 local lookupChanged = TRB.Functions.BarText.LookupChanged
+local Threshold = TRB.Functions.Threshold
+local Bar = TRB.Functions.Bar
+local Color = TRB.Functions.Color
+local Character = TRB.Functions.Character
+local frameLevels = TRB.Data.constants.frameLevels
 
 local targetsTimerFrame = TRB.Frames.targetsTimerFrame
 
@@ -224,10 +229,10 @@ local function FillSpecializationCache()
 end
 
 local function Setup_Balance()
-	TRB.Functions.Character:FillSpecializationCacheSettings("druid", "balance")
+	Character:FillSpecializationCacheSettings("druid", "balance")
 	
 	-- Destroy existing bar groups before creating new ones
-	--TRB.Functions.Bar:DestroyBarGroups()
+	--Bar:DestroyBarGroups()
 	
 	-- Create bar groups for Balance using new OOP system
 	--TRB.Frames.barGroups = TRB.Classes.Druid.BarGroupsFactory:CreateForSpec(1)
@@ -242,10 +247,10 @@ local function FillSpellData_Balance()
 end
 
 local function Setup_Feral()
-	TRB.Functions.Character:FillSpecializationCacheSettings("druid", "feral")
+	Character:FillSpecializationCacheSettings("druid", "feral")
 	
 	-- Destroy existing bar groups before creating new ones
-	--TRB.Functions.Bar:DestroyBarGroups()
+	--Bar:DestroyBarGroups()
 	
 	-- Create bar groups for Feral using new OOP system
 	--TRB.Frames.barGroups = TRB.Classes.Druid.BarGroupsFactory:CreateForSpec(2)
@@ -260,10 +265,10 @@ local function FillSpellData_Feral()
 end
 
 local function Setup_Guardian()
-	TRB.Functions.Character:FillSpecializationCacheSettings("druid", "guardian")
+	Character:FillSpecializationCacheSettings("druid", "guardian")
 	
 	-- Destroy existing bar groups before creating new ones
-	--TRB.Functions.Bar:DestroyBarGroups()
+	--Bar:DestroyBarGroups()
 	
 	-- Create bar groups for Guardian using new OOP system
 	--TRB.Frames.barGroups = TRB.Classes.Druid.BarGroupsFactory:CreateForSpec(3)
@@ -278,10 +283,10 @@ local function FillSpellData_Guardian()
 end
 
 local function Setup_Restoration()
-	TRB.Functions.Character:FillSpecializationCacheSettings("druid", "restoration", true)
+	Character:FillSpecializationCacheSettings("druid", "restoration", true)
 	
 	-- Destroy existing bar groups before creating new ones
-	--TRB.Functions.Bar:DestroyBarGroups()
+	--Bar:DestroyBarGroups()
 	
 	-- Create bar groups for Restoration using new OOP system
 	--TRB.Frames.barGroups = TRB.Classes.Druid.BarGroupsFactory:CreateForSpec(4)
@@ -342,7 +347,6 @@ end
 local function DruidPowerEvent(self, event, ...)
 	if event == "UNIT_POWER_UPDATE" or event == "UNIT_POWER_FREQUENT" then
 		UpdateResourceValues()
-		TRB.Functions.Character:UpdateOvercapColor()
 		TRB.Data.lookupDirty = true
 	elseif event == "UNIT_MAXPOWER" then
 		local unitTarget, powerType = ...
@@ -421,7 +425,7 @@ local function UpdateShapeshiftForm()
 	end
 	
 	if TRB.Data.snapshotData ~= nil and TRB.Data.snapshotData.snapshots ~= nil then
-		TRB.Functions.Character:ResetColorCaches()
+		Character:ResetColorCaches()
 
 		-- Recreate bar text frames BEFORE triggering updates. Form changes alter which
 		-- bar aliases (AstralPowerBar, EnergyBar, etc.) resolve to an actual frame, so
@@ -445,7 +449,7 @@ local function UpdateShapeshiftForm()
 	-- - Wrong extendAbove (gap between CDM and top bar)
 	-- - Wrong baseOffsetX (primary shifted away from CDM center)
 	if TRB.Functions.Bar and TRB.Functions.Bar.RefreshWrapperPositioning then
-		TRB.Functions.Bar:RefreshWrapperPositioning()
+		Bar:RefreshWrapperPositioning()
 	end
 end
 
@@ -563,7 +567,7 @@ local function ConstructResourceBar(settings)
 			primaryNode:ClearThresholds()
 			for _ = 1, #TRB.Data.cache.thresholdSpells do
 				local thresholdFrame = CreateFrame("Frame", nil, primaryNode:GetFrame())
-				TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, settings, true)
+				Threshold:ResetThresholdLine(thresholdFrame, settings, true)
 				primaryNode:RegisterThreshold(thresholdFrame)
 			end
 		end
@@ -571,12 +575,12 @@ local function ConstructResourceBar(settings)
 		-- ConstructBarGroups now handles the Druid special case internally:
 		-- For non-Feral Druids, it looks up Feral's combo point settings from specCache
 		-- and creates a new merged settings object without modifying the original.
-		TRB.Functions.Bar:ConstructBarGroups(settings, barGroups)
+		Bar:ConstructBarGroups(settings, barGroups)
 	end
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	-- TRB.Functions.Bar:HideResourceBar()
+	-- Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -673,7 +677,7 @@ local function RefreshLookupData_Balance()
 			local currentAstralPower
 			local castingAstralPower
 			if sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentAstralPowerColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentAstralPowerColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				currentAstralPower = textColorResult:WrapTextInColorCode(resourceFormatted)
 				castingAstralPower = textColorResult:WrapTextInColorCode(string.format("%.0f", TRB.Functions.Number:RoundTo(snapshotData.casting.resourceFinal, resourcePrecision, "floor")))
@@ -825,7 +829,7 @@ local function RefreshLookupData_Feral()
 			local currentEnergy
 			local castingEnergy
 			if not isStealthed and sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentEnergyColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentEnergyColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				currentEnergy = textColorResult:WrapTextInColorCode(resourceFormatted)
 				castingEnergy = textColorResult:WrapTextInColorCode(string.format("%.0f", TRB.Functions.Number:RoundTo(snapshotData.casting.resourceFinal, resourcePrecision, "floor")))
@@ -933,7 +937,7 @@ local function RefreshLookupData_Guardian()
 		if lookupChanged(prevState, "$rage", resourceFormatted, currentRageColor) then
 			local currentRage
 			if sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentRageColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentRageColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				currentRage = textColorResult:WrapTextInColorCode(resourceFormatted)
 			else
@@ -1405,7 +1409,7 @@ local function IsApexPredatorsCravingActive()
 end
 
 local function UpdateSnapshot()
-	TRB.Functions.Character:UpdateSnapshot()
+	Character:UpdateSnapshot()
 end
 
 local function UpdateSnapshot_Balance()
@@ -1471,7 +1475,7 @@ local function UpdateResourceBar()
 
 	-- Always call HideResourceBar first to ensure visibility is correctly determined
 	-- even if we return early due to missing data
-	TRB.Functions.Bar:HideResourceBar()
+	Bar:HideResourceBar()
 
 	if not (barGroups and barGroups.primary) then
 		return
@@ -1557,7 +1561,7 @@ local function UpdateResourceBar()
 			-- Create threshold on-demand if missing
 			if thresholds[thresholdId] == nil then
 				local thresholdFrame = CreateFrame("Frame", nil, resourceFrame)
-				TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, formSpecCacheSettings, true)
+				Threshold:ResetThresholdLine(thresholdFrame, formSpecCacheSettings, true)
 				primaryNode:RegisterThreshold(thresholdFrame)
 				thresholds = primaryNode:GetThresholds()
 			end
@@ -1573,7 +1577,7 @@ local function UpdateResourceBar()
 				local isUsable = spell:IsUsable()
 				local showThreshold = true
 				local thresholdColor = formSpecCacheSettings.colors.threshold.over.color
-				local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+				local frameLevel = frameLevels.thresholdOver
 				local snapshot = snapshots[spell.id]
 				
 				if resourceAmount == 0 then
@@ -1585,19 +1589,19 @@ local function UpdateResourceBar()
 				elseif spell.hasCooldown then
 					if snapshotData.snapshots[spell.id].cooldown:IsUnusable() then
 						thresholdColor = formSpecCacheSettings.colors.threshold.unusable.color
-						frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+						frameLevel = frameLevels.thresholdUnusable
 					elseif isUsable then
 						thresholdColor = formSpecCacheSettings.colors.threshold.over.color
 					else
 						thresholdColor = formSpecCacheSettings.colors.threshold.under.color
-						frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+						frameLevel = frameLevels.thresholdUnder
 					end
 				else -- This is an active/available/normal spell threshold
 					if isUsable then
 						thresholdColor = formSpecCacheSettings.colors.threshold.over.color
 					else
 						thresholdColor = formSpecCacheSettings.colors.threshold.under.color
-						frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+						frameLevel = frameLevels.thresholdUnder
 					end
 				end
 				
@@ -1606,8 +1610,8 @@ local function UpdateResourceBar()
 				end
 
 				if thresholds[thresholdId] then
-					local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, formSpecCacheSettings)
-					TRB.Functions.Threshold:RepositionThreshold(formSpecCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, resourceFrame, resourceAmount, maxPrimaryBarResource)
+					local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, formSpecCacheSettings)
+					Threshold:RepositionThreshold(formSpecCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, resourceFrame, resourceAmount, maxPrimaryBarResource)
 				end
 			end
 		end
@@ -1642,7 +1646,7 @@ local function UpdateResourceBar()
 		end
 
 		if showCp and cpSettings then
-			local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(cpSettings.colors.comboPoints.background.color, true)
+			local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(cpSettings.colors.comboPoints.background.color, true)
 			
 			for x = 1, TRB.Data.character.maxComboPoints do
 				local cpBorderColor = cpSettings.colors.comboPoints.border.color
@@ -1655,14 +1659,14 @@ local function UpdateResourceBar()
 					local cpNode = barGroups.secondary:GetNode(x)
 					if cpNode then
 						if (snapshotData.attributes.comboPoints or 0) >= x then
-							TRB.Functions.Bar:SetBarNodeValue(formSpecCacheSettings, "comboPoint" .. x, cpNode, 1, 1)
+							Bar:SetBarNodeValue(formSpecCacheSettings, "comboPoint" .. x, cpNode, 1, 1)
 							if (cpSettings.comboPoints.sameColor and snapshotData.attributes.comboPoints == (TRB.Data.character.maxComboPoints - 1)) or (not cpSettings.comboPoints.sameColor and x == (TRB.Data.character.maxComboPoints - 1)) then
 								cpColor = cpSettings.colors.comboPoints.penultimate.color
 							elseif (cpSettings.comboPoints.sameColor and snapshotData.attributes.comboPoints == (TRB.Data.character.maxComboPoints)) or x == TRB.Data.character.maxComboPoints then
 								cpColor = cpSettings.colors.comboPoints.final.color
 							end
 						else
-							TRB.Functions.Bar:SetBarNodeValue(formSpecCacheSettings, "comboPoint" .. x, cpNode, 0, 1)
+							Bar:SetBarNodeValue(formSpecCacheSettings, "comboPoint" .. x, cpNode, 0, 1)
 						end
 						
 						cpNode:SetBorderColor(cpBorderColor)
@@ -1711,7 +1715,7 @@ local function UpdateResourceBar()
 
 				-- Set min/max before setting value to ensure correct scaling
 				primaryNode:SetMinMax(0, maxPrimaryBarResourceUnnormalized)
-				TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "resource", primaryNode, currentResource, maxPrimaryBarResourceUnnormalized)
+				Bar:SetBarNodeValue(specCacheSettings, "resource", primaryNode, currentResource, maxPrimaryBarResourceUnnormalized)
 
 				local barColor = specSettings.colors.bar.base.color
 				-- Use simple colors when in non-native form
@@ -1739,7 +1743,7 @@ local function UpdateResourceBar()
 							-- Create threshold on-demand if missing
 							if thresholds[thresholdId] == nil then
 								local thresholdFrame = CreateFrame("Frame", nil, nodeResourceFrame)
-								TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
+								Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
 								primaryNode:RegisterThreshold(thresholdFrame)
 								thresholds = primaryNode:GetThresholds()
 							end
@@ -1747,7 +1751,7 @@ local function UpdateResourceBar()
 							local resourceAmount = spell:GetPrimaryResourceCost()
 							local showThreshold = true
 							local thresholdColor = specCacheSettings.colors.threshold.over.color --[[@as string?]]
-							local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+							local frameLevel = frameLevels.thresholdOver
 							local snapshot = snapshots[spell.id]
 							local isUsable = spell:IsUsable()
 
@@ -1759,7 +1763,7 @@ local function UpdateResourceBar()
 										thresholdColor = specCacheSettings.colors.threshold.over.color
 									else
 										thresholdColor = specCacheSettings.colors.threshold.under.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+										frameLevel = frameLevels.thresholdUnder
 									end
 									
 									if showThreshold then
@@ -1778,15 +1782,15 @@ local function UpdateResourceBar()
 									else
 										-- Use ColorCurve to dynamically change threshold color based on resource
 										local baseCost = resourceAmount / spell.primaryResourceTypeMod
-										local thresholdCurve = TRB.Functions.Color:BuildThresholdCurve(
+										local thresholdCurve = Color:BuildThresholdCurve(
 											spell.primaryResourceTypeMod,
 											baseCost,
 											specCacheSettings.colors.threshold.under.color,
 											specCacheSettings.colors.threshold.over.color
 										)
-										local iconCurve = TRB.Functions.Color:BuildIconVertexColorCurve(spell.primaryResourceTypeMod, baseCost)
-										frameLevel = isUsable and TRB.Data.constants.frameLevels.thresholdOver or TRB.Data.constants.frameLevels.thresholdUnder
-										local curveApplied = TRB.Functions.Threshold:ApplyThresholdCurveColor(
+										local iconCurve = Color:BuildIconVertexColorCurve(spell.primaryResourceTypeMod, baseCost)
+										frameLevel = isUsable and frameLevels.thresholdOver or frameLevels.thresholdUnder
+										local curveApplied = Threshold:ApplyThresholdCurveColor(
 											spell, thresholds[thresholdId], thresholdCurve, TRB.Data.resource, specCacheSettings, iconCurve, frameLevel, pairOffset, isUsable
 										)
 										if curveApplied then
@@ -1802,15 +1806,15 @@ local function UpdateResourceBar()
 									else
 										-- Use ColorCurve to dynamically change threshold color based on resource
 										local baseCost = resourceAmount / spell.primaryResourceTypeMod
-										local thresholdCurve = TRB.Functions.Color:BuildThresholdCurve(
+										local thresholdCurve = Color:BuildThresholdCurve(
 											spell.primaryResourceTypeMod,
 											baseCost,
 											specCacheSettings.colors.threshold.under.color,
 											specCacheSettings.colors.threshold.over.color
 										)
-										local iconCurve = TRB.Functions.Color:BuildIconVertexColorCurve(spell.primaryResourceTypeMod, baseCost)
-										frameLevel = isUsable and TRB.Data.constants.frameLevels.thresholdOver or TRB.Data.constants.frameLevels.thresholdUnder
-										local curveApplied = TRB.Functions.Threshold:ApplyThresholdCurveColor(
+										local iconCurve = Color:BuildIconVertexColorCurve(spell.primaryResourceTypeMod, baseCost)
+										frameLevel = isUsable and frameLevels.thresholdOver or frameLevels.thresholdUnder
+										local curveApplied = Threshold:ApplyThresholdCurveColor(
 											spell, thresholds[thresholdId], thresholdCurve, TRB.Data.resource, specCacheSettings, iconCurve, frameLevel, pairOffset, isUsable
 										)
 										if curveApplied then
@@ -1827,7 +1831,7 @@ local function UpdateResourceBar()
 										thresholdColor = specCacheSettings.colors.threshold.over.color
 									else
 										thresholdColor = specCacheSettings.colors.threshold.under.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+										frameLevel = frameLevels.thresholdUnder
 									end
 									
 									if showThreshold then
@@ -1853,14 +1857,14 @@ local function UpdateResourceBar()
 									thresholdColor = specCacheSettings.colors.threshold.over.color
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							else -- This is an active/available/normal spell threshold
 								if isUsable then
 									thresholdColor = specCacheSettings.colors.threshold.over.color
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							end
 
@@ -1878,8 +1882,8 @@ local function UpdateResourceBar()
 								showThreshold = false
 							end
 
-							local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-							TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, nodeResourceFrame, resourceAmount, maxPrimaryBarResource)
+							local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+							Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, nodeResourceFrame, resourceAmount, maxPrimaryBarResource)
 						end -- shouldProcessThreshold
 					end
 					
@@ -1894,7 +1898,7 @@ local function UpdateResourceBar()
 						if specSettings.endOf.eclipse.enabled and (not specSettings.endOf.eclipse.celestialAlignmentOnly or snapshots[spells.celestialAlignment.id].buff.isActive or snapshots[spells.incarnationChosenOfElune.id].buff.isActive) then
 							useEndOfEclipseColor = true
 							if specSettings.endOf.eclipse.mode == "gcd" then
-								local gcd = TRB.Functions.Character:GetCurrentGCDTime()
+								local gcd = Character:GetCurrentGCDTime()
 								timeThreshold = gcd * specSettings.endOf.eclipse.gcdsMax
 							elseif specSettings.endOf.eclipse.mode == "time" then
 								timeThreshold = specSettings.endOf.eclipse.timeMax
@@ -1921,7 +1925,7 @@ local function UpdateResourceBar()
 
 				-- Apply overcap border color if enabled (Cat/Feral uses Energy, Bear/Guardian uses Rage)
 				if formSpecSettings.colors.bar.borderOvercap ~= nil and formSpecSettings.colors.bar.borderOvercap.enabled and affectingCombat then
-					local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(formSpecSettings, barBorderColor, formSpecSettings.colors.bar.borderOvercap.color)
+					local overcapBorderCurve = Color:BuildResourceThresholdCurve(formSpecSettings, barBorderColor, formSpecSettings.colors.bar.borderOvercap.color)
 					local borderColorResult = UnitPowerPercent("player", displayResourceType, true, overcapBorderCurve)
 					primaryNode:SetBorderColorCurve(borderColorResult)
 				else
@@ -1933,9 +1937,9 @@ local function UpdateResourceBar()
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
 
 				if flashBar then
-					TRB.Functions.Bar:PulseFrame(barGroups.primary:GetContainerFrame(), specSettings.colors.bar.flashAlpha, specSettings.colors.bar.flashPeriod)
+					Bar:PulseFrame(barGroups.primary:GetContainerFrame(), specSettings.colors.bar.flashAlpha, specSettings.colors.bar.flashPeriod)
 				end
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 			
 			local refreshTextFromComboPoints = ConstructComboPointsGeneric()
@@ -1952,7 +1956,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			elseif barGroups and barGroups.health and not isInEditMode then
 				barGroups.health:Hide()
 			end
@@ -1989,7 +1993,7 @@ local function UpdateResourceBar()
 
 				-- Set min/max before setting value to ensure correct scaling
 				primaryNode:SetMinMax(0, maxPrimaryBarResourceUnnormalized)
-				TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "resource", primaryNode, currentResource, maxPrimaryBarResourceUnnormalized)
+				Bar:SetBarNodeValue(specCacheSettings, "resource", primaryNode, currentResource, maxPrimaryBarResourceUnnormalized)
 
 				local barColor = specSettings.colors.bar.base.color
 				local barBorderColor = specSettings.colors.bar.border.color
@@ -2023,7 +2027,7 @@ local function UpdateResourceBar()
 							-- Create threshold on-demand if missing
 							if thresholds[thresholdId] == nil then
 								local thresholdFrame = CreateFrame("Frame", nil, nodeResourceFrame)
-								TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
+								Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
 								primaryNode:RegisterThreshold(thresholdFrame)
 								thresholds = primaryNode:GetThresholds()
 							end
@@ -2033,7 +2037,7 @@ local function UpdateResourceBar()
 							local showThreshold = true
 							---@type string?
 							local thresholdColor = specCacheSettings.colors.threshold.over.color
-							local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+							local frameLevel = frameLevels.thresholdOver
 							local snapshot = snapshots[spell.id]
 
 							if spell.attributes.isClearcasting and snapshots[spells.clearcasting.id].buff.applications ~= nil and snapshots[spells.clearcasting.id].buff.applications > 0 then
@@ -2049,7 +2053,7 @@ local function UpdateResourceBar()
 											thresholdColor = specCacheSettings.colors.threshold.over.color
 										else
 											thresholdColor = specCacheSettings.colors.threshold.under.color
-											frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+											frameLevel = frameLevels.thresholdUnder
 										end
 									elseif spell.id == spells.ferociousBiteMaximum.id and spell.settingKey == "ferociousBiteMaximum" then
 										if apcActive then
@@ -2057,15 +2061,15 @@ local function UpdateResourceBar()
 										elseif isUsable then
 											-- Use ColorCurve to correctly evaluate max cost against secret Energy
 											local baseCost = resourceAmount / spell.primaryResourceTypeMod
-											local thresholdCurve = TRB.Functions.Color:BuildThresholdCurve(
+											local thresholdCurve = Color:BuildThresholdCurve(
 												spell.primaryResourceTypeMod,
 												baseCost,
 												specCacheSettings.colors.threshold.under.color,
 												specCacheSettings.colors.threshold.over.color
 											)
-											local iconCurve = TRB.Functions.Color:BuildIconVertexColorCurve(spell.primaryResourceTypeMod, baseCost)
-											frameLevel = TRB.Data.constants.frameLevels.thresholdOver
-											local curveApplied = TRB.Functions.Threshold:ApplyThresholdCurveColor(
+											local iconCurve = Color:BuildIconVertexColorCurve(spell.primaryResourceTypeMod, baseCost)
+											frameLevel = frameLevels.thresholdOver
+											local curveApplied = Threshold:ApplyThresholdCurveColor(
 												spell, thresholds[thresholdId], thresholdCurve, displayResourceType, specCacheSettings, iconCurve, frameLevel, pairOffset, isUsable
 											)
 											if curveApplied then
@@ -2075,7 +2079,7 @@ local function UpdateResourceBar()
 											end
 										else
 											thresholdColor = specCacheSettings.colors.threshold.under.color
-											frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+											frameLevel = frameLevels.thresholdUnder
 										end
 									end
 								elseif spell.id == spells.ravageMinimum.id then
@@ -2086,7 +2090,7 @@ local function UpdateResourceBar()
 											thresholdColor = specCacheSettings.colors.threshold.over.color
 										else
 											thresholdColor = specCacheSettings.colors.threshold.under.color
-											frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+											frameLevel = frameLevels.thresholdUnder
 										end
 									elseif spell.id == spells.ravageMaximum.id and spell.settingKey == "ravageMaximum" then
 										if apcActive then
@@ -2094,15 +2098,15 @@ local function UpdateResourceBar()
 										elseif isUsable then
 											-- Use ColorCurve to correctly evaluate max cost against secret Energy
 											local baseCost = resourceAmount / spell.primaryResourceTypeMod
-											local thresholdCurve = TRB.Functions.Color:BuildThresholdCurve(
+											local thresholdCurve = Color:BuildThresholdCurve(
 												spell.primaryResourceTypeMod,
 												baseCost,
 												specCacheSettings.colors.threshold.under.color,
 												specCacheSettings.colors.threshold.over.color
 											)
-											local iconCurve = TRB.Functions.Color:BuildIconVertexColorCurve(spell.primaryResourceTypeMod, baseCost)
-											frameLevel = TRB.Data.constants.frameLevels.thresholdOver
-											local curveApplied = TRB.Functions.Threshold:ApplyThresholdCurveColor(
+											local iconCurve = Color:BuildIconVertexColorCurve(spell.primaryResourceTypeMod, baseCost)
+											frameLevel = frameLevels.thresholdOver
+											local curveApplied = Threshold:ApplyThresholdCurveColor(
 												spell, thresholds[thresholdId], thresholdCurve, displayResourceType, specCacheSettings, iconCurve, frameLevel, pairOffset, isUsable
 											)
 											if curveApplied then
@@ -2112,7 +2116,7 @@ local function UpdateResourceBar()
 											end
 										else
 											thresholdColor = specCacheSettings.colors.threshold.under.color
-											frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+											frameLevel = frameLevels.thresholdUnder
 										end
 									end
 								elseif spell.id == spells.moonfire.id then
@@ -2122,50 +2126,50 @@ local function UpdateResourceBar()
 										thresholdColor = specCacheSettings.colors.threshold.over.color
 									else
 										thresholdColor = specCacheSettings.colors.threshold.under.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+										frameLevel = frameLevels.thresholdUnder
 									end
 								elseif spell.id == spells.swipe.id then
 									if isUsable then
 										thresholdColor = specCacheSettings.colors.threshold.over.color
 									else
 										thresholdColor = specCacheSettings.colors.threshold.under.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+										frameLevel = frameLevels.thresholdUnder
 									end
 								elseif spell.id == spells.frenziedRegeneration.id then
 									if not talents:IsTalentActive(spells.empoweredShapeshifting) then
 										showThreshold = false
 									elseif snapshots[spell.id].cooldown:IsUnusable() then
 										thresholdColor = specCacheSettings.colors.threshold.unusable.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+										frameLevel = frameLevels.thresholdUnusable
 									elseif isUsable then
 										thresholdColor = specCacheSettings.colors.threshold.over.color
 									else
 										thresholdColor = specCacheSettings.colors.threshold.under.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+										frameLevel = frameLevels.thresholdUnder
 									end
 								elseif spell.id == spells.feralFrenzy.id then
 									if talents:IsTalentActive(spells.franticFrenzy) then
 										showThreshold = false
 									elseif snapshots[spell.id].cooldown:IsUnusable() then
 										thresholdColor = specCacheSettings.colors.threshold.unusable.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+										frameLevel = frameLevels.thresholdUnusable
 									elseif isUsable then
 										thresholdColor = specCacheSettings.colors.threshold.over.color
 									else
 										thresholdColor = specCacheSettings.colors.threshold.under.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+										frameLevel = frameLevels.thresholdUnder
 									end
 								elseif spell.id == spells.franticFrenzy.id then
 									if not talents:IsTalentActive(spells.franticFrenzy) then
 										showThreshold = false
 									elseif snapshots[spell.id].cooldown:IsUnusable() then
 										thresholdColor = specCacheSettings.colors.threshold.unusable.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+										frameLevel = frameLevels.thresholdUnusable
 									elseif isUsable then
 										thresholdColor = specCacheSettings.colors.threshold.over.color
 									else
 										thresholdColor = specCacheSettings.colors.threshold.under.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+										frameLevel = frameLevels.thresholdUnder
 									end
 								else
 									showThreshold = false
@@ -2179,19 +2183,19 @@ local function UpdateResourceBar()
 							elseif spell.hasCooldown then
 							if snapshots[spell.id].cooldown:IsUnusable() then
 								thresholdColor = specCacheSettings.colors.threshold.unusable.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+								frameLevel = frameLevels.thresholdUnusable
 							elseif isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						else -- This is an active/available/normal spell threshold
 							if isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						end
 						
@@ -2199,8 +2203,8 @@ local function UpdateResourceBar()
 							showThreshold = false
 						end
 
-						local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-						TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, nodeResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
+						local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+						Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, nodeResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
 						end
 					end
 
@@ -2219,7 +2223,7 @@ local function UpdateResourceBar()
 							local maxBiteCost = spells.ferociousBiteMaximum:GetPrimaryResourceCost()
 							local maxEnergy = TRB.Data.character.maxEnergy or 100
 							local maxBitePercent = maxBiteCost / maxEnergy
-							local maxBiteCurve = TRB.Functions.Color:GetStepColorCurve("feralMaxBite", barColor, specSettings.colors.bar.maxBite.color, maxBitePercent)
+							local maxBiteCurve = Color:GetStepColorCurve("feralMaxBite", barColor, specSettings.colors.bar.maxBite.color, maxBitePercent)
 							barColorCurveResult = UnitPowerPercent("player", displayResourceType, true, maxBiteCurve)
 						end
 
@@ -2244,7 +2248,7 @@ local function UpdateResourceBar()
 						primaryNode:SetBorderColor(specSettings.colors.bar.borderStealth.color)
 					elseif specSettings.colors.bar.borderOvercap ~= nil and specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
 						-- Apply overcap border color if enabled (skipped when stealthed)
-						local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+						local overcapBorderCurve = Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 						local borderColorResult = UnitPowerPercent("player", displayResourceType, true, overcapBorderCurve)
 						primaryNode:SetBorderColorCurve(borderColorResult)
 					else
@@ -2262,7 +2266,7 @@ local function UpdateResourceBar()
 				end
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			-- Show native combo points (with Berserk tick tracking) when in Cat form or
@@ -2271,7 +2275,7 @@ local function UpdateResourceBar()
 			if (currentForm == "cat" or displaySpecId == 2) and specSettings.displayBar.secondary.visibility ~= "never" then
 				refreshText = true
 				local spells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Druid.FeralSpells]]
-				local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
+				local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
 				local berserkTotalCps = snapshots[spells.berserk.id].attributes.ticks
 				local berserkNextTick = snapshots[spells.berserk.id].attributes.tickRate - snapshots[spells.berserk.id].attributes.untilNextTick
 
@@ -2288,7 +2292,7 @@ local function UpdateResourceBar()
 						local cpNode = barGroups.secondary:GetNode(x)
 						if cpNode then
 							if snapshotData.attributes.resource2 >= x then
-								TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, cpNode, 1, 1)
+								Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, cpNode, 1, 1)
 								if (specSettings.comboPoints.sameColor and snapshotData.attributes.resource2 == (TRB.Data.character.maxResource2 - 1)) or (not specSettings.comboPoints.sameColor and x == (TRB.Data.character.maxResource2 - 1)) then
 									cpColor = specSettings.colors.comboPoints.penultimate.color
 								elseif (specSettings.comboPoints.sameColor and snapshotData.attributes.resource2 == (TRB.Data.character.maxResource2)) or x == TRB.Data.character.maxResource2 then
@@ -2296,7 +2300,7 @@ local function UpdateResourceBar()
 								end
 							else
 								if specSettings.colors.comboPoints.generation and berserkTickShown == 0 and berserkTotalCps > 0 then
-									TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, cpNode, berserkNextTick * 1000, spells.berserk:GetTickRate() * 1000)
+									Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, cpNode, berserkNextTick * 1000, spells.berserk:GetTickRate() * 1000)
 									berserkTickShown = 1
 
 									if (specSettings.comboPoints.sameColor and snapshotData.attributes.resource2 == (TRB.Data.character.maxResource2 - 1)) or (not specSettings.comboPoints.sameColor and x == (TRB.Data.character.maxResource2 - 1)) then
@@ -2305,7 +2309,7 @@ local function UpdateResourceBar()
 										cpColor = specSettings.colors.comboPoints.final.color
 									end
 								else
-									TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, cpNode, 0, 1)
+									Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, cpNode, 0, 1)
 								end
 							end
 							
@@ -2332,7 +2336,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			elseif barGroups and barGroups.health and not isInEditMode then
 				barGroups.health:Hide()
 			end
@@ -2390,7 +2394,7 @@ local function UpdateResourceBar()
 
 				-- Set min/max before setting value to ensure correct scaling
 				primaryNode:SetMinMax(0, maxPrimaryBarResourceUnnormalized)
-				TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "resource", primaryNode, currentResource, maxPrimaryBarResourceUnnormalized)
+				Bar:SetBarNodeValue(specCacheSettings, "resource", primaryNode, currentResource, maxPrimaryBarResourceUnnormalized)
 
 				local barColor = specSettings.colors.bar.base.color
 				local barBorderColor = specSettings.colors.bar.border.color
@@ -2421,7 +2425,7 @@ local function UpdateResourceBar()
 							-- Create threshold on-demand if missing
 							if thresholds[thresholdId] == nil then
 								local thresholdFrame = CreateFrame("Frame", nil, nodeResourceFrame)
-								TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
+								Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
 								primaryNode:RegisterThreshold(thresholdFrame)
 								thresholds = primaryNode:GetThresholds()
 							end
@@ -2430,7 +2434,7 @@ local function UpdateResourceBar()
 						local isUsable = spell:IsUsable()
 						local showThreshold = true
 						local thresholdColor = specCacheSettings.colors.threshold.over.color
-						local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+						local frameLevel = frameLevels.thresholdOver
 						local snapshot = snapshots[spell.id]
 
 						if spell.isSnowflake then -- These are special snowflakes that we need to handle manually
@@ -2443,7 +2447,7 @@ local function UpdateResourceBar()
 									thresholdColor = specCacheSettings.colors.threshold.over.color
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							end
 						elseif resourceAmount == 0 then
@@ -2455,19 +2459,19 @@ local function UpdateResourceBar()
 						elseif spell.hasCooldown then
 							if snapshotData.snapshots[spell.id].cooldown:IsUnusable() then
 								thresholdColor = specCacheSettings.colors.threshold.unusable.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+								frameLevel = frameLevels.thresholdUnusable
 							elseif isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						else -- This is an active/available/normal spell threshold
 							if isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						end
 
@@ -2475,8 +2479,8 @@ local function UpdateResourceBar()
 							showThreshold = false
 						end
 
-						local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-						TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, nodeResourceFrame, resourceAmount, maxPrimaryBarResource)
+						local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+						Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, nodeResourceFrame, resourceAmount, maxPrimaryBarResource)
 						end
 					end
 				
@@ -2493,7 +2497,7 @@ local function UpdateResourceBar()
 						if specSettings.endOf.berserk.enabled then
 							useEndOfBerserkColor = true
 							if specSettings.endOf.berserk.mode == "gcd" then
-								local gcd = TRB.Functions.Character:GetCurrentGCDTime()
+								local gcd = Character:GetCurrentGCDTime()
 								timeThreshold = gcd * specSettings.endOf.berserk.gcdsMax
 							elseif specSettings.endOf.berserk.mode == "time" then
 								timeThreshold = specSettings.endOf.berserk.timeMax
@@ -2509,7 +2513,7 @@ local function UpdateResourceBar()
 
 					-- Apply overcap border color if enabled
 					if specSettings.colors.bar.borderOvercap ~= nil and specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
-						local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+						local overcapBorderCurve = Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 						local borderColorResult = UnitPowerPercent("player", displayResourceType, true, overcapBorderCurve)
 						primaryNode:SetBorderColorCurve(borderColorResult)
 					else
@@ -2520,7 +2524,7 @@ local function UpdateResourceBar()
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
 				primaryNode:SetColor(barColor)
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			local refreshTextFromComboPoints = ConstructComboPointsGeneric()
@@ -2537,7 +2541,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			elseif barGroups and barGroups.health and not isInEditMode then
 				barGroups.health:Hide()
 			end
@@ -2557,7 +2561,7 @@ local function UpdateResourceBar()
 
 				-- Set min/max before setting value to ensure correct scaling
 				primaryNode:SetMinMax(0, maxPrimaryBarResourceUnnormalized)
-				TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "resource", primaryNode, currentResource, maxPrimaryBarResourceUnnormalized)
+				Bar:SetBarNodeValue(specCacheSettings, "resource", primaryNode, currentResource, maxPrimaryBarResourceUnnormalized)
 
 				local barBorderColor = formSpecSettings.colors.bar.border.color
 				local barColor = specSettings.colors.bar.base.color
@@ -2577,7 +2581,7 @@ local function UpdateResourceBar()
 							if specSettings.endOf.incarnation.enabled then
 								useEndOfIncarnationColor = true
 								if specSettings.endOf.incarnation.mode == "gcd" then
-									local gcd = TRB.Functions.Character:GetCurrentGCDTime()
+									local gcd = Character:GetCurrentGCDTime()
 									timeThreshold = gcd * specSettings.endOf.incarnation.gcdsMax
 								elseif specSettings.endOf.incarnation.mode == "time" then
 									timeThreshold = specSettings.endOf.incarnation.timeMax
@@ -2595,7 +2599,7 @@ local function UpdateResourceBar()
 
 				-- Apply overcap border color if enabled (Cat/Feral uses Energy, Bear/Guardian uses Rage)
 				if formSpecSettings.colors.bar.borderOvercap ~= nil and formSpecSettings.colors.bar.borderOvercap.enabled and affectingCombat then
-					local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(formSpecSettings, barBorderColor, formSpecSettings.colors.bar.borderOvercap.color)
+					local overcapBorderCurve = Color:BuildResourceThresholdCurve(formSpecSettings, barBorderColor, formSpecSettings.colors.bar.borderOvercap.color)
 					local borderColorResult = UnitPowerPercent("player", displayResourceType, true, overcapBorderCurve)
 					primaryNode:SetBorderColorCurve(borderColorResult)
 				else
@@ -2606,7 +2610,7 @@ local function UpdateResourceBar()
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			local refreshTextFromComboPoints = ConstructComboPointsGeneric()
@@ -2623,7 +2627,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			elseif barGroups and barGroups.health and not isInEditMode then
 				barGroups.health:Hide()
 			end
@@ -2645,11 +2649,11 @@ local function SwitchSpec()
 	TRB.Data.prevLookupState = {}
 	TRB.Data.lookupDirty = true
 	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+		Bar:QueueRenderTransition("switchSpec", 0.8)
 	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 	end
-	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
+	Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 	
 	TRB.Data.character.currentShapeshiftFormId = 0
@@ -2657,7 +2661,7 @@ local function SwitchSpec()
 	if TRB.Data.character.specId == 1 then
 		specCache.druid_balance.talents:GetTalents()
 		FillSpellData_Balance()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.druid_balance)
+		Character:LoadFromSpecializationCache(specCache.druid_balance)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Druid.BalanceSpells]]
@@ -2665,7 +2669,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Unified
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.druid_balance.settings)
+		Bar:UpdateSanityCheckValues(specCache.druid_balance.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#wrath"] = spells.wrath.icon
@@ -2703,7 +2707,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 2 then
 		specCache.druid_feral.talents:GetTalents()
 		FillSpellData_Feral()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.druid_feral)
+		Character:LoadFromSpecializationCache(specCache.druid_feral)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Druid.FeralSpells]]
@@ -2711,7 +2715,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Unified
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.druid_feral.settings)
+		Bar:UpdateSanityCheckValues(specCache.druid_feral.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#apexPredatorsCraving"] = spells.apexPredatorsCraving.icon
@@ -2746,7 +2750,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 3 then
 		specCache.druid_guardian.talents:GetTalents()
 		FillSpellData_Guardian()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.druid_guardian)
+		Character:LoadFromSpecializationCache(specCache.druid_guardian)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Druid.GuardianSpells]]
@@ -2754,7 +2758,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Unified
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.druid_guardian)
+		Bar:UpdateSanityCheckValues(specCache.druid_guardian)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#berserk"] = spells.berserk.icon
@@ -2774,7 +2778,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 4 then
 		specCache.druid_restoration.talents:GetTalents()
 		FillSpellData_Restoration()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.druid_restoration)
+		Character:LoadFromSpecializationCache(specCache.druid_restoration)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Druid.RestorationSpells]]
@@ -2782,7 +2786,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Unified
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.druid_restoration)
+		Bar:UpdateSanityCheckValues(specCache.druid_restoration)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#efflorescence"] = spells.efflorescence.icon
@@ -2809,7 +2813,7 @@ local function SwitchSpec()
 		TRB.Functions.Aura:ClearAuraInstanceIds()
 			
 		-- Destroy existing bar groups before creating new ones
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		
 		-- Create bar groups for Restoration using new OOP system
 		TRB.Frames.barGroups = TRB.Classes.Druid.BarGroupsFactory:CreateForSpec(TRB.Data.character.specId)
@@ -2821,9 +2825,9 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				TRB.Functions.Character:ResetCaches()
+				Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
-				TRB.Functions.Character:UpdateHealthValues()
+				Character:UpdateHealthValues()
 				TRB.Functions.Class:TriggerResourceBarUpdates()
 				UpdateShapeshiftForm()
 			end
@@ -2978,9 +2982,9 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
 				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+					Bar:QueueRenderTransition("eventPreSwitch", 0.8)
 				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-					TRB.Functions.Bar:HideResourceBar(true)
+					Bar:HideResourceBar(true)
 				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
@@ -2997,7 +3001,7 @@ function TRB.Functions.Class:CheckCharacter()
 	if specId ~= TRB.Data.character.specId then
 		SwitchSpec()
 	end
-	TRB.Functions.Character:CheckCharacter()
+	Character:CheckCharacter()
 	TRB.Data.character.className = "druid"
 
 	local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]
@@ -3014,7 +3018,7 @@ function TRB.Functions.Class:CheckCharacter()
 
 		if sharedSettings ~= nil and barGroups then
 			if barGroups.primary then
-				TRB.Functions.Bar:SetPosition(sharedSettings, barGroups.primary:GetContainerFrame())
+				Bar:SetPosition(sharedSettings, barGroups.primary:GetContainerFrame())
 			end
 			
 			-- Configure secondary bar for combo points (used when in Cat form)
@@ -3036,11 +3040,11 @@ function TRB.Functions.Class:CheckCharacter()
 				if feralSettings ~= nil and feralSettings.comboPoints ~= nil
 					and feralSettings.colors and feralSettings.colors.comboPoints then
 					-- Get effective width for secondary bar, accounting for CDM width matching
-					local effectiveWidth, cdmForced = TRB.Functions.Bar:GetEffectiveWidthForBarGroup(barGroups, feralSettings, "secondary")
+					local effectiveWidth, cdmForced = Bar:GetEffectiveWidthForBarGroup(barGroups, feralSettings, "secondary")
 					
 					barGroups.secondary:SetMaxNodes(TRB.Data.character.maxComboPoints)
 					barGroups.secondary:SetNodeCount(TRB.Data.character.maxComboPoints)
-					barGroups.secondary:SetLayout(feralSettings.comboPoints.spacing, TRB.Functions.Bar:GetMatchWidth(feralSettings.comboPoints), "HORIZONTAL")
+					barGroups.secondary:SetLayout(feralSettings.comboPoints.spacing, Bar:GetMatchWidth(feralSettings.comboPoints), "HORIZONTAL")
 					if cdmForced then
 						barGroups.secondary.fullWidth = true
 					end
@@ -3169,7 +3173,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.specSupported = false
 	end
 
-	TRB.Functions.Character:EventRegistration()
+	Character:EventRegistration()
 	TRB.Data.resourceToken = primaryResourceToken
 	
 	-- Override resource tracking for Druids to track ALL power types
@@ -3514,8 +3518,8 @@ function TRB.Functions.Class:HasActiveTimers()
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
-	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
-		TRB.Functions.Bar:HideResourceBar(true)
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and Bar:IsRenderTransitionActive() then
+		Bar:HideResourceBar(true)
 		return
 	end
 
@@ -3523,7 +3527,7 @@ function TRB.Functions.Class:TriggerResourceBarUpdates()
 		return
 	end
 	if TRB.Data.character.specId ~= 1 and TRB.Data.character.specId ~= 2 and TRB.Data.character.specId ~= 3 and TRB.Data.character.specId ~= 4 then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 		return
 	end
 

--- a/ClassModules/Evoker.lua
+++ b/ClassModules/Evoker.lua
@@ -10,6 +10,7 @@ local Threshold = TRB.Functions.Threshold
 local Bar = TRB.Functions.Bar
 local Color = TRB.Functions.Color
 local Character = TRB.Functions.Character
+local frameLevels = TRB.Data.constants.frameLevels
 
 local targetsTimerFrame = TRB.Frames.targetsTimerFrame
 

--- a/ClassModules/Evoker.lua
+++ b/ClassModules/Evoker.lua
@@ -6,6 +6,10 @@ end
 local L = TRB.Localization
 TRB.Functions.Class = TRB.Functions.Class or {}
 local lookupChanged = TRB.Functions.BarText.LookupChanged
+local Threshold = TRB.Functions.Threshold
+local Bar = TRB.Functions.Bar
+local Color = TRB.Functions.Color
+local Character = TRB.Functions.Character
 
 local targetsTimerFrame = TRB.Frames.targetsTimerFrame
 
@@ -144,11 +148,11 @@ local function FillSpecializationCache()
 end
 
 local function Setup_Devastation()
-	TRB.Functions.Character:FillSpecializationCacheSettings("evoker", "devastation")
+	Character:FillSpecializationCacheSettings("evoker", "devastation")
 
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "evoker_devastation" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Evoker.BarGroupsFactory:CreateForSpec(1)
 	end
 end
@@ -160,11 +164,11 @@ local function FillSpellData_Devastation()
 end
 
 local function Setup_Preservation()
-	TRB.Functions.Character:FillSpecializationCacheSettings("evoker", "preservation", true)
+	Character:FillSpecializationCacheSettings("evoker", "preservation", true)
 
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "evoker_preservation" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Evoker.BarGroupsFactory:CreateForSpec(2)
 	end
 end
@@ -176,11 +180,11 @@ local function FillSpellData_Preservation()
 end
 
 local function Setup_Augmentation()
-	TRB.Functions.Character:FillSpecializationCacheSettings("evoker", "augmentation")
+	Character:FillSpecializationCacheSettings("evoker", "augmentation")
 
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "evoker_augmentation" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Evoker.BarGroupsFactory:CreateForSpec(3)
 	end
 end
@@ -233,12 +237,12 @@ local function ConstructResourceBar(settings)
 			primaryNode:ClearThresholds()
 			for thresholdId = 1, #TRB.Data.cache.thresholdSpells do
 				local thresholdFrame = CreateFrame("Frame", nil, primaryNode:GetFrame())
-				TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, settings, true)
+				Threshold:ResetThresholdLine(thresholdFrame, settings, true)
 				primaryNode:RegisterThreshold(thresholdFrame)
 			end
 		end
 
-		TRB.Functions.Bar:ConstructBarGroups(settings, barGroups)
+		Bar:ConstructBarGroups(settings, barGroups)
 	end
 
 	-- Configure secondary bar for Essence (all specs)
@@ -249,7 +253,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	-- TRB.Functions.Bar:HideResourceBar()
+	-- Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -663,7 +667,7 @@ function TRB.Functions.Class:DisableEvents()
 end
 
 local function UpdateSnapshot()
-	TRB.Functions.Character:UpdateSnapshot()
+	Character:UpdateSnapshot()
 	local currentTime = GetTime()
 end
 
@@ -695,7 +699,7 @@ end
 ---@param specCacheSettings table # The spec cache settings
 local function UpdateEssence(specSettings, specCacheSettings)
 	local snapshotData = TRB.Data.snapshotData --[[@as TRB.Classes.SnapshotData]]
-	local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
+	local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
 	local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]
 
 	for x = 1, TRB.Data.character.maxResource2 do
@@ -718,7 +722,7 @@ local function UpdateEssence(specSettings, specCacheSettings)
 		if barGroups and barGroups.secondary then
 			local essenceNode = barGroups.secondary:GetNode(x)
 			if essenceNode then
-				TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "essence" .. x, essenceNode, essenceValue, 1000)
+				Bar:SetBarNodeValue(specCacheSettings, "essence" .. x, essenceNode, essenceValue, 1000)
 				essenceNode:SetBorderColor(cpBorderColor)
 				essenceNode:SetColor(cpColor)
 				essenceNode:SetBackgroundColor(cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha)
@@ -739,7 +743,7 @@ local function UpdateResourceBar()
 
 	-- Always call HideResourceBar first to ensure visibility is correctly determined
 	-- even if we return early due to missing data
-	TRB.Functions.Bar:HideResourceBar()
+	Bar:HideResourceBar()
 
 	if TRB.Data.character.maxResource == nil or TRB.Data.character.maxResource2 == nil then
 		return
@@ -783,7 +787,7 @@ local function UpdateResourceBar()
 				local barColor = specSettings.colors.bar.base.color
 				local barBorderColor = specSettings.colors.bar.border.color
 
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
 
 				-- Dragonrage bar color changes
@@ -795,7 +799,7 @@ local function UpdateResourceBar()
 					if specSettings.endOf.dragonrage.enabled then
 						useEndOfDragonrageColor = true
 						if specSettings.endOf.dragonrage.mode == "gcd" then
-							local gcd = TRB.Functions.Character:GetCurrentGCDTime()
+							local gcd = Character:GetCurrentGCDTime()
 							dragonrageTimeThreshold = gcd * specSettings.endOf.dragonrage.gcdsMax
 						elseif specSettings.endOf.dragonrage.mode == "time" then
 							dragonrageTimeThreshold = specSettings.endOf.dragonrage.timeMax
@@ -820,7 +824,7 @@ local function UpdateResourceBar()
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			refreshText = UpdateEssenceOuter(specSettings, specCacheSettings) or refreshText
@@ -835,7 +839,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -858,11 +862,11 @@ local function UpdateResourceBar()
 					end
 				end
 
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			refreshText = UpdateEssenceOuter(specSettings, specCacheSettings) or refreshText
@@ -877,7 +881,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -896,7 +900,7 @@ local function UpdateResourceBar()
 				local barColor = specSettings.colors.bar.base.color
 				local barBorderColor = specSettings.colors.bar.border.color
 
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
 
 				-- Ebon Might bar color changes
@@ -908,7 +912,7 @@ local function UpdateResourceBar()
 					if specSettings.endOf.ebonMight.enabled then
 						useEndOfEbonMightColor = true
 						if specSettings.endOf.ebonMight.mode == "gcd" then
-							local gcd = TRB.Functions.Character:GetCurrentGCDTime()
+							local gcd = Character:GetCurrentGCDTime()
 							ebonMightTimeThreshold = gcd * specSettings.endOf.ebonMight.gcdsMax
 						elseif specSettings.endOf.ebonMight.mode == "time" then
 							ebonMightTimeThreshold = specSettings.endOf.ebonMight.timeMax
@@ -954,7 +958,7 @@ local function UpdateResourceBar()
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			refreshText = UpdateEssenceOuter(specSettings, specCacheSettings) or refreshText
@@ -969,7 +973,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -989,16 +993,16 @@ local function SwitchSpec()
 	TRB.Data.prevLookupState = {}
 	TRB.Data.lookupDirty = true
 	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+		Bar:QueueRenderTransition("switchSpec", 0.8)
 	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 	end
-	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
+	Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 	if TRB.Data.character.specId == 1 then
 		specCache.evoker_devastation.talents:GetTalents()
 		FillSpellData_Devastation()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.evoker_devastation)
+		Character:LoadFromSpecializationCache(specCache.evoker_devastation)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Evoker.DevastationSpells]]
@@ -1007,7 +1011,7 @@ local function SwitchSpec()
 		local targetData = TRB.Data.snapshotData.targetData		
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Devastation
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.evoker_devastation.settings)
+		Bar:UpdateSanityCheckValues(specCache.evoker_devastation.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#dragonrage"] = spells.dragonrage.icon
@@ -1023,7 +1027,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 2 then
 		specCache.evoker_preservation.talents:GetTalents()
 		FillSpellData_Preservation()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.evoker_preservation)
+		Character:LoadFromSpecializationCache(specCache.evoker_preservation)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Evoker.PreservationSpells]]
@@ -1032,7 +1036,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Preservation
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.evoker_preservation.settings)
+		Bar:UpdateSanityCheckValues(specCache.evoker_preservation.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		TRB.Data.lookup = lookup
@@ -1047,7 +1051,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 3 then
 		specCache.evoker_augmentation.talents:GetTalents()
 		FillSpellData_Augmentation()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.evoker_augmentation)
+		Character:LoadFromSpecializationCache(specCache.evoker_augmentation)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Evoker.AugmentationSpells]]
@@ -1056,7 +1060,7 @@ local function SwitchSpec()
 		local targetData = TRB.Data.snapshotData.targetData
 		
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Augmentation
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.evoker_augmentation.settings)
+		Bar:UpdateSanityCheckValues(specCache.evoker_augmentation.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#ebonMight"] = spells.ebonMight.icon
@@ -1083,9 +1087,9 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				TRB.Functions.Character:ResetCaches()
+				Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
-				TRB.Functions.Character:UpdateHealthValues()
+				Character:UpdateHealthValues()
 				TRB.Functions.Class:TriggerResourceBarUpdates()
 			end
 		end)
@@ -1213,9 +1217,9 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
 				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+					Bar:QueueRenderTransition("eventPreSwitch", 0.8)
 				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-					TRB.Functions.Bar:HideResourceBar(true)
+					Bar:HideResourceBar(true)
 				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
@@ -1232,7 +1236,7 @@ function TRB.Functions.Class:CheckCharacter()
 	if specId ~= TRB.Data.character.specId then
 		SwitchSpec()
 	end
-	TRB.Functions.Character:CheckCharacter()
+	Character:CheckCharacter()
 	TRB.Data.character.className = "evoker"
 	TRB.Data.character.maxResource = UnitPowerMax("player", TRB.Data.resource, true)
 	TRB.Data.character.maxResourceUnmodified = UnitPowerMax("player", TRB.Data.resource, false)
@@ -1259,7 +1263,7 @@ function TRB.Functions.Class:CheckCharacter()
 		--if maxComboPoints ~= TRB.Data.character.maxResource2 then
 			TRB.Data.character.maxResource2 = maxComboPoints
 			if TRB.Frames.barGroups and TRB.Frames.barGroups.primary then
-				TRB.Functions.Bar:SetPosition(sharedSettings, TRB.Frames.barGroups.primary:GetContainerFrame())
+				Bar:SetPosition(sharedSettings, TRB.Frames.barGroups.primary:GetContainerFrame())
 			end
 		--end
 	end
@@ -1290,7 +1294,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Functions.Class:DisableEvents()
 	end
 
-	TRB.Functions.Character:EventRegistration()
+	Character:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
@@ -1451,8 +1455,8 @@ function TRB.Functions.Class:HasActiveTimers()
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
-	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
-		TRB.Functions.Bar:HideResourceBar(true)
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and Bar:IsRenderTransitionActive() then
+		Bar:HideResourceBar(true)
 		return
 	end
 
@@ -1460,7 +1464,7 @@ function TRB.Functions.Class:TriggerResourceBarUpdates()
 		return
 	end
 	if (TRB.Data.character.specId ~= 1 and TRB.Data.character.specId ~= 2 and TRB.Data.character.specId ~= 3) then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 		return
 	end
 

--- a/ClassModules/Hunter.lua
+++ b/ClassModules/Hunter.lua
@@ -10,6 +10,7 @@ local Threshold = TRB.Functions.Threshold
 local Bar = TRB.Functions.Bar
 local Color = TRB.Functions.Color
 local Character = TRB.Functions.Character
+local frameLevels = TRB.Data.constants.frameLevels
 
 local targetsTimerFrame = TRB.Frames.targetsTimerFrame
 

--- a/ClassModules/Hunter.lua
+++ b/ClassModules/Hunter.lua
@@ -6,6 +6,10 @@ end
 local L = TRB.Localization
 TRB.Functions.Class = TRB.Functions.Class or {}
 local lookupChanged = TRB.Functions.BarText.LookupChanged
+local Threshold = TRB.Functions.Threshold
+local Bar = TRB.Functions.Bar
+local Color = TRB.Functions.Color
+local Character = TRB.Functions.Character
 
 local targetsTimerFrame = TRB.Frames.targetsTimerFrame
 
@@ -158,11 +162,11 @@ local function FillSpecializationCache()
 end
 
 local function Setup_BeastMastery()
-	TRB.Functions.Character:FillSpecializationCacheSettings("hunter", "beastMastery")
+	Character:FillSpecializationCacheSettings("hunter", "beastMastery")
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "hunter_beastMastery" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Hunter.BarGroupsFactory:CreateForSpec(1, UIParent)
 	end
 end
@@ -176,11 +180,11 @@ local function FillSpellData_BeastMastery()
 end
 
 local function Setup_Marksmanship()
-	TRB.Functions.Character:FillSpecializationCacheSettings("hunter", "marksmanship")
+	Character:FillSpecializationCacheSettings("hunter", "marksmanship")
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "hunter_marksmanship" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Hunter.BarGroupsFactory:CreateForSpec(2, UIParent)
 	end
 end
@@ -194,11 +198,11 @@ local function FillSpellData_Marksmanship()
 end
 
 local function Setup_Survival()
-	TRB.Functions.Character:FillSpecializationCacheSettings("hunter", "survival", true)
+	Character:FillSpecializationCacheSettings("hunter", "survival", true)
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "hunter_survival" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Hunter.BarGroupsFactory:CreateForSpec(3, UIParent)
 	end
 end
@@ -266,12 +270,12 @@ local function ConstructResourceBar(settings)
 			primaryNode:ClearThresholds()
 			for _ = 1, #TRB.Data.cache.thresholdSpells do
 				local thresholdFrame = CreateFrame("Frame", nil, primaryNode:GetFrame())
-				TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, settings, true)
+				Threshold:ResetThresholdLine(thresholdFrame, settings, true)
 				primaryNode:RegisterThreshold(thresholdFrame)
 			end
 		end
 
-		TRB.Functions.Bar:ConstructBarGroups(settings, barGroups)
+		Bar:ConstructBarGroups(settings, barGroups)
 	end
 
 	-- Survival uses secondary bar (Tip of the Spear); BM/MM do not.
@@ -286,7 +290,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	-- TRB.Functions.Bar:HideResourceBar()
+	-- Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -344,7 +348,7 @@ local function RefreshLookupData_BeastMastery()
 			local currentFocus
 			local castingFocus
 			if sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentFocusColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentFocusColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				currentFocus = textColorResult:WrapTextInColorCode(resourceFormatted)
 				castingFocus = textColorResult:WrapTextInColorCode(string.format("%.0f", _castingFocus))
@@ -443,7 +447,7 @@ local function RefreshLookupData_Marksmanship()
 			local currentFocus
 			local castingFocus
 			if sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentFocusColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentFocusColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				currentFocus = textColorResult:WrapTextInColorCode(resourceFormatted)
 				castingFocus = textColorResult:WrapTextInColorCode(string.format("%.0f", _castingFocus))
@@ -530,7 +534,7 @@ local function RefreshLookupData_Survival()
 			local currentFocus
 			local castingFocus
 			if sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentFocusColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentFocusColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				currentFocus = textColorResult:WrapTextInColorCode(resourceFormatted)
 				castingFocus = textColorResult:WrapTextInColorCode(string.format("%.0f", _castingFocus))
@@ -685,7 +689,7 @@ function TRB.Functions.Class:SpellCast(event, spellId)
 end
 
 local function UpdateSnapshot()
-	TRB.Functions.Character:UpdateSnapshot()
+	Character:UpdateSnapshot()
 
 	local spells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Hunter.HunterBaseSpells]]
 	---@type table<integer, TRB.Classes.Snapshot>
@@ -753,7 +757,7 @@ local function UpdateResourceBar()
 
 	-- Always call HideResourceBar first to ensure visibility is correctly determined
 	-- even if we return early due to missing data
-	TRB.Functions.Bar:HideResourceBar()
+	Bar:HideResourceBar()
 
 	if not (barGroups and barGroups.primary) then
 		return
@@ -782,7 +786,7 @@ local function UpdateResourceBar()
 				local affectingCombat = TRB.Data.character.inCombat
 				refreshText = true
 				local spells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Hunter.BeastMasterySpells]]				
-				local gcd = TRB.Functions.Character:GetCurrentGCDTime(true)
+				local gcd = Character:GetCurrentGCDTime(true)
 				local currentResource = snapshotData.attributes.resource
 
 				local maxPrimaryBarResourceUnnormalized = TRB.Data.character.maxResourceUnmodified
@@ -790,7 +794,7 @@ local function UpdateResourceBar()
 					maxPrimaryBarResourceUnnormalized = math.min(specCacheSettings.maxResource.value, maxPrimaryBarResourceUnnormalized)
 				end
 
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 
 				-- Get resourceFrame and thresholds from the BarNode
 				local resourceFrame = primaryNode:GetFrame()
@@ -801,7 +805,7 @@ local function UpdateResourceBar()
 					-- Create threshold on-demand if missing
 					if thresholds[thresholdId] == nil then
 						local thresholdFrame = CreateFrame("Frame", nil, resourceFrame)
-						TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
+						Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
 						primaryNode:RegisterThreshold(thresholdFrame)
 						thresholds = primaryNode:GetThresholds()
 					end
@@ -810,7 +814,7 @@ local function UpdateResourceBar()
 					local isUsable = spell:IsUsable()
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
-					local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+					local frameLevel = frameLevels.thresholdOver
 					local snapshot = snapshots[spell.id]
 
 					if spell.isSnowflake then -- These are special snowflakes that we need to handle manually
@@ -819,17 +823,17 @@ local function UpdateResourceBar()
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						elseif spell.id == spells.killCommand.id then
 							if snapshots[spell.id].cooldown:IsUnusable() then
 								thresholdColor = specCacheSettings.colors.threshold.unusable.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+								frameLevel = frameLevels.thresholdUnusable
 							elseif isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						elseif spell.id == spells.wailingArrow.id then
 							if not snapshots[spells.bestialWrath.id].buff.isActive then
@@ -840,7 +844,7 @@ local function UpdateResourceBar()
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						else
 							showThreshold = false
@@ -854,19 +858,19 @@ local function UpdateResourceBar()
 					elseif spell.hasCooldown then
 						if snapshotData.snapshots[spell.id].cooldown:IsUnusable() then
 							thresholdColor = specCacheSettings.colors.threshold.unusable.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+							frameLevel = frameLevels.thresholdUnusable
 						elseif isUsable then
 							thresholdColor = specCacheSettings.colors.threshold.over.color
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					else -- This is an active/available/normal spell threshold
 						if isUsable then
 							thresholdColor = specCacheSettings.colors.threshold.over.color
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					end
 					
@@ -875,8 +879,8 @@ local function UpdateResourceBar()
 					end
 
 					if thresholds[thresholdId] then
-						local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-						TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, resourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
+						local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+						Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, resourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
 					end
 				end
 
@@ -891,7 +895,7 @@ local function UpdateResourceBar()
 					if specSettings.endOf.bestialWrath.enabled then
 						useEndOfBestialWrathColor = true
 						if specSettings.endOf.bestialWrath.mode == "gcd" then
-							local gcd = TRB.Functions.Character:GetCurrentGCDTime()
+							local gcd = Character:GetCurrentGCDTime()
 							timeThreshold = gcd * specSettings.endOf.bestialWrath.gcdsMax
 						elseif specSettings.endOf.bestialWrath.mode == "time" then
 							timeThreshold = specSettings.endOf.bestialWrath.timeMax
@@ -911,7 +915,7 @@ local function UpdateResourceBar()
 
 				if spells.bestialWrath:IsUsable() then
 					if specSettings.colors.bar.flashEnabled and TRB.Data.character.inCombat then
-						TRB.Functions.Bar:PulseFrame(barGroups.primary:GetContainerFrame(), specSettings.colors.bar.flashAlpha, specSettings.colors.bar.flashPeriod)
+						Bar:PulseFrame(barGroups.primary:GetContainerFrame(), specSettings.colors.bar.flashAlpha, specSettings.colors.bar.flashPeriod)
 					else
 						barGroups.primary:GetContainerFrame():SetAlpha(1.0)
 					end
@@ -921,7 +925,7 @@ local function UpdateResourceBar()
 
 				-- Apply overcap border color if enabled
 				if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
-					local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+					local overcapBorderCurve = Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 					local borderColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapBorderCurve)
 					primaryNode:SetBorderColorCurve(borderColorResult)
 				else
@@ -929,7 +933,7 @@ local function UpdateResourceBar()
 				end
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -944,7 +948,7 @@ local function UpdateResourceBar()
 				healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 				healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 			end
-			TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+			Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
 	elseif TRB.Data.character.specId == 2 then
@@ -957,7 +961,7 @@ local function UpdateResourceBar()
 				local affectingCombat = TRB.Data.character.inCombat
 				refreshText = true
 				local spells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Hunter.MarksmanshipSpells]]
-				local gcd = TRB.Functions.Character:GetCurrentGCDTime(true)
+				local gcd = Character:GetCurrentGCDTime(true)
 				local currentResource = snapshotData.attributes.resource
 
 				local maxPrimaryBarResourceUnnormalized = TRB.Data.character.maxResourceUnmodified
@@ -967,7 +971,7 @@ local function UpdateResourceBar()
 
 				local barBorderColor = specSettings.colors.bar.border.color
 				
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 
 				-- Get resourceFrame and thresholds from the BarNode
 				local resourceFrame = primaryNode:GetFrame()
@@ -978,7 +982,7 @@ local function UpdateResourceBar()
 					-- Create threshold on-demand if missing
 					if thresholds[thresholdId] == nil then
 						local thresholdFrame = CreateFrame("Frame", nil, resourceFrame)
-						TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
+						Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
 						primaryNode:RegisterThreshold(thresholdFrame)
 						thresholds = primaryNode:GetThresholds()
 					end
@@ -987,41 +991,41 @@ local function UpdateResourceBar()
 					local isUsable = spell:IsUsable()
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
-					local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+					local frameLevel = frameLevels.thresholdOver
 					local snapshot = snapshots[spell.id]
 
 					if spell.isSnowflake then -- These are special snowflakes that we need to handle manually
 						if spell.id == spells.aimedShot.id then
 							if snapshots[spell.id].cooldown:IsUnusable() then
 								thresholdColor = specCacheSettings.colors.threshold.unusable.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+								frameLevel = frameLevels.thresholdUnusable
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						elseif spell.id == spells.killShot.id and not talents:IsTalentActive(spells.blackArrow) then
 							if snapshots[spell.id].cooldown:IsUnusable() then
 								thresholdColor = specCacheSettings.colors.threshold.unusable.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+								frameLevel = frameLevels.thresholdUnusable
 							elseif isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								-- Hide the threshold if we can't use it
 								showThreshold = false
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						elseif spell.id == spells.blackArrow.id and talents:IsTalentActive(spells.blackArrow) then
 							if snapshotData.snapshots[spell.id].cooldown:IsUnusable() then
 								thresholdColor = specCacheSettings.colors.threshold.unusable.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+								frameLevel = frameLevels.thresholdUnusable
 							elseif isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								-- Hide the threshold if we can't use it
 								showThreshold = false
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						elseif spell.id == spells.wailingArrow.id then
 							if not snapshots[spells.trueshot.id].buff.isActive then
@@ -1032,7 +1036,7 @@ local function UpdateResourceBar()
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						else
 							showThreshold = false
@@ -1046,19 +1050,19 @@ local function UpdateResourceBar()
 					elseif spell.hasCooldown then
 						if snapshotData.snapshots[spell.id].cooldown:IsUnusable() then
 							thresholdColor = specCacheSettings.colors.threshold.unusable.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+							frameLevel = frameLevels.thresholdUnusable
 						elseif isUsable then
 							thresholdColor = specCacheSettings.colors.threshold.over.color
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					else -- This is an active/available/normal spell threshold
 						if isUsable then
 							thresholdColor = specCacheSettings.colors.threshold.over.color
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					end
 					
@@ -1067,8 +1071,8 @@ local function UpdateResourceBar()
 					end
 
 					if thresholds[thresholdId] then
-						local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-						TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, resourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
+						local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+						Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, resourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
 					end
 				end
 
@@ -1081,7 +1085,7 @@ local function UpdateResourceBar()
 					if specSettings.endOf.trueshot.enabled then
 						useEndOfTrueshotColor = true
 						if specSettings.endOf.trueshot.mode == "gcd" then
-							local gcd = TRB.Functions.Character:GetCurrentGCDTime()
+							local gcd = Character:GetCurrentGCDTime()
 							timeThreshold = gcd * specSettings.endOf.trueshot.gcdsMax
 						elseif specSettings.endOf.trueshot.mode == "time" then
 							timeThreshold = specSettings.endOf.trueshot.timeMax
@@ -1098,7 +1102,7 @@ local function UpdateResourceBar()
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
 				-- Apply overcap border color if enabled
 				if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
-					local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+					local overcapBorderCurve = Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 					local borderColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapBorderCurve)
 					primaryNode:SetBorderColorCurve(borderColorResult)
 				else
@@ -1106,7 +1110,7 @@ local function UpdateResourceBar()
 				end
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -1121,7 +1125,7 @@ local function UpdateResourceBar()
 				healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 				healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 			end
-			TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+			Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
 	elseif TRB.Data.character.specId == 3 then
@@ -1134,7 +1138,7 @@ local function UpdateResourceBar()
 				local affectingCombat = TRB.Data.character.inCombat
 				refreshText = true
 				local spells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Hunter.SurvivalSpells]]
-				local gcd = TRB.Functions.Character:GetCurrentGCDTime(true)
+				local gcd = Character:GetCurrentGCDTime(true)
 				local currentResource = snapshotData.attributes.resource
 
 				local maxPrimaryBarResourceUnnormalized = TRB.Data.character.maxResourceUnmodified
@@ -1144,7 +1148,7 @@ local function UpdateResourceBar()
 
 				local barBorderColor = specSettings.colors.bar.border.color
 				
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 
 				-- Get resourceFrame and thresholds from the BarNode
 				local resourceFrame = primaryNode:GetFrame()
@@ -1155,7 +1159,7 @@ local function UpdateResourceBar()
 					-- Create threshold on-demand if missing
 					if thresholds[thresholdId] == nil then
 						local thresholdFrame = CreateFrame("Frame", nil, resourceFrame)
-						TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
+						Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
 						primaryNode:RegisterThreshold(thresholdFrame)
 						thresholds = primaryNode:GetThresholds()
 					end
@@ -1164,7 +1168,7 @@ local function UpdateResourceBar()
 					local isUsable = spell:IsUsable()
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
-					local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+					local frameLevel = frameLevels.thresholdOver
 					local snapshot = snapshots[spell.id]
 
 					if spell.isSnowflake then -- These are special snowflakes that we need to handle manually
@@ -1177,19 +1181,19 @@ local function UpdateResourceBar()
 					elseif spell.hasCooldown then
 						if snapshots[spell.id].cooldown:IsUnusable() then
 							thresholdColor = specCacheSettings.colors.threshold.unusable.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+							frameLevel = frameLevels.thresholdUnusable
 						elseif isUsable or spell:IsFree() then
 							thresholdColor = specCacheSettings.colors.threshold.over.color
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					else -- This is an active/available/normal spell threshold
 						if isUsable then
 							thresholdColor = specCacheSettings.colors.threshold.over.color
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					end
 					
@@ -1198,8 +1202,8 @@ local function UpdateResourceBar()
 					end
 
 					if thresholds[thresholdId] then
-						local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-						TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, resourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
+						local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+						Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, resourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
 					end
 				end
 
@@ -1212,7 +1216,7 @@ local function UpdateResourceBar()
 					if specSettings.endOf.takedown.enabled then
 						useEndOfTakedownColor = true
 						if specSettings.endOf.takedown.mode == "gcd" then
-							local gcd = TRB.Functions.Character:GetCurrentGCDTime()
+							local gcd = Character:GetCurrentGCDTime()
 							timeThreshold = gcd * specSettings.endOf.takedown.gcdsMax
 						elseif specSettings.endOf.takedown.mode == "time" then
 							timeThreshold = specSettings.endOf.takedown.timeMax
@@ -1229,7 +1233,7 @@ local function UpdateResourceBar()
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
 				-- Apply overcap border color if enabled
 				if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
-					local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+					local overcapBorderCurve = Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 					local borderColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapBorderCurve)
 					primaryNode:SetBorderColorCurve(borderColorResult)
 				else
@@ -1237,7 +1241,7 @@ local function UpdateResourceBar()
 				end
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			-- Secondary resource bar: Tip of the Spear stacks
@@ -1246,7 +1250,7 @@ local function UpdateResourceBar()
 				refreshText = true
 				if barGroups.secondary then
 					local spells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Hunter.SurvivalSpells]]
-					local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
+					local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
 					local maxStacks = spells.tipOfTheSpear.maxStacks
 					local currentStacks = snapshots[spells.tipOfTheSpear.id].buff.applications or 0
 					local cpBorderColor = specSettings.colors.comboPoints.border.color
@@ -1259,7 +1263,7 @@ local function UpdateResourceBar()
 						local stackNode = barGroups.secondary:GetNode(x)
 						if stackNode then
 							if isFilled then
-								TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, stackNode, 1, 1)
+								Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, stackNode, 1, 1)
 
 								-- Determine color based on position and sameColor setting
 								if specSettings.colors.comboPoints.sameColor then
@@ -1282,7 +1286,7 @@ local function UpdateResourceBar()
 									end
 								end
 							else
-								TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, stackNode, 0, 1)
+								Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, stackNode, 0, 1)
 							end
 
 							stackNode:SetBorderColor(cpBorderColor)
@@ -1329,7 +1333,7 @@ local function UpdateResourceBar()
 				healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 				healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 			end
-			TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+			Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
 	end
@@ -1348,17 +1352,17 @@ local function SwitchSpec()
 	TRB.Data.prevLookupState = {}
 	TRB.Data.lookupDirty = true
 	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+		Bar:QueueRenderTransition("switchSpec", 0.8)
 	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 	end
-	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
+	Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 
 	if TRB.Data.character.specId == 1 then
 		specCache.hunter_beastMastery.talents:GetTalents()
 		FillSpellData_BeastMastery()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.hunter_beastMastery)
+		Character:LoadFromSpecializationCache(specCache.hunter_beastMastery)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Hunter.BeastMasterySpells]]
@@ -1367,7 +1371,7 @@ local function SwitchSpec()
 		local targetData = TRB.Data.snapshotData.targetData
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_BeastMastery
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.hunter_beastMastery.settings)
+		Bar:UpdateSanityCheckValues(specCache.hunter_beastMastery.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#beastCleave"] = spells.beastCleave.icon
@@ -1390,7 +1394,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 2 then
 		specCache.hunter_marksmanship.talents:GetTalents()
 		FillSpellData_Marksmanship()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.hunter_marksmanship)
+		Character:LoadFromSpecializationCache(specCache.hunter_marksmanship)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Hunter.MarksmanshipSpells]]
@@ -1399,7 +1403,7 @@ local function SwitchSpec()
 		local targetData = TRB.Data.snapshotData.targetData
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Marksmanship
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.hunter_marksmanship.settings)
+		Bar:UpdateSanityCheckValues(specCache.hunter_marksmanship.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#aimedShot"] = spells.aimedShot.icon
@@ -1425,7 +1429,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 3 then
 		specCache.hunter_survival.talents:GetTalents()
 		FillSpellData_Survival()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.hunter_survival)
+		Character:LoadFromSpecializationCache(specCache.hunter_survival)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Hunter.SurvivalSpells]]
@@ -1434,7 +1438,7 @@ local function SwitchSpec()
 		local targetData = TRB.Data.snapshotData.targetData
 		
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Survival
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.hunter_survival.settings)
+		Bar:UpdateSanityCheckValues(specCache.hunter_survival.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#killCommand"] = spells.killCommand.icon
@@ -1470,9 +1474,9 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				TRB.Functions.Character:ResetCaches()
+				Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
-				TRB.Functions.Character:UpdateHealthValues()
+				Character:UpdateHealthValues()
 				TRB.Functions.Class:TriggerResourceBarUpdates()
 			end
 		end)
@@ -1600,9 +1604,9 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
 				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+					Bar:QueueRenderTransition("eventPreSwitch", 0.8)
 				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-					TRB.Functions.Bar:HideResourceBar(true)
+					Bar:HideResourceBar(true)
 				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
@@ -1619,7 +1623,7 @@ function TRB.Functions.Class:CheckCharacter()
 	if specId ~= TRB.Data.character.specId then
 		SwitchSpec()
 	end
-	TRB.Functions.Character:CheckCharacter()
+	Character:CheckCharacter()
 	TRB.Data.character.className = "hunter"
 	TRB.Data.character.maxResource = UnitPowerMax("player", Enum.PowerType.Focus, true)
 	TRB.Data.character.maxResourceUnmodified = UnitPowerMax("player", Enum.PowerType.Focus, false)
@@ -1649,8 +1653,8 @@ function TRB.Functions.Class:CheckCharacter()
 				if barGroups and barGroups.secondary and sharedSettings then
 					if maxComboPoints > 0 then
 						barGroups.secondary:Show()
-						TRB.Functions.Bar:ApplyBarGroupsLayout(sharedSettings, barGroups)
-						TRB.Functions.Bar:ApplyBarGroupsAppearance(sharedSettings, barGroups)
+						Bar:ApplyBarGroupsLayout(sharedSettings, barGroups)
+						Bar:ApplyBarGroupsAppearance(sharedSettings, barGroups)
 					else
 						barGroups.secondary:Hide()
 					end
@@ -1684,7 +1688,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.specSupported = false
 	end
 
-	TRB.Functions.Character:EventRegistration()
+	Character:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
@@ -1859,8 +1863,8 @@ function TRB.Functions.Class:HasActiveTimers()
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
-	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
-		TRB.Functions.Bar:HideResourceBar(true)
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and Bar:IsRenderTransitionActive() then
+		Bar:HideResourceBar(true)
 		return
 	end
 
@@ -1868,7 +1872,7 @@ function TRB.Functions.Class:TriggerResourceBarUpdates()
 		return
 	end
 	if TRB.Data.character.specId ~= 1 and TRB.Data.character.specId ~= 2 and TRB.Data.character.specId ~= 3 then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 		return
 	end
 

--- a/ClassModules/Mage.lua
+++ b/ClassModules/Mage.lua
@@ -6,6 +6,11 @@ end
 local L = TRB.Localization
 TRB.Functions.Class = TRB.Functions.Class or {}
 local lookupChanged = TRB.Functions.BarText.LookupChanged
+local Threshold = TRB.Functions.Threshold
+local Bar = TRB.Functions.Bar
+local Color = TRB.Functions.Color
+local Character = TRB.Functions.Character
+local frameLevels = TRB.Data.constants.frameLevels
 
 local targetsTimerFrame = TRB.Frames.targetsTimerFrame
 
@@ -126,11 +131,11 @@ local function FillSpecializationCache()
 end
 
 local function Setup_Arcane()
-	TRB.Functions.Character:FillSpecializationCacheSettings("mage", "arcane", true)
+	Character:FillSpecializationCacheSettings("mage", "arcane", true)
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "mage_arcane" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Mage.BarGroupsFactory:CreateForSpec(1, UIParent)
 	end
 end
@@ -144,11 +149,11 @@ local function FillSpellData_Arcane()
 end
 
 local function Setup_Fire()
-	TRB.Functions.Character:FillSpecializationCacheSettings("mage", "fire")
+	Character:FillSpecializationCacheSettings("mage", "fire")
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "mage_fire" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Mage.BarGroupsFactory:CreateForSpec(2, UIParent)
 	end
 end
@@ -162,11 +167,11 @@ local function FillSpellData_Fire()
 end
 
 local function Setup_Frost()
-	TRB.Functions.Character:FillSpecializationCacheSettings("mage", "frost")
+	Character:FillSpecializationCacheSettings("mage", "frost")
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "mage_frost" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Mage.BarGroupsFactory:CreateForSpec(3, UIParent)
 	end
 end
@@ -249,12 +254,12 @@ local function ConstructResourceBar(settings)
 			primaryNode:ClearThresholds()
 			for _ = 1, #TRB.Data.cache.thresholdSpells do
 				local thresholdFrame = CreateFrame("Frame", nil, primaryNode:GetFrame())
-				TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, settings, true)
+				Threshold:ResetThresholdLine(thresholdFrame, settings, true)
 				primaryNode:RegisterThreshold(thresholdFrame)
 			end
 		end
 
-		TRB.Functions.Bar:ConstructBarGroups(settings, barGroups)
+		Bar:ConstructBarGroups(settings, barGroups)
 	end
 
 	-- Arcane uses secondary bar (Arcane Charges); Frost uses secondary bar (Icicles); Fire does not.
@@ -264,11 +269,11 @@ local function ConstructResourceBar(settings)
 			
 			-- Ensure secondary group knows the correct node count
 			barGroups.secondary:SetNodeCount(maxCharges)
-			barGroups.secondary:SetLayout(settings.comboPoints.spacing, TRB.Functions.Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
+			barGroups.secondary:SetLayout(settings.comboPoints.spacing, Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
 			barGroups.secondary:Show()
 			
 			-- Get effective width for secondary bar, accounting for CDM width matching
-			local effectiveWidth, cdmForced = TRB.Functions.Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
+			local effectiveWidth, cdmForced = Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
 			if cdmForced then
 				barGroups.secondary.fullWidth = true
 			end
@@ -306,11 +311,11 @@ local function ConstructResourceBar(settings)
 			else
 				-- Ensure secondary group knows the correct node count
 				barGroups.secondary:SetNodeCount(maxIcicles)
-				barGroups.secondary:SetLayout(settings.comboPoints.spacing, TRB.Functions.Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
+				barGroups.secondary:SetLayout(settings.comboPoints.spacing, Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
 				barGroups.secondary:Show()
 
 				-- Get effective width for secondary bar, accounting for CDM width matching
-				local effectiveWidth, cdmForced = TRB.Functions.Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
+				local effectiveWidth, cdmForced = Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
 				if cdmForced then
 					barGroups.secondary.fullWidth = true
 				end
@@ -337,7 +342,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	-- TRB.Functions.Bar:HideResourceBar()
+	-- Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -581,7 +586,7 @@ function TRB.Functions.Class:SpellCast(event, spellId)
 end
 
 local function UpdateSnapshot()
-	TRB.Functions.Character:UpdateSnapshot()
+	Character:UpdateSnapshot()
 	--local currentTime = GetTime()
 end
 
@@ -609,7 +614,7 @@ local function UpdateResourceBar()
 
 	-- Always call HideResourceBar first to ensure visibility is correctly determined
 	-- even if we return early due to missing data
-	TRB.Functions.Bar:HideResourceBar()
+	Bar:HideResourceBar()
 
 	if not (barGroups and barGroups.primary) then
 		return
@@ -642,18 +647,18 @@ local function UpdateResourceBar()
 				local currentResource = snapshotData.attributes.resourceModified
 				local barBorderColor = specSettings.colors.bar.border.color
 				local barColor = specSettings.colors.bar.base.color
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			if specSettings.displayBar.secondary.visibility ~= "never" then
 				refreshText = true
 				local currentCharges = snapshotData.attributes.resource2 or 0
-				local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
+				local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
 				for x = 1, TRB.Data.character.maxResource2 do
 					local cpBorderColor = specSettings.colors.comboPoints.border.color
 					local cpColor = specSettings.colors.comboPoints.base.color
@@ -673,7 +678,7 @@ local function UpdateResourceBar()
 					if barGroups and barGroups.secondary then
 						local chargeNode = barGroups.secondary:GetNode(x)
 						if chargeNode then
-							TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, chargeNode, filled and 1 or 0, 1)
+							Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, chargeNode, filled and 1 or 0, 1)
 							chargeNode:SetBorderColor(cpBorderColor)
 							chargeNode:SetColor(cpColor)
 							chargeNode:SetBackgroundColor(cpBR, cpBG, cpBB, cpBackgroundAlpha)
@@ -692,7 +697,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -745,12 +750,12 @@ local function UpdateResourceBar()
 				local currentResource = snapshotData.attributes.resourceModified
 				local barColor = specSettings.colors.bar.base.color
 				local barBorderColor = specSettings.colors.bar.border.color
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			if specSettings.displayBar.health.visibility ~= "never" then
@@ -763,7 +768,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -778,12 +783,12 @@ local function UpdateResourceBar()
 				local currentResource = snapshotData.attributes.resourceModified
 				local barColor = specSettings.colors.bar.base.color
 				local barBorderColor = specSettings.colors.bar.border.color
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			-- Icicles bar (only when Icicles is talented, i.e. maxResource2 > 0)
@@ -793,7 +798,7 @@ local function UpdateResourceBar()
 				local snapshots = snapshotData.snapshots
 				local currentIcicles = snapshots[spells.icicles.id].buff.applications or 0
 				local maxIcicles = spells.icicles.maxStacks
-				local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
+				local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
 				for x = 1, maxIcicles do
 					local cpBorderColor = specSettings.colors.comboPoints.border.color
 					local cpColor = specSettings.colors.comboPoints.base.color
@@ -813,7 +818,7 @@ local function UpdateResourceBar()
 					if barGroups and barGroups.secondary then
 						local icicleNode = barGroups.secondary:GetNode(x)
 						if icicleNode then
-							TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, icicleNode, filled and 1 or 0, 1)
+							Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, icicleNode, filled and 1 or 0, 1)
 							icicleNode:SetBorderColor(cpBorderColor)
 							icicleNode:SetColor(cpColor)
 							icicleNode:SetBackgroundColor(cpBR, cpBG, cpBB, cpBackgroundAlpha)
@@ -832,7 +837,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -875,17 +880,17 @@ local function SwitchSpec()
 	TRB.Data.prevLookupState = {}
 	TRB.Data.lookupDirty = true
 	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+		Bar:QueueRenderTransition("switchSpec", 0.8)
 	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 	end
-	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
+	Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 	
 	if TRB.Data.character.specId == 1 then
 		specCache.mage_arcane.talents:GetTalents()
 		FillSpellData_Arcane()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.mage_arcane)
+		Character:LoadFromSpecializationCache(specCache.mage_arcane)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Mage.ArcaneSpells]]
@@ -893,7 +898,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Arcane
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.mage_arcane.settings)
+		Bar:UpdateSanityCheckValues(specCache.mage_arcane.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		TRB.Data.lookup = lookup
@@ -910,7 +915,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 2 then
 		specCache.mage_fire.talents:GetTalents()
 		FillSpellData_Fire()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.mage_fire)
+		Character:LoadFromSpecializationCache(specCache.mage_fire)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Mage.FireSpells]]
@@ -918,7 +923,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Fire
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.mage_fire.settings)
+		Bar:UpdateSanityCheckValues(specCache.mage_fire.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		TRB.Data.lookup = lookup
@@ -935,7 +940,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 3 then
 		specCache.mage_frost.talents:GetTalents()
 		FillSpellData_Frost()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.mage_frost)
+		Character:LoadFromSpecializationCache(specCache.mage_frost)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Mage.FrostSpells]]
@@ -944,7 +949,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Frost
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.mage_frost.settings)
+		Bar:UpdateSanityCheckValues(specCache.mage_frost.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		TRB.Data.lookup = lookup
@@ -978,9 +983,9 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				TRB.Functions.Character:ResetCaches()
+				Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
-				TRB.Functions.Character:UpdateHealthValues()
+				Character:UpdateHealthValues()
 				TRB.Functions.Class:TriggerResourceBarUpdates()
 			end
 		end)
@@ -1108,9 +1113,9 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
 				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+					Bar:QueueRenderTransition("eventPreSwitch", 0.8)
 				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-					TRB.Functions.Bar:HideResourceBar(true)
+					Bar:HideResourceBar(true)
 				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
@@ -1127,7 +1132,7 @@ function TRB.Functions.Class:CheckCharacter()
 	if specId ~= TRB.Data.character.specId then
 		SwitchSpec()
 	end
-	TRB.Functions.Character:CheckCharacter()
+	Character:CheckCharacter()
 	TRB.Data.character.className = "mage"
 	TRB.Data.character.maxResource = UnitPowerMax("player", TRB.Data.resource)
 
@@ -1146,8 +1151,8 @@ function TRB.Functions.Class:CheckCharacter()
 				local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]
 				if barGroups and barGroups.secondary then
 					barGroups.secondary:Show()
-					TRB.Functions.Bar:ApplyBarGroupsLayout(sharedSettings, barGroups)
-					TRB.Functions.Bar:ApplyBarGroupsAppearance(sharedSettings, barGroups)
+					Bar:ApplyBarGroupsLayout(sharedSettings, barGroups)
+					Bar:ApplyBarGroupsAppearance(sharedSettings, barGroups)
 				end
 			end
 		end
@@ -1171,7 +1176,7 @@ function TRB.Functions.Class:CheckCharacter()
 			if maxIcicles ~= TRB.Data.character.maxResource2 then
 				TRB.Data.character.maxResource2 = maxIcicles
 				if TRB.Frames.barGroups and TRB.Frames.barGroups.primary then
-					TRB.Functions.Bar:SetPosition(sharedSettings, TRB.Frames.barGroups.primary:GetContainerFrame())
+					Bar:SetPosition(sharedSettings, TRB.Frames.barGroups.primary:GetContainerFrame())
 				end
 			end
 		end
@@ -1203,7 +1208,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.specSupported = false
 	end
 
-	TRB.Functions.Character:EventRegistration()
+	Character:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
@@ -1333,8 +1338,8 @@ function TRB.Functions.Class:GetBarTextFrame(relativeToFrame)
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
-	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
-		TRB.Functions.Bar:HideResourceBar(true)
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and Bar:IsRenderTransitionActive() then
+		Bar:HideResourceBar(true)
 		return
 	end
 
@@ -1342,7 +1347,7 @@ function TRB.Functions.Class:TriggerResourceBarUpdates()
 		return
 	end
 	if (TRB.Data.character.specId ~= 1 and TRB.Data.character.specId ~= 2 and TRB.Data.character.specId ~= 3) then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 		return
 	end
 

--- a/ClassModules/Monk.lua
+++ b/ClassModules/Monk.lua
@@ -6,6 +6,11 @@ end
 local L = TRB.Localization
 TRB.Functions.Class = TRB.Functions.Class or {}
 local lookupChanged = TRB.Functions.BarText.LookupChanged
+local Threshold = TRB.Functions.Threshold
+local Bar = TRB.Functions.Bar
+local Color = TRB.Functions.Color
+local Character = TRB.Functions.Character
+local frameLevels = TRB.Data.constants.frameLevels
 
 local targetsTimerFrame = TRB.Frames.targetsTimerFrame
 
@@ -168,12 +173,12 @@ local function FillSpecializationCache()
 end
 
 local function Setup_Brewmaster()
-	TRB.Functions.Character:FillSpecializationCacheSettings("monk", "brewmaster")
+	Character:FillSpecializationCacheSettings("monk", "brewmaster")
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	-- (guards against redundant delayed SwitchSpec calls that would orphan initialized bars)
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "monk_brewmaster" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Monk.BarGroupsFactory:CreateForSpec(1)
 	end
 end
@@ -188,12 +193,12 @@ local function FillSpellData_Brewmaster()
 end
 
 local function Setup_Mistweaver()
-	TRB.Functions.Character:FillSpecializationCacheSettings("monk", "mistweaver", true)
+	Character:FillSpecializationCacheSettings("monk", "mistweaver", true)
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	-- (guards against redundant delayed SwitchSpec calls that would orphan initialized bars)
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "monk_mistweaver" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Monk.BarGroupsFactory:CreateForSpec(2)
 	end
 end
@@ -208,12 +213,12 @@ local function FillSpellData_Mistweaver()
 end
 
 local function Setup_Windwalker()
-	TRB.Functions.Character:FillSpecializationCacheSettings("monk", "windwalker")
+	Character:FillSpecializationCacheSettings("monk", "windwalker")
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	-- (guards against redundant delayed SwitchSpec calls that would orphan initialized bars)
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "monk_windwalker" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Monk.BarGroupsFactory:CreateForSpec(3)
 	end
 end
@@ -258,12 +263,12 @@ local function ConstructResourceBar(settings)
 			primaryNode:ClearThresholds()
 			for _ = 1, #TRB.Data.cache.thresholdSpells do
 				local thresholdFrame = CreateFrame("Frame", nil, primaryNode:GetFrame())
-				TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, settings, true)
+				Threshold:ResetThresholdLine(thresholdFrame, settings, true)
 				primaryNode:RegisterThreshold(thresholdFrame)
 			end
 		end
 
-		TRB.Functions.Bar:ConstructBarGroups(settings, barGroups)
+		Bar:ConstructBarGroups(settings, barGroups)
 	end
 
 	-- Handle secondary bar based on spec
@@ -286,7 +291,7 @@ local function ConstructResourceBar(settings)
 					
 					for _ = 1, 3 do
 						local thresholdFrame = CreateFrame("Frame", nil, staggerNode:GetFrame())
-						TRB.Functions.Threshold:ResetThresholdLineCustomBar(thresholdFrame, thresholdWidth, thresholdHeight, borderColor)
+						Threshold:ResetThresholdLineCustomBar(thresholdFrame, thresholdWidth, thresholdHeight, borderColor)
 						staggerNode:RegisterThreshold(thresholdFrame)
 					end
 				end
@@ -304,11 +309,11 @@ local function ConstructResourceBar(settings)
 			
 			-- Set the node count and layout for Chi
 			barGroups.secondary:SetNodeCount(maxChi)
-			barGroups.secondary:SetLayout(settings.comboPoints.spacing, TRB.Functions.Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
+			barGroups.secondary:SetLayout(settings.comboPoints.spacing, Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
 			barGroups.secondary:Show()
 			
 			-- Get effective width for secondary bar, accounting for CDM width matching
-			local effectiveWidth, cdmForced = TRB.Functions.Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
+			local effectiveWidth, cdmForced = Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
 			if cdmForced then
 				barGroups.secondary.fullWidth = true
 			end
@@ -343,7 +348,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	-- TRB.Functions.Bar:HideResourceBar()
+	-- Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -400,7 +405,7 @@ local function RefreshLookupData_Brewmaster()
 			local currentEnergy
 			local castingEnergy
 			if sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentEnergyColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentEnergyColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				currentEnergy = textColorResult:WrapTextInColorCode(resourceFormatted)
 				castingEnergy = textColorResult:WrapTextInColorCode(string.format("%.0f", _castingEnergy))
@@ -426,7 +431,7 @@ local function RefreshLookupData_Brewmaster()
 		local staggerColor = staggerColors.low and staggerColors.low.color
 		if snapshotData.attributes.staggerColor then
 			local r, g, b, a = snapshotData.attributes.staggerColor:GetRGBA()
-			staggerColor = TRB.Functions.Color:ConvertColorDecimalToHex(r, g, b, a)
+			staggerColor = Color:ConvertColorDecimalToHex(r, g, b, a)
 		end
 
 		lookupLogic["$stagger"] = _stagger
@@ -560,7 +565,7 @@ local function RefreshLookupData_Windwalker()
 			local currentEnergy
 			local castingEnergy
 			if sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentEnergyColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentEnergyColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				currentEnergy = textColorResult:WrapTextInColorCode(resourceFormatted)
 				castingEnergy = textColorResult:WrapTextInColorCode(string.format("%.0f", TRB.Functions.Number:RoundTo(_castingEnergy, resourcePrecision, "floor")))
@@ -793,7 +798,7 @@ function TRB.Functions.Class:DisableEvents()
 end
 
 local function UpdateSnapshot()
-	TRB.Functions.Character:UpdateSnapshot()
+	Character:UpdateSnapshot()
 	--local currentTime = GetTime()
 end
 
@@ -824,7 +829,7 @@ local function UpdateStaggerColor()
 	-- Light/Low stagger color and threshold (renamed from "light" to "low" in new structure)
 	if staggerBarSettings.low then
 		if staggerBarSettings.low.color then
-			lightR, lightG, lightB, lightA = TRB.Functions.Color:GetRGBAFromString(staggerBarSettings.low.color, true)
+			lightR, lightG, lightB, lightA = Color:GetRGBAFromString(staggerBarSettings.low.color, true)
 		end
 		if staggerBarSettings.low.threshold then
 			lightThreshold = staggerBarSettings.low.threshold
@@ -832,7 +837,7 @@ local function UpdateStaggerColor()
 	elseif staggerBarSettings.light then
 		-- Backwards compatibility with old structure
 		if staggerBarSettings.light.color then
-			lightR, lightG, lightB, lightA = TRB.Functions.Color:GetRGBAFromString(staggerBarSettings.light.color, true)
+			lightR, lightG, lightB, lightA = Color:GetRGBAFromString(staggerBarSettings.light.color, true)
 		end
 		if staggerBarSettings.light.threshold then
 			lightThreshold = staggerBarSettings.light.threshold
@@ -844,7 +849,7 @@ local function UpdateStaggerColor()
 	-- Heavy stagger color and threshold
 	if staggerBarSettings.heavy then
 		if staggerBarSettings.heavy.color then
-			heavyR, heavyG, heavyB, heavyA = TRB.Functions.Color:GetRGBAFromString(staggerBarSettings.heavy.color, true)
+			heavyR, heavyG, heavyB, heavyA = Color:GetRGBAFromString(staggerBarSettings.heavy.color, true)
 		end
 		if staggerBarSettings.heavy.threshold then
 			heavyThreshold = staggerBarSettings.heavy.threshold
@@ -856,7 +861,7 @@ local function UpdateStaggerColor()
 	local extremeThreshold = 1.0
 	if staggerBarSettings.extreme then
 		if staggerBarSettings.extreme.color then
-			extremeR, extremeG, extremeB, extremeA = TRB.Functions.Color:GetRGBAFromString(staggerBarSettings.extreme.color, true)
+			extremeR, extremeG, extremeB, extremeA = Color:GetRGBAFromString(staggerBarSettings.extreme.color, true)
 		end
 		if staggerBarSettings.extreme.threshold then
 			extremeThreshold = staggerBarSettings.extreme.threshold
@@ -884,7 +889,7 @@ local function UpdateStaggerColor()
 		-- Medium stagger color and threshold
 		if staggerBarSettings.medium then
 			if staggerBarSettings.medium.color then
-				mediumR, mediumG, mediumB, mediumA = TRB.Functions.Color:GetRGBAFromString(staggerBarSettings.medium.color, true)
+				mediumR, mediumG, mediumB, mediumA = Color:GetRGBAFromString(staggerBarSettings.medium.color, true)
 			end
 			if staggerBarSettings.medium.threshold then
 				mediumThreshold = staggerBarSettings.medium.threshold
@@ -973,7 +978,7 @@ local function UpdateResourceBar()
 
 	-- Always call HideResourceBar first to ensure visibility is correctly determined
 	-- even if we return early due to missing data
-	TRB.Functions.Bar:HideResourceBar()
+	Bar:HideResourceBar()
 
 	if TRB.Data.character.maxResource == nil then
 		return
@@ -1001,7 +1006,7 @@ local function UpdateResourceBar()
 				end
 				
 				if primaryNode then
-					TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+					Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 					
 					local thresholds = primaryNode:GetThresholds()
 					local nodeResourceFrame = primaryNode:GetFrame()
@@ -1011,7 +1016,7 @@ local function UpdateResourceBar()
 						-- Create threshold on-demand if missing
 						if thresholds[thresholdId] == nil then
 							local thresholdFrame = CreateFrame("Frame", nil, nodeResourceFrame)
-							TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
+							Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
 							primaryNode:RegisterThreshold(thresholdFrame)
 							thresholds = primaryNode:GetThresholds()
 						end
@@ -1020,7 +1025,7 @@ local function UpdateResourceBar()
 						local isUsable = spell:IsUsable()
 						local showThreshold = true
 						local thresholdColor = specCacheSettings.colors.threshold.over.color
-						local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+						local frameLevel = frameLevels.thresholdOver
 						local snapshot = snapshots[spell.id]
 
 						if spell.isSnowflake then -- These are special snowflakes that we need to handle manually
@@ -1033,19 +1038,19 @@ local function UpdateResourceBar()
 						elseif spell.hasCooldown then
 							if snapshotData.snapshots[spell.id].cooldown:IsUnusable() then
 								thresholdColor = specCacheSettings.colors.threshold.unusable.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+								frameLevel = frameLevels.thresholdUnusable
 							elseif isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						else -- This is an active/available/normal spell threshold
 							if isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						end
 
@@ -1053,8 +1058,8 @@ local function UpdateResourceBar()
 							showThreshold = false
 						end
 
-						local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-						TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, nodeResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
+						local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+						Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, nodeResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
 					end
 
 					local barBorderColor = specSettings.colors.bar.border.color
@@ -1069,7 +1074,7 @@ local function UpdateResourceBar()
 						if specSettings.endOf.invokeNiuzao.enabled then
 							useEndOfNiuzaoColor = true
 							if specSettings.endOf.invokeNiuzao.mode == "gcd" then
-								local gcd = TRB.Functions.Character:GetCurrentGCDTime()
+								local gcd = Character:GetCurrentGCDTime()
 								timeThreshold = gcd * specSettings.endOf.invokeNiuzao.gcdsMax
 							elseif specSettings.endOf.invokeNiuzao.mode == "time" then
 								timeThreshold = specSettings.endOf.invokeNiuzao.timeMax
@@ -1086,7 +1091,7 @@ local function UpdateResourceBar()
 					barGroups.primary:GetContainerFrame():SetAlpha(1.0)
 					-- Apply overcap border color if enabled
 					if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
-						local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+						local overcapBorderCurve = Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 						local borderColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapBorderCurve)
 						primaryNode:SetBorderColorCurve(borderColorResult)
 					else
@@ -1094,7 +1099,7 @@ local function UpdateResourceBar()
 					end
 					primaryNode:SetColor(barColor)
 					primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-					TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+					Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 				end
 			end
 
@@ -1119,7 +1124,7 @@ local function UpdateResourceBar()
 						
 						-- Calculate effective width (respects fullWidth setting and Edit Mode CDM width matching)
 						local staggerWidth
-						if TRB.Functions.Bar:GetMatchWidth(staggerSettings) then
+						if Bar:GetMatchWidth(staggerSettings) then
 							-- When matchWidth is enabled, use effectiveWidth (which accounts for CDM width matching)
 							staggerWidth = (barGroups and barGroups.effectiveWidth) or specSettings.bar.width
 						else
@@ -1128,7 +1133,7 @@ local function UpdateResourceBar()
 						
 						local cpBackgroundColor = staggerColors.background
 						if type(cpBackgroundColor) == "table" then cpBackgroundColor = cpBackgroundColor.color end
-						local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(cpBackgroundColor, true)
+						local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(cpBackgroundColor, true)
 						local cpBorderColor = staggerColors.border
 						if type(cpBorderColor) == "table" then cpBorderColor = cpBorderColor.color end
 						cpBorderColor = cpBorderColor
@@ -1147,8 +1152,8 @@ local function UpdateResourceBar()
 							local mediumColor = staggerColors.medium and staggerColors.medium.color
 							-- Hide threshold if it exceeds the bar's max scale
 							local showMediumThreshold = specSettings.thresholds.stagger and specSettings.thresholds.stagger.medium and specSettings.thresholds.stagger.medium.enabled and mediumThreshold <= maxScale or false
-							TRB.Functions.Color:SetThresholdColor(staggerThresholds[1], mediumColor, true)
-							TRB.Functions.Threshold:RepositionThresholdCustomBar("staggerThreshold1", staggerThresholds[1], showMediumThreshold, staggerNode:GetFrame(), mediumThreshold * snapshotData.attributes.healthMax, scaledMaxHealth, staggerWidth, staggerBorder)
+							Color:SetThresholdColor(staggerThresholds[1], mediumColor, true)
+							Threshold:RepositionThresholdCustomBar("staggerThreshold1", staggerThresholds[1], showMediumThreshold, staggerNode:GetFrame(), mediumThreshold * snapshotData.attributes.healthMax, scaledMaxHealth, staggerWidth, staggerBorder)
 						end
 
 						-- Heavy Stagger threshold (configurable position, discrete color)
@@ -1157,8 +1162,8 @@ local function UpdateResourceBar()
 							local heavyColor = staggerColors.heavy and staggerColors.heavy.color
 							-- Hide threshold if it exceeds the bar's max scale
 							local showHeavyThreshold = specSettings.thresholds.stagger and specSettings.thresholds.stagger.heavy and specSettings.thresholds.stagger.heavy.enabled and heavyThreshold <= maxScale or false
-							TRB.Functions.Color:SetThresholdColor(staggerThresholds[2], heavyColor, true)
-							TRB.Functions.Threshold:RepositionThresholdCustomBar("staggerThreshold2", staggerThresholds[2], showHeavyThreshold, staggerNode:GetFrame(), heavyThreshold * snapshotData.attributes.healthMax, scaledMaxHealth, staggerWidth, staggerBorder)
+							Color:SetThresholdColor(staggerThresholds[2], heavyColor, true)
+							Threshold:RepositionThresholdCustomBar("staggerThreshold2", staggerThresholds[2], showHeavyThreshold, staggerNode:GetFrame(), heavyThreshold * snapshotData.attributes.healthMax, scaledMaxHealth, staggerWidth, staggerBorder)
 						end
 
 						-- Extremely Heavy Stagger threshold (configurable position, discrete color)
@@ -1167,8 +1172,8 @@ local function UpdateResourceBar()
 							local extremeColor = staggerColors.extreme and staggerColors.extreme.color
 							-- Hide threshold if it exceeds the bar's max scale
 							local showExtremeThreshold = specSettings.thresholds.stagger and specSettings.thresholds.stagger.extreme and specSettings.thresholds.stagger.extreme.enabled and extremeThreshold <= maxScale or false
-							TRB.Functions.Color:SetThresholdColor(staggerThresholds[3], extremeColor, true)
-							TRB.Functions.Threshold:RepositionThresholdCustomBar("staggerThreshold3", staggerThresholds[3], showExtremeThreshold, staggerNode:GetFrame(), extremeThreshold * snapshotData.attributes.healthMax, scaledMaxHealth, staggerWidth, staggerBorder)
+							Color:SetThresholdColor(staggerThresholds[3], extremeColor, true)
+							Threshold:RepositionThresholdCustomBar("staggerThreshold3", staggerThresholds[3], showExtremeThreshold, staggerNode:GetFrame(), extremeThreshold * snapshotData.attributes.healthMax, scaledMaxHealth, staggerWidth, staggerBorder)
 						end
 					end
 				end
@@ -1184,7 +1189,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1201,7 +1206,7 @@ local function UpdateResourceBar()
 				local currentResource = snapshotData.attributes.resourceModified
 
 				if primaryNode then
-					TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+					Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 
 					local barColor = specSettings.colors.bar.base.color
 					local barBorderColor = specSettings.colors.bar.border.color
@@ -1214,7 +1219,7 @@ local function UpdateResourceBar()
 					primaryNode:SetBorderColor(barBorderColor)
 					primaryNode:SetColor(barColor)
 					primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-					TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+					Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 				end
 			end
 
@@ -1228,7 +1233,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1253,7 +1258,7 @@ local function UpdateResourceBar()
 				end
 
 				if primaryNode then
-					TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+					Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 
 					local thresholds = primaryNode:GetThresholds()
 					local nodeResourceFrame = primaryNode:GetFrame()
@@ -1263,7 +1268,7 @@ local function UpdateResourceBar()
 						-- Create threshold on-demand if missing
 						if thresholds[thresholdId] == nil then
 							local thresholdFrame = CreateFrame("Frame", nil, nodeResourceFrame)
-							TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
+							Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
 							primaryNode:RegisterThreshold(thresholdFrame)
 							thresholds = primaryNode:GetThresholds()
 						end
@@ -1272,7 +1277,7 @@ local function UpdateResourceBar()
 						local isUsable = spell:IsUsable()
 						local showThreshold = true
 						local thresholdColor = specCacheSettings.colors.threshold.over.color
-						local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+						local frameLevel = frameLevels.thresholdOver
 						local snapshot = snapshots[spell.id]
 
 						if spell.isSnowflake then -- These are special snowflakes that we need to handle manually
@@ -1281,12 +1286,12 @@ local function UpdateResourceBar()
 									showThreshold = false
 								elseif snapshotData.snapshots[spell.id].cooldown:IsUnusable() then
 									thresholdColor = specCacheSettings.colors.threshold.unusable.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+									frameLevel = frameLevels.thresholdUnusable
 								elseif isUsable then
 									thresholdColor = specCacheSettings.colors.threshold.over.color
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							end
 						elseif resourceAmount == 0 then
@@ -1298,19 +1303,19 @@ local function UpdateResourceBar()
 						elseif spell.hasCooldown then
 							if snapshotData.snapshots[spell.id].cooldown:IsUnusable() then
 								thresholdColor = specCacheSettings.colors.threshold.unusable.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+								frameLevel = frameLevels.thresholdUnusable
 							elseif isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						else -- This is an active/available/normal spell threshold
 							if isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						end
 
@@ -1318,15 +1323,15 @@ local function UpdateResourceBar()
 							spell--[[@as TRB.Classes.SpellComboPointThreshold]].comboPoints == true
 							and snapshotData.attributes.resource2 == 0 then
 							thresholdColor = specCacheSettings.colors.threshold.unusable.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+							frameLevel = frameLevels.thresholdUnusable
 						end
 						
 						if resourceAmount >= maxPrimaryBarResourceUnnormalized then
 							showThreshold = false
 						end
 
-						local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-						TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, nodeResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
+						local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+						Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, nodeResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
 					end
 
 					local barColor = specSettings.colors.bar.base.color
@@ -1344,7 +1349,7 @@ local function UpdateResourceBar()
 					barGroups.primary:GetContainerFrame():SetAlpha(1.0)
 					-- Apply overcap border color if enabled
 					if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
-						local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+						local overcapBorderCurve = Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 						local borderColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapBorderCurve)
 						primaryNode:SetBorderColorCurve(borderColorResult)
 					else
@@ -1352,14 +1357,14 @@ local function UpdateResourceBar()
 					end
 					primaryNode:SetColor(barColor)
 					primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-					TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+					Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 				end
 			end
 			
 			if specSettings.displayBar.secondary.visibility ~= "never" then
 				refreshText = true
 				-- Update Chi using BarNodes
-				local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
+				local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
 				
 				for x = 1, TRB.Data.character.maxResource2 do
 					local cpBorderColor = specSettings.colors.comboPoints.border.color
@@ -1372,14 +1377,14 @@ local function UpdateResourceBar()
 						local chiNode = barGroups.secondary:GetNode(x)
 						if chiNode then
 							if snapshotData.attributes.resource2 >= x then
-								TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, chiNode, 1, 1)
+								Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, chiNode, 1, 1)
 								if (specSettings.comboPoints.sameColor and snapshotData.attributes.resource2 == (TRB.Data.character.maxResource2 - 1)) or (not specSettings.comboPoints.sameColor and x == (TRB.Data.character.maxResource2 - 1)) then
 									cpColor = specSettings.colors.comboPoints.penultimate.color
 								elseif (specSettings.comboPoints.sameColor and snapshotData.attributes.resource2 == (TRB.Data.character.maxResource2)) or x == TRB.Data.character.maxResource2 then
 									cpColor = specSettings.colors.comboPoints.final.color
 								end
 							else
-								TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, chiNode, 0, 1)
+								Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, chiNode, 0, 1)
 							end
 							
 							chiNode:SetBorderColor(cpBorderColor)
@@ -1400,7 +1405,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -1479,17 +1484,17 @@ local function SwitchSpec()
 	TRB.Data.prevLookupState = {}
 	TRB.Data.lookupDirty = true
 	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+		Bar:QueueRenderTransition("switchSpec", 0.8)
 	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 	end
-	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
+	Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 
 	if TRB.Data.character.specId == 1 then
 		specCache.monk_brewmaster.talents:GetTalents()
 		FillSpellData_Brewmaster()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.monk_brewmaster)
+		Character:LoadFromSpecializationCache(specCache.monk_brewmaster)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Monk.BrewmasterSpells]]
@@ -1497,7 +1502,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Brewmaster
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.monk_brewmaster.settings)
+		Bar:UpdateSanityCheckValues(specCache.monk_brewmaster.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#niuzao"] = spells.invokeNiuzao.icon
@@ -1516,7 +1521,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 2 then
 		specCache.monk_mistweaver.talents:GetTalents()
 		FillSpellData_Mistweaver()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.monk_mistweaver)
+		Character:LoadFromSpecializationCache(specCache.monk_mistweaver)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Monk.MistweaverSpells]]
@@ -1524,7 +1529,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Mistweaver
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.monk_mistweaver.settings)
+		Bar:UpdateSanityCheckValues(specCache.monk_mistweaver.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#hotjs"] = spells.heartOfTheJadeSerpent.icon
@@ -1543,7 +1548,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 3 then
 		specCache.monk_windwalker.talents:GetTalents()
 		FillSpellData_Windwalker()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.monk_windwalker)
+		Character:LoadFromSpecializationCache(specCache.monk_windwalker)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Monk.WindwalkerSpells]]
@@ -1552,7 +1557,7 @@ local function SwitchSpec()
 		local targetData = TRB.Data.snapshotData.targetData
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Windwalker
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.monk_windwalker.settings)
+		Bar:UpdateSanityCheckValues(specCache.monk_windwalker.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#blackoutKick"] = spells.blackoutKick.icon
@@ -1603,13 +1608,13 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				TRB.Functions.Character:ResetCaches()
+				Character:ResetCaches()
 				-- Reapply bar textures after spec switch to ensure health bar and other bar textures render correctly
 				if TRB.Frames.barGroups then
-					TRB.Functions.Bar:ApplyBarGroupsAppearance(specCache[TRB.Data.barConstructedForSpec].settings, TRB.Frames.barGroups)
+					Bar:ApplyBarGroupsAppearance(specCache[TRB.Data.barConstructedForSpec].settings, TRB.Frames.barGroups)
 				end
 				-- Ensure health values are populated so the health bar displays immediately
-				TRB.Functions.Character:UpdateHealthValues()
+				Character:UpdateHealthValues()
 				TRB.Functions.Class:TriggerResourceBarUpdates()
 			end
 		end)
@@ -1734,9 +1739,9 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
 				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+					Bar:QueueRenderTransition("eventPreSwitch", 0.8)
 				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-					TRB.Functions.Bar:HideResourceBar(true)
+					Bar:HideResourceBar(true)
 				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
@@ -1753,7 +1758,7 @@ function TRB.Functions.Class:CheckCharacter()
 	if specId ~= TRB.Data.character.specId then
 		SwitchSpec()
 	end
-	TRB.Functions.Character:CheckCharacter()
+	Character:CheckCharacter()
 	TRB.Data.character.className = "monk"
 	TRB.Data.character.maxResource = UnitPowerMax("player", TRB.Data.resource)
 	local maxComboPoints = 0
@@ -1772,7 +1777,7 @@ function TRB.Functions.Class:CheckCharacter()
 			if maxComboPoints ~= TRB.Data.character.maxResource2 then
 				TRB.Data.character.maxResource2 = maxComboPoints
 				if barGroups and barGroups.primary then
-					TRB.Functions.Bar:SetPosition(sharedSettings, barGroups.primary:GetContainerFrame())
+					Bar:SetPosition(sharedSettings, barGroups.primary:GetContainerFrame())
 				end
 			end
 		end
@@ -1795,7 +1800,7 @@ function TRB.Functions.Class:CheckCharacter()
 			if maxComboPoints ~= TRB.Data.character.maxResource2 then
 				TRB.Data.character.maxResource2 = maxComboPoints
 				if barGroups and barGroups.primary then
-					TRB.Functions.Bar:SetPosition(sharedSettings, barGroups.primary:GetContainerFrame())
+					Bar:SetPosition(sharedSettings, barGroups.primary:GetContainerFrame())
 				end
 				-- Rebuild secondary bar layout when chi count changes
 				if barGroups and barGroups.secondary then
@@ -1804,10 +1809,10 @@ function TRB.Functions.Class:CheckCharacter()
 					
 					barGroups.secondary:SetMaxNodes(maxComboPoints)
 					barGroups.secondary:SetNodeCount(maxComboPoints)
-					barGroups.secondary:SetLayout(sharedSettings.comboPoints.spacing, TRB.Functions.Bar:GetMatchWidth(sharedSettings.comboPoints), "HORIZONTAL")
+					barGroups.secondary:SetLayout(sharedSettings.comboPoints.spacing, Bar:GetMatchWidth(sharedSettings.comboPoints), "HORIZONTAL")
 					
 					-- Get effective width for secondary bar, accounting for CDM width matching
-					local effectiveWidth, cdmForced = TRB.Functions.Bar:GetEffectiveWidthForBarGroup(barGroups, sharedSettings, "secondary")
+					local effectiveWidth, cdmForced = Bar:GetEffectiveWidthForBarGroup(barGroups, sharedSettings, "secondary")
 					if cdmForced then
 						barGroups.secondary.fullWidth = true
 					end
@@ -1866,7 +1871,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Functions.Class:DisableEvents()
 	end
 
-	TRB.Functions.Character:EventRegistration()
+	Character:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
@@ -2051,7 +2056,7 @@ function TRB.Functions.Class:RecreateThresholds(settings, barGroups)
 				primaryNode:ClearThresholds()
 				for _ = 1, #thresholdSpells do
 					local thresholdFrame = CreateFrame("Frame", nil, primaryNode:GetFrame())
-					TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, settings, true)
+					Threshold:ResetThresholdLine(thresholdFrame, settings, true)
 					primaryNode:RegisterThreshold(thresholdFrame)
 				end
 			end
@@ -2073,7 +2078,7 @@ function TRB.Functions.Class:RecreateThresholds(settings, barGroups)
 				
 				for _ = 1, 3 do
 					local thresholdFrame = CreateFrame("Frame", nil, staggerNode:GetFrame())
-					TRB.Functions.Threshold:ResetThresholdLineCustomBar(thresholdFrame, thresholdWidth, thresholdHeight, borderColor)
+					Threshold:ResetThresholdLineCustomBar(thresholdFrame, thresholdWidth, thresholdHeight, borderColor)
 					staggerNode:RegisterThreshold(thresholdFrame)
 				end
 			end
@@ -2099,8 +2104,8 @@ function TRB.Functions.Class:HasActiveTimers()
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
-	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
-		TRB.Functions.Bar:HideResourceBar(true)
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and Bar:IsRenderTransitionActive() then
+		Bar:HideResourceBar(true)
 		return
 	end
 
@@ -2108,7 +2113,7 @@ function TRB.Functions.Class:TriggerResourceBarUpdates()
 		return
 	end
 	if TRB.Data.character.specId ~= 1 and TRB.Data.character.specId ~= 2 and TRB.Data.character.specId ~= 3 then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 		return
 	end
 

--- a/ClassModules/Paladin.lua
+++ b/ClassModules/Paladin.lua
@@ -6,6 +6,11 @@ end
 local L = TRB.Localization
 TRB.Functions.Class = TRB.Functions.Class or {}
 local lookupChanged = TRB.Functions.BarText.LookupChanged
+local Threshold = TRB.Functions.Threshold
+local Bar = TRB.Functions.Bar
+local Color = TRB.Functions.Color
+local Character = TRB.Functions.Character
+local frameLevels = TRB.Data.constants.frameLevels
 
 local targetsTimerFrame = TRB.Frames.targetsTimerFrame
 
@@ -130,11 +135,11 @@ local function FillSpecializationCache()
 end
 
 local function Setup_Holy()
-	TRB.Functions.Character:FillSpecializationCacheSettings("paladin", "holy", true)
+	Character:FillSpecializationCacheSettings("paladin", "holy", true)
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "paladin_holy" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Paladin.BarGroupsFactory:CreateForSpec(1, UIParent)
 	end
 end
@@ -148,11 +153,11 @@ local function FillSpellData_Holy()
 end
 
 local function Setup_Protection()
-	TRB.Functions.Character:FillSpecializationCacheSettings("paladin", "protection", true)
+	Character:FillSpecializationCacheSettings("paladin", "protection", true)
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "paladin_protection" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Paladin.BarGroupsFactory:CreateForSpec(2, UIParent)
 	end
 end
@@ -166,11 +171,11 @@ local function FillSpellData_Protection()
 end
 
 local function Setup_Retribution()
-	TRB.Functions.Character:FillSpecializationCacheSettings("paladin", "retribution", true)
+	Character:FillSpecializationCacheSettings("paladin", "retribution", true)
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "paladin_retribution" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Paladin.BarGroupsFactory:CreateForSpec(3, UIParent)
 	end
 end
@@ -243,12 +248,12 @@ local function ConstructResourceBar(settings)
 			primaryNode:ClearThresholds()
 			for _ = 1, #TRB.Data.cache.thresholdSpells do
 				local thresholdFrame = CreateFrame("Frame", nil, primaryNode:GetFrame())
-				TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, settings, true)
+				Threshold:ResetThresholdLine(thresholdFrame, settings, true)
 				primaryNode:RegisterThreshold(thresholdFrame)
 			end
 		end
 
-		TRB.Functions.Bar:ConstructBarGroups(settings, barGroups)
+		Bar:ConstructBarGroups(settings, barGroups)
 	end
 
 	-- All Paladin specs use Holy Power secondary bar
@@ -257,11 +262,11 @@ local function ConstructResourceBar(settings)
 		
 		-- Ensure secondary group knows the correct node count
 		barGroups.secondary:SetNodeCount(maxHolyPower)
-		barGroups.secondary:SetLayout(settings.comboPoints.spacing, TRB.Functions.Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
+		barGroups.secondary:SetLayout(settings.comboPoints.spacing, Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
 		barGroups.secondary:Show()
 		
 		-- Get effective width for secondary bar, accounting for CDM width matching
-		local effectiveWidth, cdmForced = TRB.Functions.Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
+		local effectiveWidth, cdmForced = Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
 		if cdmForced then
 			barGroups.secondary.fullWidth = true
 		end
@@ -295,7 +300,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	-- TRB.Functions.Bar:HideResourceBar()
+	-- Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -555,7 +560,7 @@ function TRB.Functions.Class:SpellCast(event, spellId)
 end
 
 local function UpdateSnapshot()
-	TRB.Functions.Character:UpdateSnapshot()
+	Character:UpdateSnapshot()
 	--local currentTime = GetTime()
 end
 
@@ -644,7 +649,7 @@ local function UpdateResourceBar()
 
 	-- Always call HideResourceBar first to ensure visibility is correctly determined
 	-- even if we return early due to missing data
-	TRB.Functions.Bar:HideResourceBar()
+	Bar:HideResourceBar()
 
 	if not (barGroups and barGroups.primary) then
 		return
@@ -665,7 +670,7 @@ local function UpdateResourceBar()
 
 	local function UpdateHolyPower(specSettings, specCacheSettings)
 		local currentHolyPower = snapshotData.attributes.resource2 or 0
-		local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
+		local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
 		for x = 1, TRB.Data.character.maxResource2 do
 			local cpBorderColor = specSettings.colors.comboPoints.border.color
 			local cpColor = specSettings.colors.comboPoints.base.color
@@ -689,7 +694,7 @@ local function UpdateResourceBar()
 			if barGroups and barGroups.secondary then
 				local holyPowerNode = barGroups.secondary:GetNode(x)
 				if holyPowerNode then
-					TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, holyPowerNode, filled and 1 or 0, 1)
+					Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, holyPowerNode, filled and 1 or 0, 1)
 					holyPowerNode:SetBorderColor(cpBorderColor)
 					holyPowerNode:SetColor(cpColor)
 					holyPowerNode:SetBackgroundColor(cpBR, cpBG, cpBB, cpBackgroundAlpha)
@@ -723,12 +728,12 @@ local function UpdateResourceBar()
 					snapshotData.audio.infusionOfLightPlayed = false
 				end
 
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			if specSettings.displayBar.secondary.visibility ~= "never" then
@@ -746,7 +751,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 
 		end
@@ -767,12 +772,12 @@ local function UpdateResourceBar()
 				local currentResource = snapshotData.attributes.resourceModified
 				local barColor = specSettings.colors.bar.base.color
 				local barBorderColor = specSettings.colors.bar.border.color
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			if specSettings.displayBar.secondary.visibility ~= "never" then
@@ -790,7 +795,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 
 		end
@@ -811,12 +816,12 @@ local function UpdateResourceBar()
 				local currentResource = snapshotData.attributes.resourceModified
 				local barColor = specSettings.colors.bar.base.color
 				local barBorderColor = specSettings.colors.bar.border.color
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			if specSettings.displayBar.secondary.visibility ~= "never" then
@@ -834,7 +839,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 
 		end
@@ -861,17 +866,17 @@ local function SwitchSpec()
 	TRB.Data.prevLookupState = {}
 	TRB.Data.lookupDirty = true
 	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+		Bar:QueueRenderTransition("switchSpec", 0.8)
 	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 	end
-	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
+	Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 	
 	if TRB.Data.character.specId == 1 then
 		specCache.paladin_holy.talents:GetTalents()
 		FillSpellData_Holy()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.paladin_holy)
+		Character:LoadFromSpecializationCache(specCache.paladin_holy)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Paladin.HolySpells]]
@@ -879,7 +884,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Holy
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.paladin_holy.settings)
+		Bar:UpdateSanityCheckValues(specCache.paladin_holy.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		TRB.Data.lookup = lookup
@@ -896,7 +901,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 2 then
 		specCache.paladin_protection.talents:GetTalents()
 		FillSpellData_Protection()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.paladin_protection)
+		Character:LoadFromSpecializationCache(specCache.paladin_protection)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Paladin.ProtectionSpells]]
@@ -904,7 +909,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Protection
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.paladin_protection.settings)
+		Bar:UpdateSanityCheckValues(specCache.paladin_protection.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		TRB.Data.lookup = lookup
@@ -921,7 +926,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 3 then
 		specCache.paladin_retribution.talents:GetTalents()
 		FillSpellData_Retribution()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.paladin_retribution)
+		Character:LoadFromSpecializationCache(specCache.paladin_retribution)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Paladin.RetributionSpells]]
@@ -929,7 +934,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Retribution
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.paladin_retribution.settings)
+		Bar:UpdateSanityCheckValues(specCache.paladin_retribution.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		TRB.Data.lookup = lookup
@@ -955,9 +960,9 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				TRB.Functions.Character:ResetCaches()
+				Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
-				TRB.Functions.Character:UpdateHealthValues()
+				Character:UpdateHealthValues()
 				TRB.Functions.Class:TriggerResourceBarUpdates()
 			end
 		end)
@@ -1085,9 +1090,9 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
 				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+					Bar:QueueRenderTransition("eventPreSwitch", 0.8)
 				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-					TRB.Functions.Bar:HideResourceBar(true)
+					Bar:HideResourceBar(true)
 				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
@@ -1104,7 +1109,7 @@ function TRB.Functions.Class:CheckCharacter()
 	if specId ~= TRB.Data.character.specId then
 		SwitchSpec()
 	end
-	TRB.Functions.Character:CheckCharacter()
+	Character:CheckCharacter()
 	TRB.Data.character.className = "paladin"
 	TRB.Data.character.maxResource = UnitPowerMax("player", TRB.Data.resource)
 	TRB.Data.character.maxResource2 = 1
@@ -1130,7 +1135,7 @@ function TRB.Functions.Class:CheckCharacter()
 		if maxComboPoints ~= TRB.Data.character.maxResource2 then
 			TRB.Data.character.maxResource2 = maxComboPoints
 			if barGroups and barGroups.primary then
-				TRB.Functions.Bar:SetPosition(sharedSettings, barGroups.primary:GetContainerFrame())
+				Bar:SetPosition(sharedSettings, barGroups.primary:GetContainerFrame())
 			end
 		end
 	end
@@ -1159,7 +1164,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.specSupported = false
 	end
 
-	TRB.Functions.Character:EventRegistration()
+	Character:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
@@ -1274,8 +1279,8 @@ function TRB.Functions.Class:GetBarTextFrame(relativeToFrame)
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
-	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
-		TRB.Functions.Bar:HideResourceBar(true)
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and Bar:IsRenderTransitionActive() then
+		Bar:HideResourceBar(true)
 		return
 	end
 
@@ -1283,7 +1288,7 @@ function TRB.Functions.Class:TriggerResourceBarUpdates()
 		return
 	end
 	if (TRB.Data.character.specId ~= 1 and TRB.Data.character.specId ~= 2 and TRB.Data.character.specId ~= 3) then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 		return
 	end
 

--- a/ClassModules/Priest.lua
+++ b/ClassModules/Priest.lua
@@ -6,10 +6,24 @@ end
 local L = TRB.Localization
 TRB.Functions.Class = TRB.Functions.Class or {}
 local lookupChanged = TRB.Functions.BarText.LookupChanged
+local Threshold = TRB.Functions.Threshold
+local Bar = TRB.Functions.Bar
+local Color = TRB.Functions.Color
+local Character = TRB.Functions.Character
+local frameLevels = TRB.Data.constants.frameLevels
 
 local targetsTimerFrame = TRB.Frames.targetsTimerFrame
 
 local eventFrame = CreateFrame("Frame")
+
+-- Pre-allocated Holy Word definitions table, populated once by FillSpellData_Holy().
+-- Only the mutable fields (color, enabled) are refreshed per-tick in UpdateResourceBar.
+-- This avoids creating 4 tables (1 array + 3 elements) every 50ms tick.
+local holyWordDefsCache = {
+	{ spell = nil --[[@as any]], key = "holyWordSerenity", color = "" --[[@as string]], enabled = false },
+	{ spell = nil --[[@as any]], key = "holyWordSanctify", color = "" --[[@as string]], enabled = false },
+	{ spell = nil --[[@as any]], key = "holyWordChastise", color = "" --[[@as string]], enabled = false },
+}
 
 -- Frame for handling Sustained Potency pause events (PLAYER_CONTROL_LOST/GAINED, PLAYER_REGEN_ENABLED/DISABLED)
 local sustainedPotencyFrame = CreateFrame("Frame")
@@ -258,11 +272,11 @@ local function FillSpecializationCache()
 end
 
 local function Setup_Discipline()
-	TRB.Functions.Character:FillSpecializationCacheSettings("priest", "discipline", true)
+	Character:FillSpecializationCacheSettings("priest", "discipline", true)
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "priest_discipline" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Priest.BarGroupsFactory:CreateForSpec(1, UIParent)
 	end
 end
@@ -277,11 +291,11 @@ local function FillSpellData_Discipline()
 end
 
 local function Setup_Holy()
-	TRB.Functions.Character:FillSpecializationCacheSettings("priest", "holy", true)
+	Character:FillSpecializationCacheSettings("priest", "holy", true)
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "priest_holy" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Priest.BarGroupsFactory:CreateForSpec(2, UIParent)
 	end
 end
@@ -291,15 +305,20 @@ local function FillSpellData_Holy()
 	specCache.priest_holy.spellsData:FillSpellData()
 	local spells = specCache.priest_holy.spellsData.spells --[[@as TRB.Classes.Priest.HolySpells]]
 
+	-- Populate static spell references in the pre-allocated holyWordDefs table
+	holyWordDefsCache[1].spell = spells.holyWordSerenity
+	holyWordDefsCache[2].spell = spells.holyWordSanctify
+	holyWordDefsCache[3].spell = spells.holyWordChastise
+
 	TRB.Classes.Priest.HolySpells.FillBarTextVariables(specCache.priest_holy)
 end
 
 local function Setup_Shadow()
-	TRB.Functions.Character:FillSpecializationCacheSettings("priest", "shadow")
+	Character:FillSpecializationCacheSettings("priest", "shadow")
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "priest_shadow" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Priest.BarGroupsFactory:CreateForSpec(3, UIParent)
 	end
 end
@@ -338,12 +357,12 @@ local function ConstructResourceBar(settings)
 			primaryNode:ClearThresholds()
 			for _ = 1, #TRB.Data.cache.thresholdSpells do
 				local thresholdFrame = CreateFrame("Frame", nil, primaryNode:GetFrame())
-				TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, settings, true)
+				Threshold:ResetThresholdLine(thresholdFrame, settings, true)
 				primaryNode:RegisterThreshold(thresholdFrame)
 			end
 		end
 
-		TRB.Functions.Bar:ConstructBarGroups(settings, barGroups)
+		Bar:ConstructBarGroups(settings, barGroups)
 	end
 
 	-- Power Words secondary bar (Discipline only)
@@ -355,10 +374,10 @@ local function ConstructResourceBar(settings)
 		else
 			barGroups.secondary:SetMaxNodes(maxPowerWordNodes)
 			barGroups.secondary:SetNodeCount(maxPowerWordNodes)
-			barGroups.secondary:SetLayout(settings.comboPoints.spacing, TRB.Functions.Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
+			barGroups.secondary:SetLayout(settings.comboPoints.spacing, Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
 			barGroups.secondary:Show()
 
-			local effectiveWidth, cdmForced = TRB.Functions.Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
+			local effectiveWidth, cdmForced = Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
 			if cdmForced then
 				barGroups.secondary.fullWidth = true
 			end
@@ -399,10 +418,10 @@ local function ConstructResourceBar(settings)
 		else
 			barGroups.secondary:SetMaxNodes(maxHolyWordNodes)
 			barGroups.secondary:SetNodeCount(maxHolyWordNodes)
-			barGroups.secondary:SetLayout(settings.comboPoints.spacing, TRB.Functions.Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
+			barGroups.secondary:SetLayout(settings.comboPoints.spacing, Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
 			barGroups.secondary:Show()
 
-			local effectiveWidth, cdmForced = TRB.Functions.Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
+			local effectiveWidth, cdmForced = Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
 			if cdmForced then
 				barGroups.secondary.fullWidth = true
 			end
@@ -435,7 +454,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	-- TRB.Functions.Bar:HideResourceBar()
+	-- Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -828,7 +847,7 @@ local function RefreshLookupData_Shadow()
 			local currentInsanity
 			local castingInsanity
 			if sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentInsanityColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentInsanityColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				currentInsanity = textColorResult:WrapTextInColorCode(insanityFormatted)
 				castingInsanity = textColorResult:WrapTextInColorCode(TRB.Functions.Number:RoundTo(_castingInsanity, resourcePrecision, "floor"))
@@ -1425,7 +1444,7 @@ function TRB.Functions.Class:DisableEvents()
 end
 
 local function UpdateSnapshot()
-	TRB.Functions.Character:UpdateSnapshot()
+	Character:UpdateSnapshot()
 	local spells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Priest.DisciplineSpells|TRB.Classes.Priest.HolySpells|TRB.Classes.Priest.ShadowSpells]]
 	---@type table<integer, TRB.Classes.Snapshot>
 	local snapshots = TRB.Data.snapshotData.snapshots
@@ -1527,7 +1546,7 @@ local function UpdateResourceBar()
 
 	-- Always call HideResourceBar first to ensure visibility is correctly determined
 	-- even if we return early due to missing data
-	TRB.Functions.Bar:HideResourceBar()
+	Bar:HideResourceBar()
 
 	if not (barGroups and barGroups.primary) then
 		return
@@ -1570,7 +1589,7 @@ local function UpdateResourceBar()
 					end
 				end]]
 				
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				
 				local barColor = specSettings.colors.bar.base.color
 
@@ -1578,7 +1597,7 @@ local function UpdateResourceBar()
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			-- Update Power Words secondary bar
@@ -1600,18 +1619,18 @@ local function UpdateResourceBar()
 								if chargeIndex <= charges then
 									-- Available charge: full bar
 									cpNode:ClearTimerDuration()
-									TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, cpKey, cpNode, 1, 1)
+									Bar:SetBarNodeValue(specCacheSettings, cpKey, cpNode, 1, 1)
 								elseif chargeIndex == charges + 1 and cooldown:IsRechargingManual() and cooldown.manualCooldownExpires ~= nil then
 									-- Currently recharging: manual timer-based progress
 									cpNode:ClearTimerDuration()
 									local progress = cooldown:GetManualCooldownProgress(currentTime)
 									TRB.Data.cache.values.bar[cpKey] = nil
-									TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, cpKey, cpNode, progress, 1)
+									Bar:SetBarNodeValue(specCacheSettings, cpKey, cpNode, progress, 1)
 								else
 									-- Empty charge (not yet recharging)
 									cpNode:ClearTimerDuration()
 									TRB.Data.cache.values.bar[cpKey] = nil
-									TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, cpKey, cpNode, 0, 1)
+									Bar:SetBarNodeValue(specCacheSettings, cpKey, cpNode, 0, 1)
 								end
 								cpNode:SetColor(cpColor)
 								cpNode:SetBorderColor(cpBorderColor)
@@ -1634,7 +1653,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 
 			-- Update utility bar (Angelic Feather charges)
@@ -1654,16 +1673,16 @@ local function UpdateResourceBar()
 							local nodeColor = utilityColors.nodeColors and utilityColors.nodeColors[nodeColorKey] and utilityColors.nodeColors[nodeColorKey].color or "FFFFD700"
 							if chargeIndex <= charges then
 								utilNode:ClearTimerDuration()
-								TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, nodeKey, utilNode, 1, 1)
+								Bar:SetBarNodeValue(specCacheSettings, nodeKey, utilNode, 1, 1)
 							elseif chargeIndex == charges + 1 and cooldown:IsRechargingManual() and cooldown.manualCooldownExpires ~= nil then
 								utilNode:ClearTimerDuration()
 								local progress = cooldown:GetManualCooldownProgress(currentTime)
 								TRB.Data.cache.values.bar[nodeKey] = nil
-								TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, nodeKey, utilNode, progress, 1)
+								Bar:SetBarNodeValue(specCacheSettings, nodeKey, utilNode, progress, 1)
 							else
 								utilNode:ClearTimerDuration()
 								TRB.Data.cache.values.bar[nodeKey] = nil
-								TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, nodeKey, utilNode, 0, 1)
+								Bar:SetBarNodeValue(specCacheSettings, nodeKey, utilNode, 0, 1)
 							end
 							utilNode:SetColor(nodeColor)
 							utilNode:SetBorderColor(utilityColors.border.color)
@@ -1733,7 +1752,7 @@ local function UpdateResourceBar()
 					end
 				end
 				
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 
 				local barColor = nil
 
@@ -1750,7 +1769,7 @@ local function UpdateResourceBar()
 					if specSettings.endOf.apotheosis.enabled then
 						useEndOfApotheosisColor = true
 						if specSettings.endOf.apotheosis.mode == "gcd" then
-							local gcd = TRB.Functions.Character:GetCurrentGCDTime()
+							local gcd = Character:GetCurrentGCDTime()
 							timeThreshold = gcd * specSettings.endOf.apotheosis.gcdsMax
 						elseif specSettings.endOf.apotheosis.mode == "time" then
 							timeThreshold = specSettings.endOf.apotheosis.timeMax
@@ -1772,23 +1791,25 @@ local function UpdateResourceBar()
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			if specSettings.displayBar.secondary.visibility ~= "never" then
-				local cpBR, cpBG, cpBB, cpBA = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
+				local cpBR, cpBG, cpBB, cpBA = Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
 				local cpBorderColor = specSettings.colors.comboPoints.border.color
 				local currentCp = 1
 				
 				-- Holy Words: Serenity, Sanctify, Chastise
 				-- Each may have 1 or 2 charges (Miracle Worker grants +1 to Serenity/Sanctify)
-				local holyWordDefs = {
-					{ spell = spells.holyWordSerenity, key = "holyWordSerenity", color = specSettings.colors.comboPoints.holyWordSerenity.color, enabled = specSettings.colors.comboPoints.holyWordSerenity.enabled },
-					{ spell = spells.holyWordSanctify, key = "holyWordSanctify", color = specSettings.colors.comboPoints.holyWordSanctify.color, enabled = specSettings.colors.comboPoints.holyWordSanctify.enabled and not talents:IsTalentActive(spells.ultimateSerenity) },
-					{ spell = spells.holyWordChastise, key = "holyWordChastise", color = specSettings.colors.comboPoints.holyWordChastise.color, enabled = specSettings.colors.comboPoints.holyWordChastise.enabled },
-				}
+				-- Refresh only the mutable color/enabled fields in the pre-allocated table
+				holyWordDefsCache[1].color = specSettings.colors.comboPoints.holyWordSerenity.color
+				holyWordDefsCache[1].enabled = specSettings.colors.comboPoints.holyWordSerenity.enabled
+				holyWordDefsCache[2].color = specSettings.colors.comboPoints.holyWordSanctify.color
+				holyWordDefsCache[2].enabled = specSettings.colors.comboPoints.holyWordSanctify.enabled and not talents:IsTalentActive(spells.ultimateSerenity)
+				holyWordDefsCache[3].color = specSettings.colors.comboPoints.holyWordChastise.color
+				holyWordDefsCache[3].enabled = specSettings.colors.comboPoints.holyWordChastise.enabled
 
-				for _, hwDef in ipairs(holyWordDefs) do
+				for _, hwDef in ipairs(holyWordDefsCache) do
 					if talents:IsTalentActive(hwDef.spell) and hwDef.enabled then
 						local cooldown = snapshots[hwDef.spell.id].cooldown
 						local charges = cooldown.manualCharges or 0
@@ -1803,21 +1824,21 @@ local function UpdateResourceBar()
 									if chargeIndex <= charges then
 										-- Available charge: full bar
 										cpNode:ClearTimerDuration()
-										TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, cpKey, cpNode, 1, 1)
+										Bar:SetBarNodeValue(specCacheSettings, cpKey, cpNode, 1, 1)
 									elseif chargeIndex == charges + 1 and cooldown:IsRechargingManual() and cooldown.manualCooldownExpires ~= nil then
 										-- Currently recharging: manual timer-based progress
 										cpNode:ClearTimerDuration()
 										local progress = cooldown:GetManualCooldownProgress(currentTime)
 										-- Invalidate cache so continuously changing progress always renders
 										TRB.Data.cache.values.bar[cpKey] = nil
-										TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, cpKey, cpNode, progress, 1)
+										Bar:SetBarNodeValue(specCacheSettings, cpKey, cpNode, progress, 1)
 										if holyWordCooldownCompletesKey == hwDef.key and specSettings.colors.comboPoints.completeCooldown.enabled and specSettings.colors.comboPoints[holyWordCooldownCompletesKey] and specSettings.colors.comboPoints[holyWordCooldownCompletesKey].enabled then
 											cpColor = specSettings.colors.comboPoints.completeCooldown.color
 										end
 									else
 										-- Empty charge (not yet recharging)
 										cpNode:ClearTimerDuration()
-										TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, cpKey, cpNode, 0, 1)
+										Bar:SetBarNodeValue(specCacheSettings, cpKey, cpNode, 0, 1)
 									end
 									cpNode:SetColor(cpColor)
 									cpNode:SetBorderColor(cpBorderColor)
@@ -1841,7 +1862,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 
 			-- Update utility bar (Angelic Feather charges)
@@ -1861,16 +1882,16 @@ local function UpdateResourceBar()
 							local nodeColor = utilityColors.nodeColors and utilityColors.nodeColors[nodeColorKey] and utilityColors.nodeColors[nodeColorKey].color or "FFFFD700"
 							if chargeIndex <= charges then
 								utilNode:ClearTimerDuration()
-								TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, nodeKey, utilNode, 1, 1)
+								Bar:SetBarNodeValue(specCacheSettings, nodeKey, utilNode, 1, 1)
 							elseif chargeIndex == charges + 1 and cooldown:IsRechargingManual() and cooldown.manualCooldownExpires ~= nil then
 								utilNode:ClearTimerDuration()
 								local progress = cooldown:GetManualCooldownProgress(currentTime)
 								TRB.Data.cache.values.bar[nodeKey] = nil
-								TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, nodeKey, utilNode, progress, 1)
+								Bar:SetBarNodeValue(specCacheSettings, nodeKey, utilNode, progress, 1)
 							else
 								utilNode:ClearTimerDuration()
 								TRB.Data.cache.values.bar[nodeKey] = nil
-								TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, nodeKey, utilNode, 0, 1)
+								Bar:SetBarNodeValue(specCacheSettings, nodeKey, utilNode, 0, 1)
 							end
 							utilNode:SetColor(nodeColor)
 							utilNode:SetBorderColor(utilityColors.border.color)
@@ -1912,7 +1933,7 @@ local function UpdateResourceBar()
 				-- Build overcap border curve if enabled
 				local overcapBorderCurve = nil
 				if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
-					overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+					overcapBorderCurve = Color:BuildResourceThresholdCurve(specSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 				end
 
 				-- Get resourceFrame and thresholds from the BarNode
@@ -1924,7 +1945,7 @@ local function UpdateResourceBar()
 					-- Create threshold on-demand if missing
 					if thresholds[thresholdId] == nil then
 						local thresholdFrame = CreateFrame("Frame", nil, resourceFrame)
-						TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
+						Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
 						primaryNode:RegisterThreshold(thresholdFrame)
 						thresholds = primaryNode:GetThresholds()
 					end
@@ -1933,7 +1954,7 @@ local function UpdateResourceBar()
 					local isUsable = spell:IsUsable()
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color --[[@as string?]]
-					local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+					local frameLevel = frameLevels.thresholdOver
 					local snapshot = snapshots[spell.id]
 					
 					if spell.isSnowflake then -- These are special snowflakes that we need to handle manually
@@ -1950,7 +1971,7 @@ local function UpdateResourceBar()
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						elseif spell.settingKey == spells.shadowWordMadness2--[[@as TRB.Classes.SpellThreshold]].settingKey then
 							if spell.isTalent and not talents:IsTalentActive(spell) then -- Talent not selected
@@ -1962,15 +1983,15 @@ local function UpdateResourceBar()
 							else
 								-- Use ColorCurve to dynamically change threshold color based on resource
 								local baseCost = resourceAmount / spell.primaryResourceTypeMod
-								local thresholdCurve = TRB.Functions.Color:BuildThresholdCurve(
+								local thresholdCurve = Color:BuildThresholdCurve(
 									spell.primaryResourceTypeMod,
 									baseCost,
 									specCacheSettings.colors.threshold.under.color,
 									specCacheSettings.colors.threshold.over.color
 								)
-								local iconCurve = TRB.Functions.Color:BuildIconVertexColorCurve(spell.primaryResourceTypeMod, baseCost)
-								frameLevel = isUsable and TRB.Data.constants.frameLevels.thresholdOver or TRB.Data.constants.frameLevels.thresholdUnder
-								local curveApplied = TRB.Functions.Threshold:ApplyThresholdCurveColor(
+								local iconCurve = Color:BuildIconVertexColorCurve(spell.primaryResourceTypeMod, baseCost)
+								frameLevel = isUsable and frameLevels.thresholdOver or frameLevels.thresholdUnder
+								local curveApplied = Threshold:ApplyThresholdCurveColor(
 									spell, thresholds[thresholdId], thresholdCurve, TRB.Data.resource, specCacheSettings, iconCurve, frameLevel, pairOffset, isUsable
 								)
 								if curveApplied then
@@ -1990,15 +2011,15 @@ local function UpdateResourceBar()
 							else
 								-- Use ColorCurve to dynamically change threshold color based on resource
 								local baseCost = resourceAmount / spell.primaryResourceTypeMod
-								local thresholdCurve = TRB.Functions.Color:BuildThresholdCurve(
+								local thresholdCurve = Color:BuildThresholdCurve(
 									spell.primaryResourceTypeMod,
 									baseCost,
 									specCacheSettings.colors.threshold.under.color,
 									specCacheSettings.colors.threshold.over.color
 								)
-								local iconCurve = TRB.Functions.Color:BuildIconVertexColorCurve(spell.primaryResourceTypeMod, baseCost)
-								frameLevel = isUsable and TRB.Data.constants.frameLevels.thresholdOver or TRB.Data.constants.frameLevels.thresholdUnder
-								local curveApplied = TRB.Functions.Threshold:ApplyThresholdCurveColor(
+								local iconCurve = Color:BuildIconVertexColorCurve(spell.primaryResourceTypeMod, baseCost)
+								frameLevel = isUsable and frameLevels.thresholdOver or frameLevels.thresholdUnder
+								local curveApplied = Threshold:ApplyThresholdCurveColor(
 									spell, thresholds[thresholdId], thresholdCurve, TRB.Data.resource, specCacheSettings, iconCurve, frameLevel, pairOffset, isUsable
 								)
 								if curveApplied then
@@ -2018,14 +2039,14 @@ local function UpdateResourceBar()
 					elseif spell.hasCooldown then
 						if snapshotData.snapshots[spell.id].cooldown:IsUnusable() then
 							thresholdColor = specCacheSettings.colors.threshold.unusable.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+							frameLevel = frameLevels.thresholdUnusable
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					else -- This is an active/available/normal spell threshold
 						thresholdColor = specCacheSettings.colors.threshold.under.color
-						frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+						frameLevel = frameLevels.thresholdUnder
 					end
 					
 					if resourceAmount > maxPrimaryBarResourceUnnormalized then
@@ -2033,14 +2054,14 @@ local function UpdateResourceBar()
 					end
 
 					if thresholds[thresholdId] then
-						local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-						TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, resourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
+						local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+						Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, resourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
 					end
 				end
 
 				if spells.shadowWordMadness:IsFree() or spells.shadowWordMadness:IsUsable() then
 					if specSettings.colors.bar.flashEnabled then
-						TRB.Functions.Bar:PulseFrame(barGroups.primary:GetContainerFrame(), specSettings.colors.bar.flashAlpha, specSettings.colors.bar.flashPeriod)
+						Bar:PulseFrame(barGroups.primary:GetContainerFrame(), specSettings.colors.bar.flashAlpha, specSettings.colors.bar.flashPeriod)
 					else
 						barGroups.primary:GetContainerFrame():SetAlpha(1.0)
 					end
@@ -2059,7 +2080,7 @@ local function UpdateResourceBar()
 					snapshotData.audio.playedMdCue = false
 				end
 				
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				if snapshots[spells.voidform.id].buff.isActive then
 					local timeLeft = snapshots[spells.voidform.id].buff.remaining
 					local timeThreshold = 0
@@ -2068,7 +2089,7 @@ local function UpdateResourceBar()
 					if specSettings.endOf.voidform.enabled then
 						useEndOfVoidformColor = true
 						if specSettings.endOf.voidform.mode == "gcd" then
-							local gcd = TRB.Functions.Character:GetCurrentGCDTime()
+							local gcd = Character:GetCurrentGCDTime()
 							timeThreshold = gcd * specSettings.endOf.voidform.gcdsMax
 						elseif specSettings.endOf.voidform.mode == "time" then
 							timeThreshold = specSettings.endOf.voidform.timeMax
@@ -2095,7 +2116,7 @@ local function UpdateResourceBar()
 				end
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -2110,7 +2131,7 @@ local function UpdateResourceBar()
 				healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 				healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 			end
-			TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+			Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 		end
 
 		-- Update mana bar (Shadow only)
@@ -2145,16 +2166,16 @@ local function UpdateResourceBar()
 						local nodeColor = utilityColors.nodeColors and utilityColors.nodeColors[nodeColorKey] and utilityColors.nodeColors[nodeColorKey].color or "FFFFD700"
 						if chargeIndex <= charges then
 							utilNode:ClearTimerDuration()
-							TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, nodeKey, utilNode, 1, 1)
+							Bar:SetBarNodeValue(specCacheSettings, nodeKey, utilNode, 1, 1)
 						elseif chargeIndex == charges + 1 and cooldown:IsRechargingManual() and cooldown.manualCooldownExpires ~= nil then
 							utilNode:ClearTimerDuration()
 							local progress = cooldown:GetManualCooldownProgress(currentTime)
 							TRB.Data.cache.values.bar[nodeKey] = nil
-							TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, nodeKey, utilNode, progress, 1)
+							Bar:SetBarNodeValue(specCacheSettings, nodeKey, utilNode, progress, 1)
 						else
 							utilNode:ClearTimerDuration()
 							TRB.Data.cache.values.bar[nodeKey] = nil
-							TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, nodeKey, utilNode, 0, 1)
+							Bar:SetBarNodeValue(specCacheSettings, nodeKey, utilNode, 0, 1)
 						end
 						utilNode:SetColor(nodeColor)
 						utilNode:SetBorderColor(utilityColors.border.color)
@@ -2181,16 +2202,16 @@ local function SwitchSpec()
 	TRB.Data.prevLookupState = {}
 	TRB.Data.lookupDirty = true
 	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+		Bar:QueueRenderTransition("switchSpec", 0.8)
 	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 	end
-	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
+	Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization() or 0
 	if TRB.Data.character.specId == 1 then
 		specCache.priest_discipline.talents:GetTalents()
 		FillSpellData_Discipline()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.priest_discipline)
+		Character:LoadFromSpecializationCache(specCache.priest_discipline)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Priest.DisciplineSpells]]
@@ -2198,7 +2219,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Discipline
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.priest_discipline.settings)
+		Bar:UpdateSanityCheckValues(specCache.priest_discipline.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#pwRadiance"] = spells.powerWordRadiance.icon
@@ -2236,7 +2257,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 2 then
 		specCache.priest_holy.talents:GetTalents()
 		FillSpellData_Holy()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.priest_holy)
+		Character:LoadFromSpecializationCache(specCache.priest_holy)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Priest.HolySpells]]
@@ -2244,7 +2265,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Holy
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.priest_holy.settings)
+		Bar:UpdateSanityCheckValues(specCache.priest_holy.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#flashHeal"] = spells.flashHeal.icon
@@ -2303,7 +2324,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 3 then
 		specCache.priest_shadow.talents:GetTalents()
 		FillSpellData_Shadow()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.priest_shadow)
+		Character:LoadFromSpecializationCache(specCache.priest_shadow)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Priest.ShadowSpells]]
@@ -2311,7 +2332,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Shadow
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.priest_shadow.settings)
+		Bar:UpdateSanityCheckValues(specCache.priest_shadow.settings)
 
 		local lookup = {}
 		lookup["#mb"] = spells.mindBlast.icon
@@ -2399,9 +2420,9 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				TRB.Functions.Character:ResetCaches()
+				Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
-				TRB.Functions.Character:UpdateHealthValues()
+				Character:UpdateHealthValues()
 				TRB.Functions.Class:TriggerResourceBarUpdates()
 			end
 		end)
@@ -2570,9 +2591,9 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
 				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+					Bar:QueueRenderTransition("eventPreSwitch", 0.8)
 				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-					TRB.Functions.Bar:HideResourceBar(true)
+					Bar:HideResourceBar(true)
 				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
@@ -2590,7 +2611,7 @@ function TRB.Functions.Class:CheckCharacter()
 		SwitchSpec()
 	end
 
-	TRB.Functions.Character:CheckCharacter()
+	Character:CheckCharacter()
 	TRB.Data.character.className = "priest"
 	local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 	---@type table<integer, TRB.Classes.Snapshot>
@@ -2623,7 +2644,7 @@ function TRB.Functions.Class:CheckCharacter()
 			if totalPowerWordCharges ~= TRB.Data.character.maxResource2 then
 				TRB.Data.character.maxResource2 = totalPowerWordCharges
 				if TRB.Frames.barGroups and TRB.Frames.barGroups.primary then
-					TRB.Functions.Bar:SetPosition(sharedSettings, TRB.Frames.barGroups.primary:GetContainerFrame())
+					Bar:SetPosition(sharedSettings, TRB.Frames.barGroups.primary:GetContainerFrame())
 				end
 			end
 		end
@@ -2666,7 +2687,7 @@ function TRB.Functions.Class:CheckCharacter()
 			if totalHolyWordCharges ~= TRB.Data.character.maxResource2 then
 				TRB.Data.character.maxResource2 = totalHolyWordCharges
 				if TRB.Frames.barGroups and TRB.Frames.barGroups.primary then
-					TRB.Functions.Bar:SetPosition(sharedSettings, TRB.Frames.barGroups.primary:GetContainerFrame())
+					Bar:SetPosition(sharedSettings, TRB.Frames.barGroups.primary:GetContainerFrame())
 				end
 			end
 		end
@@ -2706,7 +2727,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Functions.Class:DisableEvents()
 	end
 
-	TRB.Functions.Character:EventRegistration()
+	Character:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
@@ -3133,8 +3154,8 @@ function TRB.Functions.Class:HasActiveTimers()
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
-	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
-		TRB.Functions.Bar:HideResourceBar(true)
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and Bar:IsRenderTransitionActive() then
+		Bar:HideResourceBar(true)
 		return
 	end
 
@@ -3142,7 +3163,7 @@ function TRB.Functions.Class:TriggerResourceBarUpdates()
 		return
 	end
 	if (TRB.Data.character.specId ~= 1 and TRB.Data.character.specId ~= 2 and TRB.Data.character.specId ~= 3) then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 		return
 	end
 	

--- a/ClassModules/Priest.lua
+++ b/ClassModules/Priest.lua
@@ -20,9 +20,9 @@ local eventFrame = CreateFrame("Frame")
 -- Only the mutable fields (color, enabled) are refreshed per-tick in UpdateResourceBar.
 -- This avoids creating 4 tables (1 array + 3 elements) every 50ms tick.
 local holyWordDefsCache = {
-	{ spell = nil --[[@as any]], key = "holyWordSerenity", color = "" --[[@as string]], enabled = false },
-	{ spell = nil --[[@as any]], key = "holyWordSanctify", color = "" --[[@as string]], enabled = false },
-	{ spell = nil --[[@as any]], key = "holyWordChastise", color = "" --[[@as string]], enabled = false },
+	{ spell = nil --[[@as TRB.Classes.SpellBase]], key = "holyWordSerenity", color = "" --[[@as string]], enabled = false },
+	{ spell = nil --[[@as TRB.Classes.SpellBase]], key = "holyWordSanctify", color = "" --[[@as string]], enabled = false },
+	{ spell = nil --[[@as TRB.Classes.SpellBase]], key = "holyWordChastise", color = "" --[[@as string]], enabled = false },
 }
 
 -- Frame for handling Sustained Potency pause events (PLAYER_CONTROL_LOST/GAINED, PLAYER_REGEN_ENABLED/DISABLED)
@@ -1811,6 +1811,7 @@ local function UpdateResourceBar()
 
 				for _, hwDef in ipairs(holyWordDefsCache) do
 					if talents:IsTalentActive(hwDef.spell) and hwDef.enabled then
+---@diagnostic disable-next-line: undefined-field
 						local cooldown = snapshots[hwDef.spell.id].cooldown
 						local charges = cooldown.manualCharges or 0
 						local maxCharges = cooldown.manualMaxCharges or 1

--- a/ClassModules/Rogue.lua
+++ b/ClassModules/Rogue.lua
@@ -6,6 +6,11 @@ end
 local L = TRB.Localization
 TRB.Functions.Class = TRB.Functions.Class or {}
 local lookupChanged = TRB.Functions.BarText.LookupChanged
+local Threshold = TRB.Functions.Threshold
+local Bar = TRB.Functions.Bar
+local Color = TRB.Functions.Color
+local Character = TRB.Functions.Character
+local frameLevels = TRB.Data.constants.frameLevels
 
 local targetsTimerFrame = TRB.Frames.targetsTimerFrame
 
@@ -307,11 +312,11 @@ local function FillSpecializationCache()
 end
 
 local function Setup_Assassination()
-	TRB.Functions.Character:FillSpecializationCacheSettings("rogue", "assassination")
+	Character:FillSpecializationCacheSettings("rogue", "assassination")
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "rogue_assassination" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Rogue.BarGroupsFactory:CreateForSpec(1, UIParent)
 	end
 end
@@ -325,11 +330,11 @@ local function FillSpellData_Assassination()
 end
 
 local function Setup_Outlaw()
-	TRB.Functions.Character:FillSpecializationCacheSettings("rogue", "outlaw")
+	Character:FillSpecializationCacheSettings("rogue", "outlaw")
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "rogue_outlaw" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Rogue.BarGroupsFactory:CreateForSpec(2, UIParent)
 	end
 end
@@ -343,11 +348,11 @@ local function FillSpellData_Outlaw()
 end
 
 local function Setup_Subtlety()
-	TRB.Functions.Character:FillSpecializationCacheSettings("rogue", "subtlety")
+	Character:FillSpecializationCacheSettings("rogue", "subtlety")
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "rogue_subtlety" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Rogue.BarGroupsFactory:CreateForSpec(3, UIParent)
 	end
 end
@@ -409,12 +414,12 @@ local function ConstructResourceBar(settings)
 			primaryNode:ClearThresholds()
 			for _ = 1, #TRB.Data.cache.thresholdSpells do
 				local thresholdFrame = CreateFrame("Frame", nil, primaryNode:GetFrame())
-				TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, settings, true)
+				Threshold:ResetThresholdLine(thresholdFrame, settings, true)
 				primaryNode:RegisterThreshold(thresholdFrame)
 			end
 		end
 
-		TRB.Functions.Bar:ConstructBarGroups(settings, barGroups)
+		Bar:ConstructBarGroups(settings, barGroups)
 	end
 
 	-- All Rogue specs use secondary bar (Combo Points)
@@ -426,11 +431,11 @@ local function ConstructResourceBar(settings)
 		
 		-- Ensure secondary group knows the correct node count
 		barGroups.secondary:SetNodeCount(maxComboPoints)
-		barGroups.secondary:SetLayout(settings.comboPoints.spacing, TRB.Functions.Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
+		barGroups.secondary:SetLayout(settings.comboPoints.spacing, Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
 		barGroups.secondary:Show()
 		
 		-- Get effective width for secondary bar, accounting for CDM width matching
-		local effectiveWidth, cdmForced = TRB.Functions.Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
+		local effectiveWidth, cdmForced = Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
 		if cdmForced then
 			barGroups.secondary.fullWidth = true
 		end
@@ -464,7 +469,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	-- TRB.Functions.Bar:HideResourceBar()
+	-- Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -525,7 +530,7 @@ local function RefreshLookupData_Assassination()
 			local currentEnergy
 			local castingEnergy
 			if not isStealthed and sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentEnergyColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentEnergyColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				currentEnergy = textColorResult:WrapTextInColorCode(resourceFormatted)
 				castingEnergy = textColorResult:WrapTextInColorCode(string.format("%.0f", TRB.Functions.Number:RoundTo(_castingEnergy, resourcePrecision, "floor")))
@@ -612,7 +617,7 @@ local function RefreshLookupData_Outlaw()
 			local currentEnergy
 			local castingEnergy
 			if not isStealthed and sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentEnergyColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentEnergyColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				currentEnergy = textColorResult:WrapTextInColorCode(resourceFormatted)
 				castingEnergy = textColorResult:WrapTextInColorCode(string.format("%.0f", TRB.Functions.Number:RoundTo(_castingEnergy, resourcePrecision, "floor")))
@@ -699,7 +704,7 @@ local function RefreshLookupData_Subtlety()
 			local currentEnergy
 			local castingEnergy
 			if not isStealthed and sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentEnergyColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentEnergyColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				currentEnergy = textColorResult:WrapTextInColorCode(resourceFormatted)
 				castingEnergy = textColorResult:WrapTextInColorCode(string.format("%.0f", TRB.Functions.Number:RoundTo(_castingEnergy, resourcePrecision, "floor")))
@@ -771,7 +776,7 @@ local function UpdateRollTheBones()
 end
 
 local function UpdateSnapshot()
-	TRB.Functions.Character:UpdateSnapshot()
+	Character:UpdateSnapshot()
 	--[[local spells = TRB.Data.spellsData.spells --[@as TRB.Classes.Rogue.RogueBaseSpells]
 	---@type table<integer, TRB.Classes.Snapshot>
 	local snapshots = TRB.Data.snapshotData.snapshots
@@ -852,7 +857,7 @@ local function UpdateResourceBar()
 
 	-- Always call HideResourceBar first to ensure visibility is correctly determined
 	-- even if we return early due to missing data
-	TRB.Functions.Bar:HideResourceBar()
+	Bar:HideResourceBar()
 
 	if TRB.Data.character.maxResource == nil or TRB.Data.character.maxResource2 == nil then
 		return
@@ -880,7 +885,7 @@ local function UpdateResourceBar()
 				end
 				
 				if primaryNode then
-					TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+					Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				end
 				
 				local stealthViaBuff = snapshots[spells.subterfuge.id].buff.isActive
@@ -893,7 +898,7 @@ local function UpdateResourceBar()
 					-- Create threshold on-demand if missing
 					if primaryNode and thresholds[thresholdId] == nil then
 						local thresholdFrame = CreateFrame("Frame", nil, nodeResourceFrame)
-						TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
+						Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
 						primaryNode:RegisterThreshold(thresholdFrame)
 						thresholds = primaryNode:GetThresholds()
 					end
@@ -902,7 +907,7 @@ local function UpdateResourceBar()
 					local isUsable = spell:IsUsable()
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
-					local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+					local frameLevel = frameLevels.thresholdOver
 					local snapshot = snapshots[spell.id]
 
 					if spell.attributes.stealth and not IsStealthed() then -- Don't show stealthed lines when unstealthed.
@@ -912,7 +917,7 @@ local function UpdateResourceBar()
 									thresholdColor = specCacheSettings.colors.threshold.over.color
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							elseif snapshots[spells.blindside.id].buff.isActive then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
@@ -924,7 +929,7 @@ local function UpdateResourceBar()
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						else
 							showThreshold = false
@@ -936,7 +941,7 @@ local function UpdateResourceBar()
 									thresholdColor = specCacheSettings.colors.threshold.over.color
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							elseif spell.id == spells.garrote.id then
 								if not talents:IsTalentActive(spell) then -- Talent not selected
@@ -944,26 +949,26 @@ local function UpdateResourceBar()
 								else
 									if specCacheSettings.colors.threshold.special.enabled and snapshots[spells.improvedGarrote.id].attributes.isActiveStealth or snapshots[spells.improvedGarrote.id].buff.isActive then
 										thresholdColor = specCacheSettings.colors.threshold.special.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdHighPriority
+										frameLevel = frameLevels.thresholdHighPriority
 									elseif snapshots[spell.id].cooldown:IsUnusable() then
 										thresholdColor = specCacheSettings.colors.threshold.unusable.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+										frameLevel = frameLevels.thresholdUnusable
 									elseif isUsable then
 										thresholdColor = specCacheSettings.colors.threshold.over.color
 									else
 										thresholdColor = specCacheSettings.colors.threshold.under.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+										frameLevel = frameLevels.thresholdUnder
 									end
 								end
 							elseif spell.id == spells.mutilate.id then
 								if specCacheSettings.colors.threshold["echoingReprimand"].enabled and snapshots[spells.echoingReprimand.id].buff.isActive then
 									thresholdColor = specCacheSettings.colors.threshold["echoingReprimand"].color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdHighPriority
+									frameLevel = frameLevels.thresholdHighPriority
 								elseif isUsable then
 									thresholdColor = specCacheSettings.colors.threshold.over.color
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							end
 						elseif resourceAmount == 0 then
@@ -975,19 +980,19 @@ local function UpdateResourceBar()
 						elseif spell.hasCooldown then
 							if snapshotData.snapshots[spell.id].cooldown:IsUnusable() then
 								thresholdColor = specCacheSettings.colors.threshold.unusable.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+								frameLevel = frameLevels.thresholdUnusable
 							elseif isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						else -- This is an active/available/normal spell threshold
 							if isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						end
 					end
@@ -1000,12 +1005,12 @@ local function UpdateResourceBar()
 						spell--[[@as TRB.Classes.SpellComboPointThreshold]].comboPoints == true and
 						not isUsable then-- snapshotData.attributes.resource2 == 0 then
 						thresholdColor = specCacheSettings.colors.threshold.unusable.color
-						frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+						frameLevel = frameLevels.thresholdUnusable
 					end
 
 					if thresholds[thresholdId] then
-						local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-						TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, nodeResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
+						local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+						Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, nodeResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
 					end
 				end
 
@@ -1022,7 +1027,7 @@ local function UpdateResourceBar()
 						primaryNode:SetBorderColor(specSettings.colors.bar.borderStealth.color)
 					elseif specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
 						-- Apply overcap border color if enabled (skipped when stealthed)
-						local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+						local overcapBorderCurve = Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 						local borderColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapBorderCurve)
 						primaryNode:SetBorderColorCurve(borderColorResult)
 					else
@@ -1030,13 +1035,13 @@ local function UpdateResourceBar()
 					end
 					primaryNode:SetColor(barColor)
 					primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-					TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+					Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 				end
 			end
 
 			if specSettings.displayBar.secondary.visibility ~= "never" then
 				refreshText = true
-				local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
+				local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
 
 				local charged = GetUnitChargedPowerPoints("player")
 				for x = 1, TRB.Data.character.maxResource2 do
@@ -1051,14 +1056,14 @@ local function UpdateResourceBar()
 						local cpNode = barGroups.secondary:GetNode(x)
 						if cpNode then
 							if snapshotData.attributes.resource2 >= x then
-								TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, cpNode, 1, 1)
+								Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, cpNode, 1, 1)
 								if (specSettings.comboPoints.sameColor and snapshotData.attributes.resource2 == (TRB.Data.character.maxResource2 - 1)) or (not specSettings.comboPoints.sameColor and x == (TRB.Data.character.maxResource2 - 1)) then
 									cpColor = specSettings.colors.comboPoints.penultimate.color
 								elseif (specSettings.comboPoints.sameColor and snapshotData.attributes.resource2 == (TRB.Data.character.maxResource2)) or x == TRB.Data.character.maxResource2 then
 									cpColor = specSettings.colors.comboPoints.final.color
 								end
 							else
-								TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, cpNode, 0, 1)
+								Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, cpNode, 0, 1)
 							end
 
 							if charged ~= nil then
@@ -1071,7 +1076,7 @@ local function UpdateResourceBar()
 										end
 			
 										if not specSettings.colors.comboPoints.consistentUnfilledColor then
-											cpBR, cpBG, cpBB, _ = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.echoingReprimand.color, true)
+											cpBR, cpBG, cpBB, _ = Color:GetRGBAFromString(specSettings.colors.comboPoints.echoingReprimand.color, true)
 										end
 									end
 								end
@@ -1095,7 +1100,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -1123,7 +1128,7 @@ local function UpdateResourceBar()
 				end
 				
 				if primaryNode then
-					TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+					Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				end
 				
 				local stealthViaBuff = snapshots[spells.subterfuge.id].buff.isActive
@@ -1136,7 +1141,7 @@ local function UpdateResourceBar()
 					-- Create threshold on-demand if missing
 					if primaryNode and thresholds[thresholdId] == nil then
 						local thresholdFrame = CreateFrame("Frame", nil, nodeResourceFrame)
-						TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
+						Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
 						primaryNode:RegisterThreshold(thresholdFrame)
 						thresholds = primaryNode:GetThresholds()
 					end
@@ -1145,7 +1150,7 @@ local function UpdateResourceBar()
 					local isUsable = spell:IsUsable()
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
-					local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+					local frameLevel = frameLevels.thresholdOver
 					local snapshot = snapshots[spell.id]
 
 					if spell.attributes.stealth and not IsStealthed() then -- Don't show stealthed lines when unstealthed.
@@ -1155,7 +1160,7 @@ local function UpdateResourceBar()
 									thresholdColor = TRB.Data.settings.rogue.outlaw.colors.threshold.over.color
 								else
 									thresholdColor = TRB.Data.settings.rogue.outlaw.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							else
 								showThreshold = false
@@ -1165,7 +1170,7 @@ local function UpdateResourceBar()
 								thresholdColor = TRB.Data.settings.rogue.outlaw.colors.threshold.over.color
 							else
 								thresholdColor = TRB.Data.settings.rogue.outlaw.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						else
 							showThreshold = false
@@ -1175,58 +1180,58 @@ local function UpdateResourceBar()
 							if spell.id == spells.sinisterStrike.id then
 								if specCacheSettings.colors.threshold["echoingReprimand"].enabled and snapshots[spells.echoingReprimand.id].buff.isActive then
 									thresholdColor = specCacheSettings.colors.threshold["echoingReprimand"].color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdHighPriority
+									frameLevel = frameLevels.thresholdHighPriority
 								elseif isUsable then
 									if specCacheSettings.colors.threshold.special.enabled and snapshots[spells.skullAndCrossbones.id].buff.isActive then
 										thresholdColor = specCacheSettings.colors.threshold.special.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdHighPriority
+										frameLevel = frameLevels.thresholdHighPriority
 									else
 										thresholdColor = specCacheSettings.colors.threshold.over.color
 									end
 								else
 									if specCacheSettings.colors.threshold.special.enabled and snapshots[spells.skullAndCrossbones.id].buff.isActive then
 										thresholdColor = specCacheSettings.colors.threshold.special.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdHighPriority
+										frameLevel = frameLevels.thresholdHighPriority
 									else
 										thresholdColor = specCacheSettings.colors.threshold.under.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+										frameLevel = frameLevels.thresholdUnder
 									end
 								end
 							elseif spell.id == spells.pistolShot.id then
 								if isUsable then
 									if specCacheSettings.colors.threshold.special.enabled and snapshots[spells.opportunity.id].buff.isActive then
 										thresholdColor = specCacheSettings.colors.threshold.special.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdHighPriority
+										frameLevel = frameLevels.thresholdHighPriority
 									else
 										thresholdColor = specCacheSettings.colors.threshold.over.color
 									end
 								else
 									if specCacheSettings.colors.threshold.special.enabled and snapshots[spells.opportunity.id].buff.isActive then
 										thresholdColor = specCacheSettings.colors.threshold.special.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdHighPriority
+										frameLevel = frameLevels.thresholdHighPriority
 									else
 										thresholdColor = specCacheSettings.colors.threshold.under.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+										frameLevel = frameLevels.thresholdUnder
 									end
 								end
 							elseif spell.id == spells.betweenTheEyes.id then
 								if snapshots[spell.id].cooldown:IsUnusable() then
 									thresholdColor = specCacheSettings.colors.threshold.unusable.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+									frameLevel = frameLevels.thresholdUnusable
 								elseif isUsable then
 									if specCacheSettings.colors.threshold.special.enabled and snapshots[spells.ruthlessPrecision.id].buff.isActive then
 										thresholdColor = specCacheSettings.colors.threshold.special.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdHighPriority
+										frameLevel = frameLevels.thresholdHighPriority
 									else
 										thresholdColor = specCacheSettings.colors.threshold.over.color
 									end
 								else
 									if specCacheSettings.colors.threshold.special.enabled and snapshots[spells.ruthlessPrecision.id].buff.isActive then
 										thresholdColor = specCacheSettings.colors.threshold.special.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdHighPriority
+										frameLevel = frameLevels.thresholdHighPriority
 									else
 										thresholdColor = specCacheSettings.colors.threshold.under.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+										frameLevel = frameLevels.thresholdUnder
 									end
 								end
 							elseif spell.id == spells.sliceAndDice.id then
@@ -1234,7 +1239,7 @@ local function UpdateResourceBar()
 									thresholdColor = specCacheSettings.colors.threshold.over.color
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							elseif spell.id == spells.dispatch.id then
 								if snapshotData.attributes.coupDeGraceActive then
@@ -1243,7 +1248,7 @@ local function UpdateResourceBar()
 									thresholdColor = specCacheSettings.colors.threshold.over.color
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							elseif spell.id == spells.coupDeGrace.id then
 								if not snapshotData.attributes.coupDeGraceActive then
@@ -1251,7 +1256,7 @@ local function UpdateResourceBar()
 								else
 									if specCacheSettings.colors.threshold.special.enabled then
 										thresholdColor = specCacheSettings.colors.threshold.special.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdHighPriority
+										frameLevel = frameLevels.thresholdHighPriority
 									else
 										thresholdColor = specCacheSettings.colors.threshold.over.color
 									end
@@ -1266,19 +1271,19 @@ local function UpdateResourceBar()
 						elseif spell.hasCooldown then
 							if snapshotData.snapshots[spell.id].cooldown:IsUnusable() then
 								thresholdColor = specCacheSettings.colors.threshold.unusable.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+								frameLevel = frameLevels.thresholdUnusable
 							elseif isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						else -- This is an active/available/normal spell threshold
 							if isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						end
 					end
@@ -1288,7 +1293,7 @@ local function UpdateResourceBar()
 						not isUsable --snapshotData.attributes.resource2 == 0
 						then
 						thresholdColor = specCacheSettings.colors.threshold.unusable.color
-						frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+						frameLevel = frameLevels.thresholdUnusable
 					end
 
 					if specCacheSettings.colors.threshold["restlessBlades"].enabled and spell.attributes.restlessBlades and
@@ -1296,7 +1301,7 @@ local function UpdateResourceBar()
 						snapshot ~= nil and snapshot.cooldown.remainingTotal > 0 and snapshot.cooldown.remaining <= snapshotData.attributes.resource2
 						then
 						thresholdColor = specCacheSettings.colors.threshold["restlessBlades"].color
-						frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+						frameLevel = frameLevels.thresholdUnder
 					end
 					
 					if resourceAmount >= maxPrimaryBarResourceUnnormalized then
@@ -1304,8 +1309,8 @@ local function UpdateResourceBar()
 					end
 
 					if thresholds[thresholdId] then
-						local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-						TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, nodeResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
+						local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+						Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, nodeResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
 					end
 				end
 
@@ -1326,7 +1331,7 @@ local function UpdateResourceBar()
 						primaryNode:SetBorderColor(specSettings.colors.bar.borderRtbBad)]]
 					elseif specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
 						-- Apply overcap border color if enabled (skipped when stealthed)
-						local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+						local overcapBorderCurve = Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 						local borderColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapBorderCurve)
 						primaryNode:SetBorderColorCurve(borderColorResult)
 					else
@@ -1334,13 +1339,13 @@ local function UpdateResourceBar()
 					end
 					primaryNode:SetColor(barColor)
 					primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-					TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+					Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 				end
 			end
 
 			if specSettings.displayBar.secondary.visibility ~= "never" then
 				refreshText = true
-				local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
+				local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
 
 				local charged = GetUnitChargedPowerPoints("player")
 
@@ -1355,14 +1360,14 @@ local function UpdateResourceBar()
 						local cpNode = barGroups.secondary:GetNode(x)
 						if cpNode then
 							if snapshotData.attributes.resource2 >= x then
-								TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, cpNode, 1, 1)
+								Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, cpNode, 1, 1)
 								if (specSettings.comboPoints.sameColor and snapshotData.attributes.resource2 == (TRB.Data.character.maxResource2 - 1)) or (not specSettings.comboPoints.sameColor and x == (TRB.Data.character.maxResource2 - 1)) then
 									cpColor = specSettings.colors.comboPoints.penultimate.color
 								elseif (specSettings.comboPoints.sameColor and snapshotData.attributes.resource2 == (TRB.Data.character.maxResource2)) or x == TRB.Data.character.maxResource2 then
 									cpColor = specSettings.colors.comboPoints.final.color
 								end
 							else
-								TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, cpNode, 0, 1)
+								Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, cpNode, 0, 1)
 							end
 
 							if charged ~= nil then
@@ -1372,7 +1377,7 @@ local function UpdateResourceBar()
 										cpBorderColor = specSettings.colors.comboPoints.echoingReprimand.color
 				
 										if not specSettings.colors.comboPoints.consistentUnfilledColor then
-											cpBR, cpBG, cpBB, _ = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.echoingReprimand.color, true)
+											cpBR, cpBG, cpBB, _ = Color:GetRGBAFromString(specSettings.colors.comboPoints.echoingReprimand.color, true)
 										end
 									end
 								end
@@ -1396,7 +1401,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -1426,7 +1431,7 @@ local function UpdateResourceBar()
 				local nodeResourceFrame = nil
 				if primaryNode then
 					nodeResourceFrame = primaryNode:GetFrame()
-					TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+					Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				end
 
 				local thresholds = {}
@@ -1446,7 +1451,7 @@ local function UpdateResourceBar()
 					local isUsable = spell:IsUsable()
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
-					local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+					local frameLevel = frameLevels.thresholdOver
 					local snapshot = snapshots[spell.id]
 					
 					if spell.attributes.stealth and not IsStealthed() then -- Don't show stealthed lines when unstealthed.
@@ -1455,7 +1460,7 @@ local function UpdateResourceBar()
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						else
 							showThreshold = false
@@ -1467,7 +1472,7 @@ local function UpdateResourceBar()
 									thresholdColor = specCacheSettings.colors.threshold.over.color
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							elseif spell.id == spells.backstab.id then
 								if talents:IsTalentActive(spells.gloomblade) then
@@ -1477,7 +1482,7 @@ local function UpdateResourceBar()
 										thresholdColor = specCacheSettings.colors.threshold.over.color
 									else
 										thresholdColor = specCacheSettings.colors.threshold.under.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+										frameLevel = frameLevels.thresholdUnder
 									end
 								end
 							elseif spell.id == spells.gloomblade.id then
@@ -1486,55 +1491,55 @@ local function UpdateResourceBar()
 								else
 									if specCacheSettings.colors.threshold["echoingReprimand"].enabled and snapshots[spells.echoingReprimand.id].buff.isActive then
 										thresholdColor = specCacheSettings.colors.threshold["echoingReprimand"].color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdHighPriority
+										frameLevel = frameLevels.thresholdHighPriority
 									elseif isUsable then
 										thresholdColor = specCacheSettings.colors.threshold.over.color
 									else
 										thresholdColor = specCacheSettings.colors.threshold.under.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+										frameLevel = frameLevels.thresholdUnder
 									end
 								end
 							elseif spell.id == spells.cheapShot.id then
 								if snapshots[spells.shotInTheDark.id].buff.isActive then
 									thresholdColor = specCacheSettings.colors.threshold.over.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdHighPriority
+									frameLevel = frameLevels.thresholdHighPriority
 								elseif isUsable then
 									thresholdColor = specCacheSettings.colors.threshold.over.color
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							elseif spell.id == spells.shurikenStorm.id then
 								if specCacheSettings.colors.threshold.special.enabled and snapshots[spells.silentStorm.id].buff.isActive then
 									thresholdColor = specCacheSettings.colors.threshold.special.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdHighPriority
+									frameLevel = frameLevels.thresholdHighPriority
 								elseif isUsable then
 									thresholdColor = specCacheSettings.colors.threshold.over.color
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							elseif spell.id == spells.blackPowder.id then
 								if specCacheSettings.colors.threshold.special.enabled and snapshots[spells.finalityBlackPowder.id].buff.isActive then
 									thresholdColor = specCacheSettings.colors.threshold.special.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdHighPriority
+									frameLevel = frameLevels.thresholdHighPriority
 								elseif isUsable then
 									thresholdColor = specCacheSettings.colors.threshold.over.color
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							elseif spell.id == spells.eviscerate.id then
 								if snapshotData.attributes.coupDeGraceActive then
 									showThreshold = false
 								elseif specCacheSettings.colors.threshold.special.enabled and snapshots[spells.finalityEviscerate.id].buff.isActive then
 									thresholdColor = specCacheSettings.colors.threshold.special.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdHighPriority
+									frameLevel = frameLevels.thresholdHighPriority
 								elseif isUsable then
 									thresholdColor = specCacheSettings.colors.threshold.over.color
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							elseif spell.id == spells.coupDeGrace.id then
 								if not snapshotData.attributes.coupDeGraceActive then
@@ -1542,7 +1547,7 @@ local function UpdateResourceBar()
 								else
 									if specCacheSettings.colors.threshold.special.enabled then
 										thresholdColor = specCacheSettings.colors.threshold.special.color
-										frameLevel = TRB.Data.constants.frameLevels.thresholdHighPriority
+										frameLevel = frameLevels.thresholdHighPriority
 									else
 										thresholdColor = specCacheSettings.colors.threshold.over.color
 									end
@@ -1557,19 +1562,19 @@ local function UpdateResourceBar()
 						elseif spell.hasCooldown then
 							if snapshotData.snapshots[spell.id].cooldown:IsUnusable() then
 								thresholdColor = specCacheSettings.colors.threshold.unusable.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+								frameLevel = frameLevels.thresholdUnusable
 							elseif isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						else -- This is an active/available/normal spell threshold
 							if isUsable then
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						end
 					end
@@ -1578,10 +1583,10 @@ local function UpdateResourceBar()
 						spell--[[@as TRB.Classes.SpellComboPointThreshold]].comboPoints == true then
 						if not isUsable then-- snapshotData.attributes.resource2 == 0 then
 							thresholdColor = specCacheSettings.colors.threshold.unusable.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+							frameLevel = frameLevels.thresholdUnusable
 						elseif thresholdColor ~= specCacheSettings.colors.threshold.special.color and snapshots[spells.goremawsBite.id].buff.isActive and (snapshotData.snapshots[spell.id] == nil or snapshotData.snapshots[spell.id].cooldown:IsUsable()) then
 							thresholdColor = specCacheSettings.colors.threshold.over.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+							frameLevel = frameLevels.thresholdOver
 						end
 					end
 					
@@ -1590,8 +1595,8 @@ local function UpdateResourceBar()
 					end
 
 					if thresholds[thresholdId] then
-						local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-						TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, nodeResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
+						local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+						Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, nodeResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
 					end
 				end
 
@@ -1613,7 +1618,7 @@ local function UpdateResourceBar()
 						primaryNode:SetBorderColor(specSettings.colors.bar.borderStealth.color)
 					elseif specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
 						-- Apply overcap border color if enabled (skipped when stealthed)
-						local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+						local overcapBorderCurve = Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 						local borderColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapBorderCurve)
 						primaryNode:SetBorderColorCurve(borderColorResult)
 					else
@@ -1621,14 +1626,14 @@ local function UpdateResourceBar()
 					end
 					primaryNode:SetColor(barColor)
 					primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-					TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+					Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 				end
 			end
 
 			if specSettings.displayBar.secondary.visibility ~= "never" then
 				refreshText = true
 				local spells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Rogue.SubtletySpells]]
-				local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
+				local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
 
 				local charged = GetUnitChargedPowerPoints("player")
 
@@ -1643,14 +1648,14 @@ local function UpdateResourceBar()
 						local cpNode = barGroups.secondary:GetNode(x)
 						if cpNode then
 							if snapshotData.attributes.resource2 >= x then
-								TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, cpNode, 1, 1)
+								Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, cpNode, 1, 1)
 								if (specSettings.comboPoints.sameColor and snapshotData.attributes.resource2 == (TRB.Data.character.maxResource2 - 1)) or (not specSettings.comboPoints.sameColor and x == (TRB.Data.character.maxResource2 - 1)) then
 									cpColor = specSettings.colors.comboPoints.penultimate.color
 								elseif (specSettings.comboPoints.sameColor and snapshotData.attributes.resource2 == (TRB.Data.character.maxResource2)) or x == TRB.Data.character.maxResource2 then
 									cpColor = specSettings.colors.comboPoints.final.color
 								end
 							else
-								TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, cpNode, 0, 1)
+								Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, cpNode, 0, 1)
 							end
 						
 							local isCharged = false
@@ -1661,7 +1666,7 @@ local function UpdateResourceBar()
 										cpBorderColor = specSettings.colors.comboPoints.echoingReprimand.color
 				
 										if not specSettings.colors.comboPoints.consistentUnfilledColor then
-											cpBR, cpBG, cpBB, _ = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.echoingReprimand.color, true)
+											cpBR, cpBG, cpBB, _ = Color:GetRGBAFromString(specSettings.colors.comboPoints.echoingReprimand.color, true)
 										end
 										isCharged = true
 									end
@@ -1672,7 +1677,7 @@ local function UpdateResourceBar()
 								cpBorderColor = specSettings.colors.comboPoints.shadowTechniques.color
 
 								if not specSettings.colors.comboPoints.consistentUnfilledColor then
-									cpBR, cpBG, cpBB, _ = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.shadowTechniques.color, true)
+									cpBR, cpBG, cpBB, _ = Color:GetRGBAFromString(specSettings.colors.comboPoints.shadowTechniques.color, true)
 								end
 							end
 							
@@ -1694,7 +1699,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -1720,18 +1725,18 @@ local function SwitchSpec()
 	TRB.Data.prevLookupState = {}
 	TRB.Data.lookupDirty = true
 	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+		Bar:QueueRenderTransition("switchSpec", 0.8)
 	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 	end
-	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
+	Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 	coupDeGraceFrame:UnregisterEvent("COOLDOWN_VIEWER_SPELL_OVERRIDE_UPDATED")
 
 	if TRB.Data.character.specId == 1 then
 		specCache.rogue_assassination.talents:GetTalents()
 		FillSpellData_Assassination()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.rogue_assassination)
+		Character:LoadFromSpecializationCache(specCache.rogue_assassination)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Rogue.AssassinationSpells]]
@@ -1742,7 +1747,7 @@ local function SwitchSpec()
 		spells.shiv:ResetPrimaryResourceCost()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Assassination
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.rogue_assassination.settings)
+		Bar:UpdateSanityCheckValues(specCache.rogue_assassination.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#blindside"] = spells.blindside.icon
@@ -1768,7 +1773,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 2 then
 		specCache.rogue_outlaw.talents:GetTalents()
 		FillSpellData_Outlaw()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.rogue_outlaw)
+		Character:LoadFromSpecializationCache(specCache.rogue_outlaw)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Rogue.OutlawSpells]]
@@ -1777,7 +1782,7 @@ local function SwitchSpec()
 		local targetData = TRB.Data.snapshotData.targetData
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Outlaw
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.rogue_outlaw.settings)
+		Bar:UpdateSanityCheckValues(specCache.rogue_outlaw.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#adrenalineRush"] = spells.adrenalineRush.icon
@@ -1817,7 +1822,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 3 then
 		specCache.rogue_subtlety.talents:GetTalents()
 		FillSpellData_Subtlety()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.rogue_subtlety)
+		Character:LoadFromSpecializationCache(specCache.rogue_subtlety)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Rogue.SubtletySpells]]
@@ -1826,7 +1831,7 @@ local function SwitchSpec()
 		local targetData = TRB.Data.snapshotData.targetData
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Subtlety
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.rogue_subtlety.settings)
+		Bar:UpdateSanityCheckValues(specCache.rogue_subtlety.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#deathFromAbove"] = spells.deathFromAbove.icon
@@ -1864,9 +1869,9 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				TRB.Functions.Character:ResetCaches()
+				Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
-				TRB.Functions.Character:UpdateHealthValues()
+				Character:UpdateHealthValues()
 				TRB.Functions.Class:TriggerResourceBarUpdates()
 			end
 		end)
@@ -1994,9 +1999,9 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
 				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+					Bar:QueueRenderTransition("eventPreSwitch", 0.8)
 				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-					TRB.Functions.Bar:HideResourceBar(true)
+					Bar:HideResourceBar(true)
 				end
 				SwitchSpec()
 			end
@@ -2009,7 +2014,7 @@ function TRB.Functions.Class:CheckCharacter()
 	if specId ~= TRB.Data.character.specId then
 		SwitchSpec()
 	end
-	TRB.Functions.Character:CheckCharacter()
+	Character:CheckCharacter()
 	TRB.Data.character.className = "rogue"
 	TRB.Data.character.maxResource = UnitPowerMax("player", Enum.PowerType.Energy, true)
 	TRB.Data.character.maxResourceUnmodified = UnitPowerMax("player", Enum.PowerType.Energy, false)
@@ -2035,7 +2040,7 @@ function TRB.Functions.Class:CheckCharacter()
 		if maxComboPoints ~= TRB.Data.character.maxResource2 then
 			TRB.Data.character.maxResource2 = maxComboPoints
 			if barGroups and barGroups.primary then
-				TRB.Functions.Bar:SetPosition(sharedSettings, barGroups.primary:GetContainerFrame())
+				Bar:SetPosition(sharedSettings, barGroups.primary:GetContainerFrame())
 			end
 			-- Rebuild secondary bar layout when combo point count changes
 			if barGroups and barGroups.secondary then
@@ -2044,10 +2049,10 @@ function TRB.Functions.Class:CheckCharacter()
 				
 				barGroups.secondary:SetMaxNodes(maxComboPoints)
 				barGroups.secondary:SetNodeCount(maxComboPoints)
-				barGroups.secondary:SetLayout(sharedSettings.comboPoints.spacing, TRB.Functions.Bar:GetMatchWidth(sharedSettings.comboPoints), "HORIZONTAL")
+				barGroups.secondary:SetLayout(sharedSettings.comboPoints.spacing, Bar:GetMatchWidth(sharedSettings.comboPoints), "HORIZONTAL")
 				
 				-- Get effective width for secondary bar, accounting for CDM width matching
-				local effectiveWidth, cdmForced = TRB.Functions.Bar:GetEffectiveWidthForBarGroup(barGroups, sharedSettings, "secondary")
+				local effectiveWidth, cdmForced = Bar:GetEffectiveWidthForBarGroup(barGroups, sharedSettings, "secondary")
 				if cdmForced then
 					barGroups.secondary.fullWidth = true
 				end
@@ -2098,7 +2103,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.resource2Factor = 1
 	end
 
-	TRB.Functions.Character:EventRegistration()
+	Character:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
@@ -2213,8 +2218,8 @@ function TRB.Functions.Class:GetBarTextFrame(relativeToFrame)
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
-	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
-		TRB.Functions.Bar:HideResourceBar(true)
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and Bar:IsRenderTransitionActive() then
+		Bar:HideResourceBar(true)
 		return
 	end
 
@@ -2222,7 +2227,7 @@ function TRB.Functions.Class:TriggerResourceBarUpdates()
 		return
 	end
 	if (TRB.Data.character.specId ~= 1 and TRB.Data.character.specId ~= 2 and TRB.Data.character.specId ~= 3) then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 		return
 	end
 

--- a/ClassModules/Shaman.lua
+++ b/ClassModules/Shaman.lua
@@ -10,6 +10,7 @@ local Threshold = TRB.Functions.Threshold
 local Bar = TRB.Functions.Bar
 local Color = TRB.Functions.Color
 local Character = TRB.Functions.Character
+local frameLevels = TRB.Data.constants.frameLevels
 
 local targetsTimerFrame = TRB.Frames.targetsTimerFrame
 

--- a/ClassModules/Shaman.lua
+++ b/ClassModules/Shaman.lua
@@ -6,6 +6,10 @@ end
 local L = TRB.Localization
 TRB.Functions.Class = TRB.Functions.Class or {}
 local lookupChanged = TRB.Functions.BarText.LookupChanged
+local Threshold = TRB.Functions.Threshold
+local Bar = TRB.Functions.Bar
+local Color = TRB.Functions.Color
+local Character = TRB.Functions.Character
 
 local targetsTimerFrame = TRB.Frames.targetsTimerFrame
 
@@ -156,31 +160,31 @@ local function FillSpecializationCache()
 end
 
 local function Setup_Elemental()
-	TRB.Functions.Character:FillSpecializationCacheSettings("shaman", "elemental")
+	Character:FillSpecializationCacheSettings("shaman", "elemental")
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "shaman_elemental" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Shaman.BarGroupsFactory:CreateForSpec(1)
 	end
 end
 
 local function Setup_Enhancement()
-	TRB.Functions.Character:FillSpecializationCacheSettings("shaman", "enhancement", true)
+	Character:FillSpecializationCacheSettings("shaman", "enhancement", true)
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "shaman_enhancement" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Shaman.BarGroupsFactory:CreateForSpec(2)
 	end
 end
 
 local function Setup_Restoration()
-	TRB.Functions.Character:FillSpecializationCacheSettings("shaman", "restoration", true)
+	Character:FillSpecializationCacheSettings("shaman", "restoration", true)
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "shaman_restoration" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Shaman.BarGroupsFactory:CreateForSpec(3)
 	end
 end
@@ -242,12 +246,12 @@ local function ConstructResourceBar(settings)
 			primaryNode:ClearThresholds()
 			for _ = 1, #TRB.Data.cache.thresholdSpells do
 				local thresholdFrame = CreateFrame("Frame", nil, primaryNode:GetFrame())
-				TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, settings, true)
+				Threshold:ResetThresholdLine(thresholdFrame, settings, true)
 				primaryNode:RegisterThreshold(thresholdFrame)
 			end
 		end
 
-		TRB.Functions.Bar:ConstructBarGroups(settings, barGroups)
+		Bar:ConstructBarGroups(settings, barGroups)
 	end
 
 	-- Enhancement uses secondary bar (Maelstrom Weapon); Elemental/Restoration do not.
@@ -269,7 +273,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	-- TRB.Functions.Bar:HideResourceBar()
+	-- Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -330,7 +334,7 @@ local function RefreshLookupData_Elemental()
 			local currentMaelstrom
 			local castingMaelstrom
 			if sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentMaelstromColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentMaelstromColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				currentMaelstrom = textColorResult:WrapTextInColorCode(resourceFormatted)
 				castingMaelstrom = textColorResult:WrapTextInColorCode(string.format("%.0f", snapshotData.casting.resourceFinal))
@@ -600,7 +604,7 @@ function TRB.Functions.Class:SpellCast(event, spellId)
 					snapshots[spells.chainLightning.id].attributes.targetsHit = 1
 					snapshots[spells.chainLightning.id].attributes.hitTime = currentTime
 					snapshots[spells.chainLightning.id].attributes.hasStruckTargets = false
-				elseif currentTime > (snapshots[spells.chainLightning.id].attributes.hitTime + (TRB.Functions.Character:GetCurrentGCDTime(true) * 4) + TRB.Data.character.latency) then
+				elseif currentTime > (snapshots[spells.chainLightning.id].attributes.hitTime + (Character:GetCurrentGCDTime(true) * 4) + TRB.Data.character.latency) then
 					snapshots[spells.chainLightning.id].attributes.targetsHit = 1
 				end
 
@@ -657,7 +661,7 @@ local function UpdateSnapshot()
 	local snapshotData = TRB.Data.snapshotData --[[@as TRB.Classes.SnapshotData]]
 	local snapshots = snapshotData.snapshots
 	local currentTime = GetTime()
-	TRB.Functions.Character:UpdateSnapshot()
+	Character:UpdateSnapshot()
 
 	snapshots[spells.ascendance.id].buff:GetRemainingTime(currentTime)
 end
@@ -695,7 +699,7 @@ local function UpdateResourceBar()
 
 	-- Always call HideResourceBar first to ensure visibility is correctly determined
 	-- even if we return early due to missing data
-	TRB.Functions.Bar:HideResourceBar()
+	Bar:HideResourceBar()
 
 	if not (barGroups and barGroups.primary) then
 		return
@@ -733,7 +737,7 @@ local function UpdateResourceBar()
 
 				local barBorderColor = specSettings.colors.bar.border.color
 				
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 
 				local barColor = specSettings.colors.bar.base.color
 
@@ -747,7 +751,7 @@ local function UpdateResourceBar()
 					-- Create threshold on-demand if missing
 					if thresholds[thresholdId] == nil then
 						local thresholdFrame = CreateFrame("Frame", nil, resourceFrame)
-						TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
+						Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
 						primaryNode:RegisterThreshold(thresholdFrame)
 						thresholds = primaryNode:GetThresholds()
 					end
@@ -756,7 +760,7 @@ local function UpdateResourceBar()
 					local isUsable = spell:IsUsable()
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
-					local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+					local frameLevel = frameLevels.thresholdOver
 					local snapshot = snapshots[spell.id]
 
 					anyUsable = anyUsable or isUsable
@@ -767,10 +771,10 @@ local function UpdateResourceBar()
 							else
 								if isUsable then
 									thresholdColor = specCacheSettings.colors.threshold.over.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+									frameLevel = frameLevels.thresholdOver
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							end
 						end
@@ -783,19 +787,19 @@ local function UpdateResourceBar()
 					elseif spell.hasCooldown then
 						if snapshotData.snapshots[spell.id].cooldown:IsUnusable() then
 							thresholdColor = specCacheSettings.colors.threshold.unusable.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+							frameLevel = frameLevels.thresholdUnusable
 						elseif isUsable then
 							thresholdColor = specCacheSettings.colors.threshold.over.color
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					else -- This is an active/available/normal spell threshold
 						if isUsable then
 							thresholdColor = specCacheSettings.colors.threshold.over.color
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					end
 					
@@ -804,8 +808,8 @@ local function UpdateResourceBar()
 					end
 					
 					if thresholds[thresholdId] then
-						local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-						TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, resourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
+						local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholds[thresholdId], showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+						Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholds[thresholdId], showThreshold and isDrawn, resourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
 					end
 				end
 
@@ -824,7 +828,7 @@ local function UpdateResourceBar()
 				if anyUsable and specSettings.colors.bar.earthShock.enabled then
 					barColor = specSettings.colors.bar.earthShock.color
 					if specSettings.colors.bar.flashEnabled then
-						TRB.Functions.Bar:PulseFrame(barGroups.primary:GetContainerFrame(), specSettings.colors.bar.flashAlpha, specSettings.colors.bar.flashPeriod)
+						Bar:PulseFrame(barGroups.primary:GetContainerFrame(), specSettings.colors.bar.flashAlpha, specSettings.colors.bar.flashPeriod)
 					else
 						barGroups.primary:GetContainerFrame():SetAlpha(1.0)
 					end
@@ -846,7 +850,7 @@ local function UpdateResourceBar()
 					if specSettings.endOf.ascendance.enabled then
 						useEndOfAscendanceColor = true
 						if specSettings.endOf.ascendance.mode == "gcd" then
-							local gcd = TRB.Functions.Character:GetCurrentGCDTime()
+							local gcd = Character:GetCurrentGCDTime()
 							timeThreshold = gcd * specSettings.endOf.ascendance.gcdsMax
 						elseif specSettings.endOf.ascendance.mode == "time" then
 							timeThreshold = specSettings.endOf.ascendance.timeMax
@@ -864,7 +868,7 @@ local function UpdateResourceBar()
 
 				-- Apply overcap border color if enabled
 				if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
-					local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+					local overcapBorderCurve = Color:BuildResourceThresholdCurve(specSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 					local borderColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapBorderCurve)
 					primaryNode:SetBorderColorCurve(borderColorResult)
 				else
@@ -873,7 +877,7 @@ local function UpdateResourceBar()
 
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			if specSettings.displayBar.health.visibility ~= "never" then
@@ -886,7 +890,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 
 			-- Mana bar update (Balance only)
@@ -925,7 +929,7 @@ local function UpdateResourceBar()
 				local barColor = specSettings.colors.bar.base.color
 				local barBorderColor = specSettings.colors.bar.border.color
 
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
 				
@@ -937,7 +941,7 @@ local function UpdateResourceBar()
 					if specSettings.endOf.ascendance.enabled then
 						useEndOfAscendanceColor = true
 						if specSettings.endOf.ascendance.mode == "gcd" then
-							local gcd = TRB.Functions.Character:GetCurrentGCDTime()
+							local gcd = Character:GetCurrentGCDTime()
 							timeThreshold = gcd * specSettings.endOf.ascendance.gcdsMax
 						elseif specSettings.endOf.ascendance.mode == "time" then
 							timeThreshold = specSettings.endOf.ascendance.timeMax
@@ -954,14 +958,14 @@ local function UpdateResourceBar()
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 			
 			if specSettings.displayBar.secondary.visibility ~= "never" then
 				refreshText = true
 				-- Update Maelstrom Weapon stacks using BarNodes
 				if barGroups.secondary then
-					local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
+					local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
 					local maxStacks = spells.maelstromWeapon.maxStacks
 					local currentStacks = snapshots[spells.maelstromWeapon.id].buff.applications
 					local compressedView = specSettings.colors.comboPoints.compressedView
@@ -1015,9 +1019,9 @@ local function UpdateResourceBar()
 								end
 								
 								if isFilled then
-									TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. nodeIndex, stackNode, 1, 1)
+									Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. nodeIndex, stackNode, 1, 1)
 								else
-									TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. nodeIndex, stackNode, 0, 1)
+									Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. nodeIndex, stackNode, 0, 1)
 								end
 								
 								stackNode:SetBorderColor(cpBorderColor)
@@ -1037,7 +1041,7 @@ local function UpdateResourceBar()
 							local stackNode = barGroups.secondary:GetNode(x)
 							if stackNode then
 								if isFilled then
-									TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, stackNode, 1, 1)
+									Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, stackNode, 1, 1)
 									
 									-- Determine color based on position and sameColor setting
 									if specSettings.comboPoints.sameColor then
@@ -1064,7 +1068,7 @@ local function UpdateResourceBar()
 										end
 									end
 								else
-									TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, stackNode, 0, 1)
+									Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, stackNode, 0, 1)
 								end
 								
 								stackNode:SetBorderColor(cpBorderColor)
@@ -1086,7 +1090,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -1141,7 +1145,7 @@ local function UpdateResourceBar()
 				local currentResource = snapshotData.attributes.resourceModified
 				local barBorderColor = specSettings.colors.bar.border.color
 				
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 
 				local barColor = specSettings.colors.bar.base.color
 
@@ -1153,7 +1157,7 @@ local function UpdateResourceBar()
 					if specSettings.endOf.ascendance.enabled then
 						useEndOfAscendanceColor = true
 						if specSettings.endOf.ascendance.mode == "gcd" then
-							local gcd = TRB.Functions.Character:GetCurrentGCDTime()
+							local gcd = Character:GetCurrentGCDTime()
 							timeThreshold = gcd * specSettings.endOf.ascendance.gcdsMax
 						elseif specSettings.endOf.ascendance.mode == "time" then
 							timeThreshold = specSettings.endOf.ascendance.timeMax
@@ -1170,7 +1174,7 @@ local function UpdateResourceBar()
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			if specSettings.displayBar.health.visibility ~= "never" then
@@ -1183,7 +1187,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1203,17 +1207,17 @@ local function SwitchSpec()
 	TRB.Data.prevLookupState = {}
 	TRB.Data.lookupDirty = true
 	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+		Bar:QueueRenderTransition("switchSpec", 0.8)
 	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 	end
-	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
+	Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 
 	if TRB.Data.character.specId == 1 then
 		specCache.shaman_elemental.talents:GetTalents()
 		FillSpellData_Elemental()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.shaman_elemental)
+		Character:LoadFromSpecializationCache(specCache.shaman_elemental)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Shaman.ElementalSpells]]
@@ -1222,7 +1226,7 @@ local function SwitchSpec()
 		local targetData = TRB.Data.snapshotData.targetData
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Elemental
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.shaman_elemental.settings)
+		Bar:UpdateSanityCheckValues(specCache.shaman_elemental.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#ascendance"] = spells.ascendance.icon
@@ -1250,7 +1254,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 2 then
 		specCache.shaman_enhancement.talents:GetTalents()
 		FillSpellData_Enhancement()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.shaman_enhancement)
+		Character:LoadFromSpecializationCache(specCache.shaman_enhancement)
 			
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]		
 		local spells = spellsData.spells --[[@as TRB.Classes.Shaman.EnhancementSpells]]
@@ -1259,7 +1263,7 @@ local function SwitchSpec()
 		local targetData = TRB.Data.snapshotData.targetData
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Enhancement
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.shaman_enhancement.settings)
+		Bar:UpdateSanityCheckValues(specCache.shaman_enhancement.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#ascendance"] = spells.ascendance.icon
@@ -1277,7 +1281,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 3 then
 		specCache.shaman_restoration.talents:GetTalents()
 		FillSpellData_Restoration()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.shaman_restoration)
+		Character:LoadFromSpecializationCache(specCache.shaman_restoration)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Shaman.RestorationSpells]]
@@ -1286,7 +1290,7 @@ local function SwitchSpec()
 		local targetData = TRB.Data.snapshotData.targetData
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Restoration
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.shaman_restoration.settings)
+		Bar:UpdateSanityCheckValues(specCache.shaman_restoration.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		lookup["#ascendance"] = spells.ascendance.icon
@@ -1315,9 +1319,9 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				TRB.Functions.Character:ResetCaches()
+				Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
-				TRB.Functions.Character:UpdateHealthValues()
+				Character:UpdateHealthValues()
 				TRB.Functions.Class:TriggerResourceBarUpdates()
 			end
 		end)
@@ -1444,9 +1448,9 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
 				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+					Bar:QueueRenderTransition("eventPreSwitch", 0.8)
 				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-					TRB.Functions.Bar:HideResourceBar(true)
+					Bar:HideResourceBar(true)
 				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
@@ -1463,7 +1467,7 @@ function TRB.Functions.Class:CheckCharacter()
 	if specId ~= TRB.Data.character.specId then
 		SwitchSpec()
 	end
-	TRB.Functions.Character:CheckCharacter()
+	Character:CheckCharacter()
 	TRB.Data.character.className = "shaman"
 	local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]
 	
@@ -1485,8 +1489,8 @@ function TRB.Functions.Class:CheckCharacter()
 			TRB.Data.character.maxResource2 = maxComboPoints
 			if barGroups and barGroups.secondary and sharedSettings then
 				barGroups.secondary:Show()
-				TRB.Functions.Bar:ApplyBarGroupsLayout(sharedSettings, barGroups)
-				TRB.Functions.Bar:ApplyBarGroupsAppearance(sharedSettings, barGroups)
+				Bar:ApplyBarGroupsLayout(sharedSettings, barGroups)
+				Bar:ApplyBarGroupsAppearance(sharedSettings, barGroups)
 			end
 		end
 	elseif TRB.Data.character.specId == 3 then
@@ -1523,7 +1527,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.specSupported = false
 	end
 
-	TRB.Functions.Character:EventRegistration()
+	Character:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
@@ -1729,8 +1733,8 @@ function TRB.Functions.Class:HasActiveTimers()
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
-	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
-		TRB.Functions.Bar:HideResourceBar(true)
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and Bar:IsRenderTransitionActive() then
+		Bar:HideResourceBar(true)
 		return
 	end
 
@@ -1738,7 +1742,7 @@ function TRB.Functions.Class:TriggerResourceBarUpdates()
 		return
 	end
 	if TRB.Data.character.specId ~= 1 and TRB.Data.character.specId ~= 2 and TRB.Data.character.specId ~= 3 then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 		return
 	end
 

--- a/ClassModules/Warlock.lua
+++ b/ClassModules/Warlock.lua
@@ -6,6 +6,11 @@ end
 local L = TRB.Localization
 TRB.Functions.Class = TRB.Functions.Class or {}
 local lookupChanged = TRB.Functions.BarText.LookupChanged
+local Threshold = TRB.Functions.Threshold
+local Bar = TRB.Functions.Bar
+local Color = TRB.Functions.Color
+local Character = TRB.Functions.Character
+local frameLevels = TRB.Data.constants.frameLevels
 
 local targetsTimerFrame = TRB.Frames.targetsTimerFrame
 
@@ -134,11 +139,11 @@ local function FillSpecializationCache()
 end
 
 local function Setup_Affliction()
-	TRB.Functions.Character:FillSpecializationCacheSettings("warlock", "affliction", true)
+	Character:FillSpecializationCacheSettings("warlock", "affliction", true)
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "warlock_affliction" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Warlock.BarGroupsFactory:CreateForSpec(1, UIParent)
 	end
 end
@@ -152,11 +157,11 @@ local function FillSpellData_Affliction()
 end
 
 local function Setup_Demonology()
-	TRB.Functions.Character:FillSpecializationCacheSettings("warlock", "demonology", true)
+	Character:FillSpecializationCacheSettings("warlock", "demonology", true)
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "warlock_demonology" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Warlock.BarGroupsFactory:CreateForSpec(2, UIParent)
 	end
 end
@@ -172,11 +177,11 @@ end
 
 
 local function Setup_Destruction()
-	TRB.Functions.Character:FillSpecializationCacheSettings("warlock", "destruction", true)
+	Character:FillSpecializationCacheSettings("warlock", "destruction", true)
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "warlock_destruction" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Warlock.BarGroupsFactory:CreateForSpec(3, UIParent)
 	end
 end
@@ -237,12 +242,12 @@ local function ConstructResourceBar(settings)
 			primaryNode:ClearThresholds()
 			for _ = 1, #TRB.Data.cache.thresholdSpells do
 				local thresholdFrame = CreateFrame("Frame", nil, primaryNode:GetFrame())
-				TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, settings, true)
+				Threshold:ResetThresholdLine(thresholdFrame, settings, true)
 				primaryNode:RegisterThreshold(thresholdFrame)
 			end
 		end
 
-		TRB.Functions.Bar:ConstructBarGroups(settings, barGroups)
+		Bar:ConstructBarGroups(settings, barGroups)
 	end
 
 	-- All Warlock specs use Soul Shards secondary bar
@@ -251,11 +256,11 @@ local function ConstructResourceBar(settings)
 		
 		-- Ensure secondary group knows the correct node count
 		barGroups.secondary:SetNodeCount(maxShards)
-		barGroups.secondary:SetLayout(settings.comboPoints.spacing, TRB.Functions.Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
+		barGroups.secondary:SetLayout(settings.comboPoints.spacing, Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
 		barGroups.secondary:Show()
 		
 		-- Get effective width for secondary bar, accounting for CDM width matching
-		local effectiveWidth, cdmForced = TRB.Functions.Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
+		local effectiveWidth, cdmForced = Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
 		if cdmForced then
 			barGroups.secondary.fullWidth = true
 		end
@@ -289,7 +294,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	-- TRB.Functions.Bar:HideResourceBar()
+	-- Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -543,7 +548,7 @@ function TRB.Functions.Class:SpellCast(event, spellId)
 end
 
 local function UpdateSnapshot()
-	TRB.Functions.Character:UpdateSnapshot()
+	Character:UpdateSnapshot()
 end
 
 local function UpdateSnapshot_Affliction()
@@ -606,7 +611,7 @@ local function UpdateResourceBar()
 
 	-- Always call HideResourceBar first to ensure visibility is correctly determined
 	-- even if we return early due to missing data
-	TRB.Functions.Bar:HideResourceBar()
+	Bar:HideResourceBar()
 
 	if not (barGroups and barGroups.primary) then
 		return
@@ -626,7 +631,7 @@ local function UpdateResourceBar()
 	end
 
 	local function UpdateSoulShards(specSettings, specCacheSettings, normalizedResource2)
-		local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
+		local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
 		for x = 1, TRB.Data.character.maxResource2 do
 			local cpBorderColor = specSettings.colors.comboPoints.border.color
 			local cpColor = specSettings.colors.comboPoints.base.color
@@ -646,7 +651,7 @@ local function UpdateResourceBar()
 			if barGroups and barGroups.secondary then
 				local shardNode = barGroups.secondary:GetNode(x)
 				if shardNode then
-					TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, shardNode, filled and 1 or 0, 1)
+					Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, shardNode, filled and 1 or 0, 1)
 					shardNode:SetBorderColor(cpBorderColor)
 					shardNode:SetColor(cpColor)
 					shardNode:SetBackgroundColor(cpBR, cpBG, cpBB, cpBackgroundAlpha)
@@ -656,7 +661,7 @@ local function UpdateResourceBar()
 	end
 
 	local function UpdateSoulShardsAffliction(specSettings, specCacheSettings, normalizedResource2, spells)
-		local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
+		local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
 		for x = 1, TRB.Data.character.maxResource2 do
 			local cpBorderColor = specSettings.colors.comboPoints.border.color
 			local cpColor = specSettings.colors.comboPoints.base.color
@@ -676,7 +681,7 @@ local function UpdateResourceBar()
 			if barGroups and barGroups.secondary then
 				local shardNode = barGroups.secondary:GetNode(x)
 				if shardNode then
-					TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, shardNode, filled and 1 or 0, 1)
+					Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, shardNode, filled and 1 or 0, 1)
 					shardNode:SetBorderColor(cpBorderColor)
 					shardNode:SetColor(cpColor)
 					shardNode:SetBackgroundColor(cpBR, cpBG, cpBB, cpBackgroundAlpha)
@@ -686,7 +691,7 @@ local function UpdateResourceBar()
 	end
 
 	local function UpdateSoulShardsDestruction(specSettings, specCacheSettings, normalizedResource2)
-		local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
+		local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
 		for x = 1, TRB.Data.character.maxResource2 do
 			local cpBorderColor = specSettings.colors.comboPoints.border.color
 			local cpColor = specSettings.colors.comboPoints.base.color
@@ -710,7 +715,7 @@ local function UpdateResourceBar()
 			if barGroups and barGroups.secondary then
 				local shardNode = barGroups.secondary:GetNode(x)
 				if shardNode then
-					TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, shardNode, fillValue, 1)
+					Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, shardNode, fillValue, 1)
 					shardNode:SetBorderColor(cpBorderColor)
 					shardNode:SetColor(cpColor)
 					shardNode:SetBackgroundColor(cpBR, cpBG, cpBB, cpBackgroundAlpha)
@@ -731,12 +736,12 @@ local function UpdateResourceBar()
 				local barColor = specSettings.colors.bar.base.color
 				local barBorderColor = specSettings.colors.bar.border.color
 
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			if specSettings.displayBar.secondary.visibility ~= "never" then
@@ -756,7 +761,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -777,12 +782,12 @@ local function UpdateResourceBar()
 				local barColor = specSettings.colors.bar.base.color
 				local barBorderColor = specSettings.colors.bar.border.color
 
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			if specSettings.displayBar.secondary.visibility ~= "never" then
@@ -801,7 +806,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -822,12 +827,12 @@ local function UpdateResourceBar()
 				local barColor = specSettings.colors.bar.base.color
 				local barBorderColor = specSettings.colors.bar.border.color
 
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			if specSettings.displayBar.secondary.visibility ~= "never" then
@@ -846,7 +851,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 
@@ -872,17 +877,17 @@ local function SwitchSpec()
 	TRB.Data.prevLookupState = {}
 	TRB.Data.lookupDirty = true
 	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+		Bar:QueueRenderTransition("switchSpec", 0.8)
 	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 	end
-	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
+	Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 
 	if TRB.Data.character.specId == 1 then
 		specCache.warlock_affliction.talents:GetTalents()
 		FillSpellData_Affliction()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.warlock_affliction)
+		Character:LoadFromSpecializationCache(specCache.warlock_affliction)
 		
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Warlock.AfflictionSpells]]
@@ -891,7 +896,7 @@ local function SwitchSpec()
 		local targetData = TRB.Data.snapshotData.targetData
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Affliction
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.warlock_affliction.settings)
+		Bar:UpdateSanityCheckValues(specCache.warlock_affliction.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		TRB.Data.lookup = lookup
@@ -908,7 +913,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 2 then
 		specCache.warlock_demonology.talents:GetTalents()
 		FillSpellData_Demonology()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.warlock_demonology)
+		Character:LoadFromSpecializationCache(specCache.warlock_demonology)
 		
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Warlock.DemonologySpells]]
@@ -917,7 +922,7 @@ local function SwitchSpec()
 		local targetData = TRB.Data.snapshotData.targetData
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Demonology
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.warlock_demonology.settings)
+		Bar:UpdateSanityCheckValues(specCache.warlock_demonology.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		TRB.Data.lookup = lookup
@@ -934,7 +939,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 3 then
 		specCache.warlock_destruction.talents:GetTalents()
 		FillSpellData_Destruction()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.warlock_destruction)
+		Character:LoadFromSpecializationCache(specCache.warlock_destruction)
 		
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Warlock.DestructionSpells]]
@@ -943,7 +948,7 @@ local function SwitchSpec()
 		local targetData = TRB.Data.snapshotData.targetData
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Destruction
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.warlock_destruction.settings)
+		Bar:UpdateSanityCheckValues(specCache.warlock_destruction.settings)
 
 		local lookup = TRB.Data.lookup or {}
 		TRB.Data.lookup = lookup
@@ -971,9 +976,9 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				TRB.Functions.Character:ResetCaches()
+				Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
-				TRB.Functions.Character:UpdateHealthValues()
+				Character:UpdateHealthValues()
 				TRB.Functions.Class:TriggerResourceBarUpdates()
 			end
 		end)
@@ -1101,9 +1106,9 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
 				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+					Bar:QueueRenderTransition("eventPreSwitch", 0.8)
 				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-					TRB.Functions.Bar:HideResourceBar(true)
+					Bar:HideResourceBar(true)
 				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
@@ -1120,7 +1125,7 @@ function TRB.Functions.Class:CheckCharacter()
 	if specId ~= TRB.Data.character.specId then
 		SwitchSpec()
 	end
-	TRB.Functions.Character:CheckCharacter()
+	Character:CheckCharacter()
 	TRB.Data.character.className = "warlock"
 	TRB.Data.character.maxResource = UnitPowerMax("player", TRB.Data.resource, true)
 	TRB.Data.character.maxResourceUnmodified = UnitPowerMax("player", TRB.Data.resource, false)
@@ -1150,8 +1155,8 @@ function TRB.Functions.Class:CheckCharacter()
 			local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]
 			if barGroups and barGroups.secondary then
 				barGroups.secondary:Show()
-				TRB.Functions.Bar:ApplyBarGroupsLayout(sharedSettings, barGroups)
-				TRB.Functions.Bar:ApplyBarGroupsAppearance(sharedSettings, barGroups)
+				Bar:ApplyBarGroupsLayout(sharedSettings, barGroups)
+				Bar:ApplyBarGroupsAppearance(sharedSettings, barGroups)
 			end
 		end
 	end
@@ -1180,7 +1185,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.specSupported = false
 	end
 
-	TRB.Functions.Character:EventRegistration()
+	Character:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
@@ -1296,8 +1301,8 @@ function TRB.Functions.Class:GetBarTextFrame(relativeToFrame)
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
-	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
-		TRB.Functions.Bar:HideResourceBar(true)
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and Bar:IsRenderTransitionActive() then
+		Bar:HideResourceBar(true)
 		return
 	end
 
@@ -1305,7 +1310,7 @@ function TRB.Functions.Class:TriggerResourceBarUpdates()
 		return
 	end
 	if (TRB.Data.character.specId ~= 1 and TRB.Data.character.specId ~= 2 and TRB.Data.character.specId ~= 3) then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 		return
 	end
 

--- a/ClassModules/Warrior.lua
+++ b/ClassModules/Warrior.lua
@@ -6,6 +6,11 @@ end
 local L = TRB.Localization
 TRB.Functions.Class = TRB.Functions.Class or {}
 local lookupChanged = TRB.Functions.BarText.LookupChanged
+local Threshold = TRB.Functions.Threshold
+local Bar = TRB.Functions.Bar
+local Color = TRB.Functions.Color
+local Character = TRB.Functions.Character
+local frameLevels = TRB.Data.constants.frameLevels
 
 local targetsTimerFrame = TRB.Frames.targetsTimerFrame
 
@@ -154,11 +159,11 @@ local function FillSpecializationCache()
 end
 
 local function Setup_Arms()
-	TRB.Functions.Character:FillSpecializationCacheSettings("warrior", "arms")
+	Character:FillSpecializationCacheSettings("warrior", "arms")
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "warrior_arms" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Warrior.BarGroupsFactory:CreateForSpec(1, UIParent)
 	end
 end
@@ -172,11 +177,11 @@ local function FillSpellData_Arms()
 end
 
 local function Setup_Fury()
-	TRB.Functions.Character:FillSpecializationCacheSettings("warrior", "fury")
+	Character:FillSpecializationCacheSettings("warrior", "fury")
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "warrior_fury" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Warrior.BarGroupsFactory:CreateForSpec(2, UIParent)
 	end
 end
@@ -190,11 +195,11 @@ local function FillSpellData_Fury()
 end
 
 local function Setup_Protection()
-	TRB.Functions.Character:FillSpecializationCacheSettings("warrior", "protection", true)
+	Character:FillSpecializationCacheSettings("warrior", "protection", true)
 	
 	-- Only destroy and recreate bar groups when switching to this spec
 	if TRB.Frames.barGroups == nil or TRB.Data.barConstructedForSpec ~= "warrior_protection" then
-		TRB.Functions.Bar:DestroyBarGroups()
+		Bar:DestroyBarGroups()
 		TRB.Frames.barGroups = TRB.Classes.Warrior.BarGroupsFactory:CreateForSpec(3, UIParent)
 	end
 end
@@ -242,12 +247,12 @@ local function ConstructResourceBar(settings)
 			primaryNode:ClearThresholds()
 			for _ = 1, #TRB.Data.cache.thresholdSpells do
 				local thresholdFrame = CreateFrame("Frame", nil, primaryNode:GetFrame())
-				TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, settings, true)
+				Threshold:ResetThresholdLine(thresholdFrame, settings, true)
 				primaryNode:RegisterThreshold(thresholdFrame)
 			end
 		end
 
-		TRB.Functions.Bar:ConstructBarGroups(settings, barGroups)
+		Bar:ConstructBarGroups(settings, barGroups)
 	end
 
 	if TRB.Data.character.specId == 1 then
@@ -269,10 +274,10 @@ local function ConstructResourceBar(settings)
 			else
 				barGroups.secondary:SetMaxNodes(maxWhirlwindNodes)
 				barGroups.secondary:SetNodeCount(maxWhirlwindNodes)
-				barGroups.secondary:SetLayout(settings.comboPoints.spacing, TRB.Functions.Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
+				barGroups.secondary:SetLayout(settings.comboPoints.spacing, Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
 				barGroups.secondary:Show()
 
-				local effectiveWidth, cdmForced = TRB.Functions.Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
+				local effectiveWidth, cdmForced = Bar:GetEffectiveWidthForBarGroup(barGroups, settings, "secondary")
 				if cdmForced then
 					barGroups.secondary.fullWidth = true
 				end
@@ -321,7 +326,7 @@ local function ConstructResourceBar(settings)
 
 	TRB.Functions.Class:CheckCharacter()
 	-- Make sure bar visibility and bar text are updated immediately.
-	-- TRB.Functions.Bar:HideResourceBar()
+	-- Bar:HideResourceBar()
 	TRB.Functions.Class:TriggerResourceBarUpdates()
 end
 
@@ -382,7 +387,7 @@ local function RefreshLookupData_Arms()
 			local castingRage
 			-- Apply overcap color if enabled (takes precedence over overThreshold)
 			if sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentRageColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentRageColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				currentRage = textColorResult:WrapTextInColorCode(resourceFormatted)
 				castingRage = textColorResult:WrapTextInColorCode(string.format("%.0f", TRB.Functions.Number:RoundTo(snapshotData.casting.resourceFinal, resourcePrecision, "floor")))
@@ -462,7 +467,7 @@ local function RefreshLookupData_Fury()
 			local castingRage
 			-- Apply overcap color if enabled (takes precedence over overThreshold)
 			if sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentRageColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentRageColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				currentRage = textColorResult:WrapTextInColorCode(resourceFormatted)
 				castingRage = textColorResult:WrapTextInColorCode(string.format("%.0f", TRB.Functions.Number:RoundTo(snapshotData.casting.resourceFinal, resourcePrecision, "floor")))
@@ -565,7 +570,7 @@ local function RefreshLookupData_Protection()
 			local castingRage
 			-- Apply overcap color if enabled (takes precedence over overThreshold)
 			if sharedSettings.colors.text.overcap and sharedSettings.colors.text.overcap.enabled and TRB.Data.character.inCombat then
-				local overcapTextCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specSettings, currentRageColor, sharedSettings.colors.text.overcap.color)
+				local overcapTextCurve = Color:BuildResourceThresholdCurve(specSettings, currentRageColor, sharedSettings.colors.text.overcap.color)
 				local textColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapTextCurve)
 				currentRage = textColorResult:WrapTextInColorCode(resourceFormatted)
 				castingRage = textColorResult:WrapTextInColorCode(string.format("%.0f", TRB.Functions.Number:RoundTo(snapshotData.casting.resourceFinal, resourcePrecision, "floor")))
@@ -723,7 +728,7 @@ end
 
 local function UpdateSnapshot()
 	local currentTime = GetTime()
-	TRB.Functions.Character:UpdateSnapshot()
+	Character:UpdateSnapshot()
 	
 	local spells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Warrior.ArmsSpells|TRB.Classes.Warrior.FurySpells|TRB.Classes.Warrior.ProtectionSpells]]
 	---@type table<integer, TRB.Classes.Snapshot>
@@ -797,7 +802,7 @@ local function UpdateDefensiveBuffs(specSettings, specCacheSettings)
 	-- Handle both raw string and { color = "..." } object formats
 	local bgColor = specSettings.colors.bars.defensives.background
 	if type(bgColor) == "table" then bgColor = bgColor.color end
-	local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(bgColor, true)
+	local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(bgColor, true)
 	local cpBorderColor = specSettings.colors.bars.defensives.border
 	if type(cpBorderColor) == "table" then cpBorderColor = cpBorderColor.color end
 
@@ -843,7 +848,7 @@ local function UpdateDefensiveBuffs(specSettings, specCacheSettings)
 			if barGroups and barGroups.defensives then
 				local defensiveNode = barGroups.defensives:GetNode(currentDefensiveBar)
 				if defensiveNode then
-					TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. currentDefensiveBar, defensiveNode, cpTime, cpDuration)
+					Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. currentDefensiveBar, defensiveNode, cpTime, cpDuration)
 					defensiveNode:SetBorderColor(cpBorderColor)
 					defensiveNode:SetColor(cpColor)
 					defensiveNode:SetBackgroundColor(cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha)
@@ -874,11 +879,11 @@ local function UpdateWhirlwindCharges(specSettings, specCacheSettings)
 	if stacks < 0 then stacks = 0 end
 	if stacks > 4 then stacks = 4 end
 
-	local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
+	local cpBackgroundRed, cpBackgroundGreen, cpBackgroundBlue, cpBackgroundAlpha = Color:GetRGBAFromString(specSettings.colors.comboPoints.background.color, true)
 	local useZeroStackBg = specSettings.colors.comboPoints.zeroStackBackground.enabled and stacks == 0 and TRB.Data.character.inCombat
 	local zsBgR, zsBgG, zsBgB, zsBgA
 	if useZeroStackBg then
-		zsBgR, zsBgG, zsBgB, zsBgA = TRB.Functions.Color:GetRGBAFromString(specSettings.colors.comboPoints.zeroStackBackground.color, true)
+		zsBgR, zsBgG, zsBgB, zsBgA = Color:GetRGBAFromString(specSettings.colors.comboPoints.zeroStackBackground.color, true)
 	end
 
 	for x = 1, 4 do
@@ -898,7 +903,7 @@ local function UpdateWhirlwindCharges(specSettings, specCacheSettings)
 
 		local node = barGroups.secondary:GetNode(x)
 		if node then
-			TRB.Functions.Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, node, filled and 1 or 0, 1)
+			Bar:SetBarNodeValue(specCacheSettings, "comboPoint" .. x, node, filled and 1 or 0, 1)
 			node:SetBorderColor(cpBorderColor)
 			node:SetColor(cpColor)
 			if useZeroStackBg then
@@ -922,7 +927,7 @@ local function UpdateResourceBar()
 
 	-- Always call HideResourceBar first to ensure visibility is correctly determined
 	-- even if we return early due to missing data
-	TRB.Functions.Bar:HideResourceBar()
+	Bar:HideResourceBar()
 
 	if not (barGroups and barGroups.primary) then
 		return
@@ -961,14 +966,14 @@ local function UpdateResourceBar()
 					maxPrimaryBarResourceUnnormalized = math.min(specCacheSettings.maxResource.value, maxPrimaryBarResourceUnnormalized)
 				end
 				
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				
 				local pairOffset = 0
 				for thresholdId, spell in ipairs(TRB.Data.cache.thresholdSpells--[=[@as TRB.Classes.SpellThreshold[]]=]) do
 					local thresholds = primaryNode:GetThresholds()
 					if thresholds[thresholdId] == nil then
 						local thresholdFrame = CreateFrame("Frame", nil, primaryResourceFrame)
-						TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
+						Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
 						primaryNode:RegisterThreshold(thresholdFrame)
 						thresholds = primaryNode:GetThresholds()
 					end
@@ -978,7 +983,7 @@ local function UpdateResourceBar()
 					local showThreshold = true
 							---@type string?
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
-					local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+					local frameLevel = frameLevels.thresholdOver
 					local snapshot = snapshots[spell.id]
 
 					if spell.isSnowflake then -- These are special snowflakes that we need to handle manually
@@ -992,15 +997,15 @@ local function UpdateResourceBar()
 							elseif spell.settingKey == "executeMaximum" then
 								if isUsable then
 									-- Use ColorCurve to correctly evaluate max cost against secret Rage
-									local thresholdCurve = TRB.Functions.Color:BuildThresholdCurve(
+									local thresholdCurve = Color:BuildThresholdCurve(
 										1,
 										resourceAmount,
 										specCacheSettings.colors.threshold.under.color,
 										specCacheSettings.colors.threshold.over.color
 									)
-									local iconCurve = TRB.Functions.Color:BuildIconVertexColorCurve(1, resourceAmount)
-									frameLevel = TRB.Data.constants.frameLevels.thresholdOver
-									local curveApplied = TRB.Functions.Threshold:ApplyThresholdCurveColor(
+									local iconCurve = Color:BuildIconVertexColorCurve(1, resourceAmount)
+									frameLevel = frameLevels.thresholdOver
+									local curveApplied = Threshold:ApplyThresholdCurveColor(
 										spell, thresholds[thresholdId], thresholdCurve, TRB.Data.resource, specCacheSettings, iconCurve, frameLevel, pairOffset, isUsable
 									)
 									if curveApplied then
@@ -1019,7 +1024,7 @@ local function UpdateResourceBar()
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						elseif spell.id == spells.cleave.id then
 							if not talents:IsTalentActive(spells.cleave) then
@@ -1028,7 +1033,7 @@ local function UpdateResourceBar()
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						end
 					elseif resourceAmount == 0 then
@@ -1038,19 +1043,19 @@ local function UpdateResourceBar()
 					elseif spell.hasCooldown then
 						if snapshots[spell.id].cooldown:IsUnusable() then
 							thresholdColor = specCacheSettings.colors.threshold.unusable.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+							frameLevel = frameLevels.thresholdUnusable
 						elseif isUsable then
 							thresholdColor = specCacheSettings.colors.threshold.over.color
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					else -- This is an active/available/normal spell threshold
 						if isUsable then
 							thresholdColor = specCacheSettings.colors.threshold.over.color
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					end
 					
@@ -1059,8 +1064,8 @@ local function UpdateResourceBar()
 					end
 
 					local thresholdFrame = thresholds[thresholdId]
-					local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholdFrame, showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-					TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholdFrame, showThreshold and isDrawn, primaryResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
+					local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholdFrame, showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+					Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholdFrame, showThreshold and isDrawn, primaryResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
 				end
 
 				local barColor = specSettings.colors.bar.base.color
@@ -1069,7 +1074,7 @@ local function UpdateResourceBar()
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
 				-- Apply overcap border color if enabled
 				if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
-					local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+					local overcapBorderCurve = Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 					local borderColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapBorderCurve)
 					primaryNode:SetBorderColorCurve(borderColorResult)
 				else
@@ -1077,7 +1082,7 @@ local function UpdateResourceBar()
 				end
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			if specSettings.displayBar.health.visibility ~= "never" then
@@ -1090,7 +1095,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1112,14 +1117,14 @@ local function UpdateResourceBar()
 					maxPrimaryBarResourceUnnormalized = math.min(specCacheSettings.maxResource.value, maxPrimaryBarResourceUnnormalized)
 				end
 				
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 
 				local pairOffset = 0
 				for thresholdId, spell in ipairs(TRB.Data.cache.thresholdSpells--[=[@as TRB.Classes.SpellThreshold[]]=]) do
 					local thresholds = primaryNode:GetThresholds()
 					if thresholds[thresholdId] == nil then
 						local thresholdFrame = CreateFrame("Frame", nil, primaryResourceFrame)
-						TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
+						Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
 						primaryNode:RegisterThreshold(thresholdFrame)
 						thresholds = primaryNode:GetThresholds()
 					end
@@ -1129,7 +1134,7 @@ local function UpdateResourceBar()
 					local showThreshold = true
 					---@type string?
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
-					local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+					local frameLevel = frameLevels.thresholdOver
 					local snapshot = snapshots[spell.id]
 					
 					if spell.isSnowflake then -- These are special snowflakes that we need to handle manually
@@ -1139,15 +1144,15 @@ local function UpdateResourceBar()
 							elseif spell.settingKey == "executeMaximum" then
 								if isUsable then
 									-- Use ColorCurve to correctly evaluate max cost against secret Rage
-									local thresholdCurve = TRB.Functions.Color:BuildThresholdCurve(
+									local thresholdCurve = Color:BuildThresholdCurve(
 										1,
 										resourceAmount,
 										specCacheSettings.colors.threshold.under.color,
 										specCacheSettings.colors.threshold.over.color
 									)
-									local iconCurve = TRB.Functions.Color:BuildIconVertexColorCurve(1, resourceAmount)
-									frameLevel = TRB.Data.constants.frameLevels.thresholdOver
-									local curveApplied = TRB.Functions.Threshold:ApplyThresholdCurveColor(
+									local iconCurve = Color:BuildIconVertexColorCurve(1, resourceAmount)
+									frameLevel = frameLevels.thresholdOver
+									local curveApplied = Threshold:ApplyThresholdCurveColor(
 										spell, thresholds[thresholdId], thresholdCurve, TRB.Data.resource, specCacheSettings, iconCurve, frameLevel, pairOffset, isUsable
 									)
 									if curveApplied then
@@ -1157,14 +1162,14 @@ local function UpdateResourceBar()
 									end
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							else
 								if isUsable then
 									thresholdColor = specCacheSettings.colors.threshold.over.color
 								else
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							end
 						elseif spell.id == spells.thunderClap.id then
@@ -1176,7 +1181,7 @@ local function UpdateResourceBar()
 								thresholdColor = specCacheSettings.colors.threshold.over.color
 							else
 								thresholdColor = specCacheSettings.colors.threshold.under.color
-								frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+								frameLevel = frameLevels.thresholdUnder
 							end
 						end
 					elseif resourceAmount == 0 then
@@ -1188,14 +1193,14 @@ local function UpdateResourceBar()
 							thresholdColor = specCacheSettings.colors.threshold.over.color
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					else -- This is an active/available/normal spell threshold
 						if isUsable then
 							thresholdColor = specCacheSettings.colors.threshold.over.color
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					end
 					
@@ -1204,8 +1209,8 @@ local function UpdateResourceBar()
 					end
 
 					local thresholdFrame = thresholds[thresholdId]
-					local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholdFrame, showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-					TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholdFrame, showThreshold and isDrawn, primaryResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
+					local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholdFrame, showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+					Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholdFrame, showThreshold and isDrawn, primaryResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
 				end
 
 				local barColor = specSettings.colors.bar.base.color
@@ -1215,7 +1220,7 @@ local function UpdateResourceBar()
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
 				-- Apply overcap border color if enabled
 				if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
-					local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+					local overcapBorderCurve = Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 					local borderColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapBorderCurve)
 					primaryNode:SetBorderColorCurve(borderColorResult)
 				else
@@ -1223,7 +1228,7 @@ local function UpdateResourceBar()
 				end
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			-- Whirlwind stacks bar (only when Improved Whirlwind is talented, i.e. maxResource2 > 0)
@@ -1242,7 +1247,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1264,14 +1269,14 @@ local function UpdateResourceBar()
 					maxPrimaryBarResourceUnnormalized = math.min(specCacheSettings.maxResource.value, maxPrimaryBarResourceUnnormalized)
 				end
 				
-				TRB.Functions.Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
+				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 
 				local pairOffset = 0
 				for thresholdId, spell in ipairs(TRB.Data.cache.thresholdSpells--[=[@as TRB.Classes.SpellThreshold[]]=]) do
 					local thresholds = primaryNode:GetThresholds()
 					if thresholds[thresholdId] == nil then
 						local thresholdFrame = CreateFrame("Frame", nil, primaryResourceFrame)
-						TRB.Functions.Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
+						Threshold:ResetThresholdLine(thresholdFrame, specCacheSettings, true)
 						primaryNode:RegisterThreshold(thresholdFrame)
 						thresholds = primaryNode:GetThresholds()
 					end
@@ -1281,7 +1286,7 @@ local function UpdateResourceBar()
 					local showThreshold = true
 					---@type string?
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
-					local frameLevel = TRB.Data.constants.frameLevels.thresholdOver
+					local frameLevel = frameLevels.thresholdOver
 					local snapshot = snapshots[spell.id]
 					if spell.isTalent and not talents:IsTalentActive(spell) then -- Talent not selected
 						showThreshold = false
@@ -1295,20 +1300,20 @@ local function UpdateResourceBar()
 								else
 									showThreshold = false
 									thresholdColor = specCacheSettings.colors.threshold.under.color
-									frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+									frameLevel = frameLevels.thresholdUnder
 								end
 							elseif spell.settingKey == "executeMaximum" then
 								if isUsable then
 									-- Use ColorCurve to correctly evaluate max cost against secret Rage
-									local thresholdCurve = TRB.Functions.Color:BuildThresholdCurve(
+									local thresholdCurve = Color:BuildThresholdCurve(
 										1,
 										resourceAmount,
 										specCacheSettings.colors.threshold.under.color,
 										specCacheSettings.colors.threshold.over.color
 									)
-									local iconCurve = TRB.Functions.Color:BuildIconVertexColorCurve(1, resourceAmount)
-									frameLevel = TRB.Data.constants.frameLevels.thresholdOver
-									local curveApplied = TRB.Functions.Threshold:ApplyThresholdCurveColor(
+									local iconCurve = Color:BuildIconVertexColorCurve(1, resourceAmount)
+									frameLevel = frameLevels.thresholdOver
+									local curveApplied = Threshold:ApplyThresholdCurveColor(
 										spell, thresholds[thresholdId], thresholdCurve, TRB.Data.resource, specCacheSettings, iconCurve, frameLevel, pairOffset, isUsable
 									)
 									if curveApplied then
@@ -1326,19 +1331,19 @@ local function UpdateResourceBar()
 					elseif spell.hasCooldown then
 						if snapshots[spell.id].cooldown:IsUnusable() then
 							thresholdColor = specCacheSettings.colors.threshold.unusable.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnusable
+							frameLevel = frameLevels.thresholdUnusable
 						elseif isUsable then
 							thresholdColor = specCacheSettings.colors.threshold.over.color
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					else -- This is an active/available/normal spell threshold
 						if isUsable then
 							thresholdColor = specCacheSettings.colors.threshold.over.color
 						else
 							thresholdColor = specCacheSettings.colors.threshold.under.color
-							frameLevel = TRB.Data.constants.frameLevels.thresholdUnder
+							frameLevel = frameLevels.thresholdUnder
 						end
 					end
 					
@@ -1347,8 +1352,8 @@ local function UpdateResourceBar()
 					end
 
 					local thresholdFrame = thresholds[thresholdId]
-					local isDrawn = TRB.Functions.Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholdFrame, showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
-					TRB.Functions.Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholdFrame, showThreshold and isDrawn, primaryResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
+					local isDrawn = Threshold:AdjustThresholdDisplay(spell, spell.settingKey, thresholdFrame, showThreshold, frameLevel, pairOffset, thresholdColor, snapshot, specCacheSettings)
+					Threshold:RepositionThreshold(specCacheSettings, spell.settingKey, thresholdFrame, showThreshold and isDrawn, primaryResourceFrame, resourceAmount, maxPrimaryBarResourceUnnormalized)
 				end
 				
 				local barColor = specSettings.colors.bar.base.color
@@ -1357,7 +1362,7 @@ local function UpdateResourceBar()
 				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
 				-- Apply overcap border color if enabled
 				if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
-					local overcapBorderCurve = TRB.Functions.Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
+					local overcapBorderCurve = Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
 					local borderColorResult = UnitPowerPercent("player", TRB.Data.resource, true, overcapBorderCurve)
 					primaryNode:SetBorderColorCurve(borderColorResult)
 				else
@@ -1365,7 +1370,7 @@ local function UpdateResourceBar()
 				end
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				TRB.Functions.Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
+				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
 			if specSettings.displayBar.defensives.visibility ~= "never" then
@@ -1383,7 +1388,7 @@ local function UpdateResourceBar()
 					healthNode:SetBorderColor(specCacheSettings.colors.healthBar.border.color)
 					healthNode:SetBackgroundColorFromString(specCacheSettings.colors.healthBar.background.color)
 				end
-				TRB.Functions.Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
+				Bar:UpdateHealthBarOverlays(healthNode, snapshotData, specCacheSettings)
 			end
 		end
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
@@ -1403,17 +1408,17 @@ local function SwitchSpec()
 	TRB.Data.prevLookupState = {}
 	TRB.Data.lookupDirty = true
 	if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-		TRB.Functions.Bar:QueueRenderTransition("switchSpec", 0.8)
+		Bar:QueueRenderTransition("switchSpec", 0.8)
 	elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 	end
-	TRB.Functions.Character:DisableSpellRangeCheckUpdate()
+	Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.character.specId = GetSpecialization()
 	
 	if TRB.Data.character.specId == 1 then
 		specCache.warrior_arms.talents:GetTalents()
 		FillSpellData_Arms()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.warrior_arms)
+		Character:LoadFromSpecializationCache(specCache.warrior_arms)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Warrior.ArmsSpells]]
@@ -1421,7 +1426,7 @@ local function SwitchSpec()
 		TRB.Data.snapshotData.targetData = TRB.Classes.TargetData:New()
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Arms
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.warrior_arms.settings)
+		Bar:UpdateSanityCheckValues(specCache.warrior_arms.settings)
 		
 		local lookup = TRB.Data.lookup or {}
 		lookup["#cleave"] = spells.cleave.icon
@@ -1445,10 +1450,10 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 2 then
 		specCache.warrior_fury.talents:GetTalents()
 		FillSpellData_Fury()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.warrior_fury)
+		Character:LoadFromSpecializationCache(specCache.warrior_fury)
 		
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Fury
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.warrior_fury.settings)
+		Bar:UpdateSanityCheckValues(specCache.warrior_fury.settings)
 		
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Warrior.FurySpells]]
@@ -1474,7 +1479,7 @@ local function SwitchSpec()
 	elseif TRB.Data.character.specId == 3 then
 		specCache.warrior_protection.talents:GetTalents()
 		FillSpellData_Protection()
-		TRB.Functions.Character:LoadFromSpecializationCache(specCache.warrior_protection)
+		Character:LoadFromSpecializationCache(specCache.warrior_protection)
 
 		local spellsData = TRB.Data.spellsData --[[@as TRB.Classes.SpellsData]]
 		local spells = spellsData.spells --[[@as TRB.Classes.Warrior.ProtectionSpells]]
@@ -1483,7 +1488,7 @@ local function SwitchSpec()
 		local targetData = TRB.Data.snapshotData.targetData
 
 		TRB.Functions.RefreshLookupData = RefreshLookupData_Protection
-		TRB.Functions.Bar:UpdateSanityCheckValues(specCache.warrior_protection.settings)
+		Bar:UpdateSanityCheckValues(specCache.warrior_protection.settings)
 		
 		local lookup = TRB.Data.lookup or {}
 		lookup["#ignorePain"] = spells.ignorePain.icon
@@ -1514,9 +1519,9 @@ local function SwitchSpec()
 		C_Timer.After(0.05, function()
 			TRB.Functions.Class:CheckCharacter()
 			if TRB.Data.barConstructedForSpec ~= nil then
-				TRB.Functions.Character:ResetCaches()
+				Character:ResetCaches()
 				-- Ensure health values are populated so the health bar displays immediately
-				TRB.Functions.Character:UpdateHealthValues()
+				Character:UpdateHealthValues()
 				TRB.Functions.Class:TriggerResourceBarUpdates()
 			end
 		end)
@@ -1657,9 +1662,9 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
 
 			if TRB.Details.addonData.optionsPanelFinished and (event == "PLAYER_ENTERING_WORLD" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "TRAIT_CONFIG_UPDATED") then
 				if TRB.Functions.Bar and TRB.Functions.Bar.QueueRenderTransition then
-					TRB.Functions.Bar:QueueRenderTransition("eventPreSwitch", 0.8)
+					Bar:QueueRenderTransition("eventPreSwitch", 0.8)
 				elseif TRB.Functions.Bar and TRB.Functions.Bar.HideResourceBar then
-					TRB.Functions.Bar:HideResourceBar(true)
+					Bar:HideResourceBar(true)
 				end
 				C_Timer.After(0, function()
 					C_Timer.After(0.1, function()
@@ -1676,7 +1681,7 @@ function TRB.Functions.Class:CheckCharacter()
 	if specId ~= TRB.Data.character.specId then
 		SwitchSpec()
 	end
-	TRB.Functions.Character:CheckCharacter()
+	Character:CheckCharacter()
 	TRB.Data.character.className = "warrior"
 	TRB.Data.character.maxResource = UnitPowerMax("player", Enum.PowerType.Rage, true)
 	TRB.Data.character.maxResourceUnmodified = UnitPowerMax("player", Enum.PowerType.Rage, false)
@@ -1706,7 +1711,7 @@ function TRB.Functions.Class:CheckCharacter()
 			if whirlwindCharges ~= TRB.Data.character.maxResource2 then
 				TRB.Data.character.maxResource2 = whirlwindCharges
 				if TRB.Frames.barGroups and TRB.Frames.barGroups.primary then
-					TRB.Functions.Bar:SetPosition(sharedSettings, TRB.Frames.barGroups.primary:GetContainerFrame())
+					Bar:SetPosition(sharedSettings, TRB.Frames.barGroups.primary:GetContainerFrame())
 				end
 			end
 		end
@@ -1721,7 +1726,7 @@ function TRB.Functions.Class:CheckCharacter()
 			if maxComboPoints ~= TRB.Data.character.maxResource2 then
 				TRB.Data.character.maxResource2 = maxComboPoints
 				if barGroups and barGroups.primary then
-					TRB.Functions.Bar:SetPosition(sharedSettings, barGroups.primary:GetContainerFrame())
+					Bar:SetPosition(sharedSettings, barGroups.primary:GetContainerFrame())
 				end
 			end
 		end
@@ -1747,7 +1752,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.specSupported = false
 	end
 
-	TRB.Functions.Character:EventRegistration()
+	Character:EventRegistration()
 end
 
 function TRB.Functions.Class:HideResourceBar(force)
@@ -1951,8 +1956,8 @@ function TRB.Functions.Class:HasActiveTimers()
 end
 
 function TRB.Functions.Class:TriggerResourceBarUpdates()
-	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
-		TRB.Functions.Bar:HideResourceBar(true)
+	if TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and Bar:IsRenderTransitionActive() then
+		Bar:HideResourceBar(true)
 		return
 	end
 
@@ -1960,7 +1965,7 @@ function TRB.Functions.Class:TriggerResourceBarUpdates()
 		return
 	end
 	if TRB.Data.character.specId ~= 1 and TRB.Data.character.specId ~= 2 and TRB.Data.character.specId ~= 3 then
-		TRB.Functions.Bar:HideResourceBar(true)
+		Bar:HideResourceBar(true)
 		return
 	end
 

--- a/Classes/Snapshot.lua
+++ b/Classes/Snapshot.lua
@@ -219,7 +219,7 @@ function TRB.Classes.SnapshotBuff:Reset(includeAttributes, force)
 	self.isPaused = false
 
 	if includeAttributes then
-		self.attributes = {}
+		wipe(self.attributes)
 	end
 
 	if self.customPropertyDefinitions ~= nil then

--- a/Functions/Aura.lua
+++ b/Functions/Aura.lua
@@ -26,8 +26,8 @@ local function AuraUpdateEvent(self, event, unit, info)
 	
 	-- Short circuit this for now
 	if unit == "player" then
-		TRB.Data.cache.values.resource = {}
-		TRB.Data.cache.values.castTime = {}
+		wipe(TRB.Data.cache.values.resource)
+		wipe(TRB.Data.cache.values.castTime)
 		TRB.Data.lookupDirty = true
 		--return
 	elseif unit ~= "player" then
@@ -41,8 +41,8 @@ local function AuraUpdateEvent(self, event, unit, info)
 		end
 		if TRB.Data.character ~= nil and TRB.Data.character.classId == 12 and TRB.Data.character.specId == 3 then
 			TRB.Data.lookupDirty = true
-			TRB.Data.cache.values.resource = {}
-			TRB.Data.cache.values.castTime = {}
+			wipe(TRB.Data.cache.values.resource)
+			wipe(TRB.Data.cache.values.castTime)
 			return
 		end
 		-- Defer the full buff refresh by one frame so that the aura API has time to
@@ -63,8 +63,8 @@ local function AuraUpdateEvent(self, event, unit, info)
 		C_Timer.After(0.02, function()
 			RefreshAndUpdateBars()
 		end)
-		TRB.Data.cache.values.resource = {}
-		TRB.Data.cache.values.castTime = {}
+		wipe(TRB.Data.cache.values.resource)
+		wipe(TRB.Data.cache.values.castTime)
 		return
 	end
 
@@ -107,8 +107,8 @@ local function AuraUpdateEvent(self, event, unit, info)
 						end
 					end
 				end
-				TRB.Data.cache.values.resource = {}
-				TRB.Data.cache.values.castTime = {}
+				wipe(TRB.Data.cache.values.resource)
+				wipe(TRB.Data.cache.values.castTime)
 			end
 		else
 			-- This code works but has a fundamental flaw: UNIT_AURA only gives updates for the player, pet, and visible nameplates.
@@ -174,8 +174,8 @@ local function AuraUpdateEvent(self, event, unit, info)
 					targetData:HandleCombatLogBuff(targetSpell.id, "SPELL_AURA_REFRESH", unitGuid)
 				end
 			end
-			TRB.Data.cache.values.resource = {}
-			TRB.Data.cache.values.castTime = {}
+			wipe(TRB.Data.cache.values.resource)
+			wipe(TRB.Data.cache.values.castTime)
 		else
 			for _, v in pairs(info.updatedAuraInstanceIDs) do
 				local target = targetData.auraInstanceIds[v]
@@ -209,8 +209,8 @@ local function AuraUpdateEvent(self, event, unit, info)
 				TRB.Functions.Aura:RemoveBuffAuraInstanceId(v)
 			end
 
-			TRB.Data.cache.values.resource = {}
-			TRB.Data.cache.values.castTime = {}
+			wipe(TRB.Data.cache.values.resource)
+			wipe(TRB.Data.cache.values.castTime)
 		else
 			for _, v in pairs(info.removedAuraInstanceIDs) do
 				local target = targetData.auraInstanceIds[v]

--- a/Functions/Bar.lua
+++ b/Functions/Bar.lua
@@ -528,8 +528,8 @@ function TRB.Functions.Bar:ConstructBarGroups(settings, barGroups)
 	end
 
 	-- Clear color caches to ensure fresh application on bar construction
-	TRB.Data.cache.colors.border = {}
-	TRB.Data.cache.colors.backdrop = {}
+	wipe(TRB.Data.cache.colors.border)
+	wipe(TRB.Data.cache.colors.backdrop)
 
 	-- Initialize Edit Mode if not yet done (safe to call multiple times)
 	if TRB.Functions.EditMode and TRB.Functions.EditMode.Initialize then
@@ -907,7 +907,7 @@ function TRB.Functions.Bar:ApplyBarGroupsLayout(settings, barGroups)
 	-- This fixes a bug where moving the bar caused threshold colors to reset and stay wrong
 	-- Also clear colors cache in general
 	if TRB.Data.cache and TRB.Data.cache.values then
-		TRB.Data.cache.values.threshold = {}
+		wipe(TRB.Data.cache.values.threshold)
 		TRB.Functions.Character:ResetColorCaches()
 	end
 
@@ -1196,8 +1196,8 @@ function TRB.Functions.Bar:ApplyBarGroupsAppearance(settings, barGroups)
 	end
 
 	-- Clear color caches to ensure colors are re-applied after ApplyBackdrop resets frames
-	TRB.Data.cache.colors.border = {}
-	TRB.Data.cache.colors.backdrop = {}
+	wipe(TRB.Data.cache.colors.border)
+	wipe(TRB.Data.cache.colors.backdrop)
 
 	local frameLevels = TRB.Data.constants.frameLevels
 

--- a/Functions/BarText.lua
+++ b/Functions/BarText.lua
@@ -45,6 +45,7 @@ end
 ---Clears the lookup memoization state, forcing all variables to be recomputed on next tick.
 ---Also marks lookup data as dirty.
 function TRB.Functions.BarText:InvalidateLookupMemoization()
+	TRB.Data.prevLookupState = TRB.Data.prevLookupState or {}
 	wipe(TRB.Data.prevLookupState)
 	TRB.Data.lookupDirty = true
 end

--- a/Functions/BarText.lua
+++ b/Functions/BarText.lua
@@ -45,7 +45,7 @@ end
 ---Clears the lookup memoization state, forcing all variables to be recomputed on next tick.
 ---Also marks lookup data as dirty.
 function TRB.Functions.BarText:InvalidateLookupMemoization()
-	TRB.Data.prevLookupState = {}
+	wipe(TRB.Data.prevLookupState)
 	TRB.Data.lookupDirty = true
 end
 

--- a/Functions/Character.lua
+++ b/Functions/Character.lua
@@ -3,6 +3,13 @@ local _, TRB = ...
 TRB.Functions = TRB.Functions or {}
 TRB.Functions.Character = {}
 
+-- Cached format strings for resource/health percent formatting.
+-- Rebuilt only when the precision setting changes (spec switch / options edit).
+local cachedResourcePercentFmt = nil
+local cachedResourcePercentPrecision = nil
+local cachedHealthPercentFmt = nil
+local cachedHealthPercentPrecision = nil
+
 --TODO: Find a better home for this.
 local function OnAdvFlyEnabled()
 	TRB.Data.character.advancedFlight = true
@@ -88,7 +95,11 @@ function TRB.Functions.Character:UpdateResourceValues()
 			resourcePercentPrecision = entry.settings.precision.mana or 1
 		end
 	end
-	formatted.resourcePercent = string.format("%." .. resourcePercentPrecision .. "f", snapshotData.attributes.resourcePercent)
+	if resourcePercentPrecision ~= cachedResourcePercentPrecision then
+		cachedResourcePercentPrecision = resourcePercentPrecision
+		cachedResourcePercentFmt = "%." .. resourcePercentPrecision .. "f"
+	end
+	formatted.resourcePercent = string.format(cachedResourcePercentFmt, snapshotData.attributes.resourcePercent)
 
 	if TRB.Data.resource2 ~= nil then
 		if TRB.Data.resource2 == "SPELL" then
@@ -126,7 +137,11 @@ function TRB.Functions.Character:UpdateHealthValues()
 			healthPrecision = entry.settings.precision.health or 1
 		end
 	end
-	formatted.healthPercent = string.format("%." .. healthPrecision .. "f", snapshotData.attributes.healthPercent)
+	if healthPrecision ~= cachedHealthPercentPrecision then
+		cachedHealthPercentPrecision = healthPrecision
+		cachedHealthPercentFmt = "%." .. healthPrecision .. "f"
+	end
+	formatted.healthPercent = string.format(cachedHealthPercentFmt, snapshotData.attributes.healthPercent)
 
 	-- Get configurable color curve settings from spec settings
 	local healthBarSettings = nil
@@ -141,24 +156,29 @@ function TRB.Functions.Character:UpdateHealthValues()
 		return
 	end
 
-	-- Use configurable settings or defaults
-	---@type integer?
-	local curveType = Enum.LuaCurveType.Step
+	-- Build a composite cache key from the settings that feed into the curve.
+	-- The curve object itself is normal (non-secret); only the evaluation result is secret.
+	-- Caching the curve avoids ~4 C-side object allocations per health event.
+	local highColor = (healthBarSettings.high and healthBarSettings.high.color) or ""
+	local highThreshold = (healthBarSettings.high and healthBarSettings.high.threshold) or 0.7
+	local lowColor = (healthBarSettings.low and healthBarSettings.low.color) or ""
+	local lowThreshold = (healthBarSettings.low and healthBarSettings.low.threshold) or 0.0
+	local medColor = (healthBarSettings.medium and healthBarSettings.medium.color) or ""
+	local medThreshold = (healthBarSettings.medium and healthBarSettings.medium.threshold) or 0.3
+	local curveTypeStr = healthBarSettings.type or ""
+	local cacheKey = highColor .. highThreshold .. lowColor .. lowThreshold .. medColor .. medThreshold .. curveTypeStr
 
-	if healthBarSettings then
+	local cache = TRB.Data.cache
+	if cache.healthCurve == nil or cache.healthCurveKey ~= cacheKey then
+		-- Rebuild the curve — settings have changed
+		---@type integer?
+		local curveType = Enum.LuaCurveType.Step
+
 		local highR, highG, highB, highA = 0, 1, 0, 1
-		local highThreshold = 0.7
-		-- High health color and threshold
-		if healthBarSettings.high then
-			if healthBarSettings.high.color then
-				highR, highG, highB, highA = TRB.Functions.Color:GetRGBAFromString(healthBarSettings.high.color, true)
-			end
-			if healthBarSettings.high.threshold then
-				highThreshold = healthBarSettings.high.threshold
-			end
+		if healthBarSettings.high and healthBarSettings.high.color then
+			highR, highG, highB, highA = TRB.Functions.Color:GetRGBAFromString(healthBarSettings.high.color, true)
 		end
 
-		-- Curve type
 		if healthBarSettings.type == "linear" then
 			curveType = Enum.LuaCurveType.Linear
 		elseif healthBarSettings.type == "step" then
@@ -173,52 +193,44 @@ function TRB.Functions.Character:UpdateHealthValues()
 			curve:SetType(Enum.LuaCurveType.Step)
 			curve:AddPoint(0, CreateColor(highR, highG, highB, highA))
 		else
-			local lowThreshold = 0.0
 			local lowR, lowG, lowB, lowA = 1, 0, 0, 1
-			local mediumThreshold = 0.3
 			local mediumR, mediumG, mediumB, mediumA = 1, 1, 0, 1
 
-			-- Low health color and threshold
-			if healthBarSettings.low then
-				if healthBarSettings.low.color then
-					lowR, lowG, lowB, lowA = TRB.Functions.Color:GetRGBAFromString(healthBarSettings.low.color, true)
-				end
-				if healthBarSettings.low.threshold then
-					lowThreshold = healthBarSettings.low.threshold
-				end
+			if healthBarSettings.low and healthBarSettings.low.color then
+				lowR, lowG, lowB, lowA = TRB.Functions.Color:GetRGBAFromString(healthBarSettings.low.color, true)
+			end
+			if healthBarSettings.medium and healthBarSettings.medium.color then
+				mediumR, mediumG, mediumB, mediumA = TRB.Functions.Color:GetRGBAFromString(healthBarSettings.medium.color, true)
 			end
 
-			-- Medium health color and threshold
-			if healthBarSettings.medium then
-				if healthBarSettings.medium.color then
-					mediumR, mediumG, mediumB, mediumA = TRB.Functions.Color:GetRGBAFromString(healthBarSettings.medium.color, true)
-				end
-				if healthBarSettings.medium.threshold then
-					mediumThreshold = healthBarSettings.medium.threshold
-				end
+			local adjMedThreshold = medThreshold
+			if adjMedThreshold >= highThreshold then
+				adjMedThreshold = highThreshold - 0.000001
 			end
 
-			if mediumThreshold >= highThreshold then
-				mediumThreshold = highThreshold - 0.000001
-			end
-
-			if lowThreshold >= mediumThreshold then
-				lowThreshold = mediumThreshold - 0.000001
+			local adjLowThreshold = lowThreshold
+			if adjLowThreshold >= adjMedThreshold then
+				adjLowThreshold = adjMedThreshold - 0.000001
 			end
 
 			curve:SetType(curveType)
-			curve:AddPoint(lowThreshold, CreateColor(lowR, lowG, lowB, lowA))
-			curve:AddPoint(mediumThreshold, CreateColor(mediumR, mediumG, mediumB, mediumA))
+			curve:AddPoint(adjLowThreshold, CreateColor(lowR, lowG, lowB, lowA))
+			curve:AddPoint(adjMedThreshold, CreateColor(mediumR, mediumG, mediumB, mediumA))
 			curve:AddPoint(highThreshold, CreateColor(highR, highG, highB, highA))
 		end
-		local hpColor = UnitHealthPercent("player", true, curve)
 
-		snapshotData.attributes.healthColor = hpColor
+		cache.healthCurve = curve
+		cache.healthCurveKey = cacheKey
 	end
+
+	-- Evaluate the cached curve — the result is a secret ColorMixin
+	snapshotData.attributes.healthColor = UnitHealthPercent("player", true, cache.healthCurve)
 end
 
 ---Updates the overcap color based on current resource percentage and overcap settings
 ---Stores the result in snapshotData.attributes.overcapColor (raw ColorMixin object)
+---NOTE: Currently unused — snapshotData.attributes.overcapColor has zero consumers.
+---Kept for potential future use. All call sites have been removed for performance.
 function TRB.Functions.Character:UpdateOvercapColor()
 	local snapshotData = TRB.Data.snapshotData --[[@as TRB.Classes.SnapshotData]]
 	
@@ -301,7 +313,6 @@ local function CharacterChange(self, event, ...)
 		local unitTarget, powerType = ...
 		if unitTarget == "player" and (powerType == TRB.Data.resourceToken or powerType == TRB.Data.resource2Token) then
 			TRB.Functions.Character:UpdateResourceValues()
-			TRB.Functions.Character:UpdateOvercapColor()
 			TRB.Data.lookupDirty = true
 		end
 	elseif event == "UNIT_HEALTH" or event == "UNIT_MAXHEALTH" or event == "UNIT_ABSORB_AMOUNT_CHANGED" or event == "UNIT_HEAL_PREDICTION" then
@@ -804,20 +815,25 @@ function TRB.Functions.Character:LoadFromSpecializationCache(cache)
 end
 
 function TRB.Functions.Character:ResetColorCaches()
-	TRB.Data.cache.colors.border = {}
-	TRB.Data.cache.colors.bar = {}
-	TRB.Data.cache.colors.backdrop = {}
+	wipe(TRB.Data.cache.colors.border)
+	wipe(TRB.Data.cache.colors.bar)
+	wipe(TRB.Data.cache.colors.backdrop)
+	-- Invalidate cached health color curve so it rebuilds from fresh settings
+	TRB.Data.cache.healthCurve = nil
+	TRB.Data.cache.healthCurveKey = nil
+	-- Clear RGBA parse memoization to bound memory
+	TRB.Functions.Color:ClearRGBACache()
 end 
 
 function TRB.Functions.Character:ResetCaches()
-	TRB.Data.cache.barText = {}
+	wipe(TRB.Data.cache.barText)
 	TRB.Functions.BarText:ClearBarTextCacheHash()
-	TRB.Data.cache.symbols = {}
-	TRB.Data.cache.barTextTree = {}
+	wipe(TRB.Data.cache.symbols)
+	wipe(TRB.Data.cache.barTextTree)
 	TRB.Data.activeVariables = nil
-	TRB.Data.cache.values.bar = {}
-	TRB.Data.cache.values.resource = {}
-	TRB.Data.cache.values.threshold = {}
+	wipe(TRB.Data.cache.values.bar)
+	wipe(TRB.Data.cache.values.resource)
+	wipe(TRB.Data.cache.values.threshold)
 	TRB.Functions.Character:ResetColorCaches()
 	-- We don't do range check cache reset here since we need to track what we've enabled and clean it up when we change specs
 	--TRB.Data.cache.values.range = {}

--- a/Functions/Color.lua
+++ b/Functions/Color.lua
@@ -2,6 +2,12 @@ local _, TRB = ...
 TRB.Functions = TRB.Functions or {}
 TRB.Functions.Color = {}
 
+-- Memoization cache for GetRGBAFromString in the common case (no color/alpha adjustment).
+-- Keyed by hexString .. (normalize and "T" or "F"), storing {r, g, b, a}.
+-- Never needs explicit invalidation — a given hex string always maps to the same RGBA.
+-- Optionally cleared in ResetColorCaches() to bound memory.
+local rgbaCache = {}
+
 ---Converts a hexdecimal AARRGGBB string to separate numerical RGBA values, either out of 0-255 or 0.0 - 1.0
 ---@param s string # Hexdecimal string
 ---@param normalize boolean? # Should this be normalized to 0.0 - 1.0?
@@ -9,6 +15,27 @@ TRB.Functions.Color = {}
 ---@param percentAlphaAdjust number? # How much we scale the alpha down
 ---@return number, number, number, number
 function TRB.Functions.Color:GetRGBAFromString(s, normalize, percentColorAdjust, percentAlphaAdjust)
+	-- Fast path: when no color/alpha adjustment, use memoized result
+	local canCache = (percentColorAdjust == nil or percentColorAdjust == 1) and (percentAlphaAdjust == nil or percentAlphaAdjust == 1)
+	if canCache and s ~= nil and #s == 8 then
+		local cacheKey = normalize and (s .. "T") or (s .. "F")
+		local cached = rgbaCache[cacheKey]
+		if cached then
+			return cached[1], cached[2], cached[3], cached[4]
+		end
+		-- Compute and cache
+		local _a = TRB.Functions.Number:RoundTo(min(255, tonumber(string.sub(s, 1, 2), 16)), 0, floor, true)
+		local _r = TRB.Functions.Number:RoundTo(min(255, tonumber(string.sub(s, 3, 4), 16)), 0, floor, true)
+		local _g = TRB.Functions.Number:RoundTo(min(255, tonumber(string.sub(s, 5, 6), 16)), 0, floor, true)
+		local _b = TRB.Functions.Number:RoundTo(min(255, tonumber(string.sub(s, 7, 8), 16)), 0, floor, true)
+		if normalize then
+			_r, _g, _b, _a = _r/255, _g/255, _b/255, _a/255
+		end
+		rgbaCache[cacheKey] = { _r, _g, _b, _a }
+		return _r, _g, _b, _a
+	end
+
+	-- Slow path: adjustment factors are non-default
 	if percentColorAdjust == nil or percentColorAdjust > 1 then
 		percentColorAdjust = 1
 	elseif percentColorAdjust < 0 then
@@ -40,6 +67,11 @@ function TRB.Functions.Color:GetRGBAFromString(s, normalize, percentColorAdjust,
 	else
 		return _r, _g, _b, _a
 	end
+end
+
+---Clears the RGBA parse memoization cache. Call from ResetColorCaches() to bound memory.
+function TRB.Functions.Color:ClearRGBACache()
+	wipe(rgbaCache)
 end
 
 function TRB.Functions.Color:ConvertColorDecimalToHex(r, g, b, a)


### PR DESCRIPTION
# Summary

Continuation of the performance work from .27. This PR targets the non-bar-text runtime hot path — event handlers, per-tick update functions, and cache invalidation — based on a systematic audit documented in performance-non-bartext.md.

# Benchmark Results

All benchmarks recorded as a Shadow Priest at the same location, same session duration, same methodology. "Peak" and "Avg" are ms-per-tick; ">1" counts ticks exceeding 1ms; "Frames" is the total frame count over the run.

```
+-------------+-------+-------+-----+--------+-------------------+
| Release     |  Peak |   Avg |  >1 | Frames | Improvement Avg   |
+-------------+-------+-------+-----+--------+-------------------+
|                  Garrison, 20Hz, Other Addons                  |
+-------------+-------+-------+-----+--------+-------------------+
| .26-release | 1.652 | 0.344 | 270 |   5382 |                   |
| .27-release | 2.183 | 0.266 |  24 |   6197 | -22.67%           |
| WIP         | 1.814 | 0.229 |   8 |   6474 | -33.43% (-13.91%) |
+-------------+-------+-------+-----+--------+-------------------+
|                     Exodar, 20Hz, No Addons                    |
+-------------+-------+-------+-----+--------+-------------------+
| .26-release | 2.223 | 0.096 |  95 |  22408 |                   |
| .27-release | 1.723 | 0.071 |   7 |  22914 | -26.04%           |
| WIP         | 2.062 | 0.067 |   8 |  22795 | -30.21% (-5.63%)  |
+-------------+-------+-------+-----+--------+-------------------+
|                   Exodar, Uncapped, No Addons                  |
+-------------+-------+-------+-----+--------+-------------------+
| .26-release | 2.996 | 0.653 | 179 |  21049 |                   |
| .27-release | 2.313 | 0.480 |  53 |  21675 | -26.49%           |
| WIP         | 1.906 | 0.417 |  30 |  21980 | -36.14% (-13.13%) |
+-------------+-------+-------+-----+--------+-------------------+
```

Cumulative improvement over .26 ranges from **-30% to -36% average tick time** depending on scenario. The incremental improvement from this PR over .27 alone is **-5.6% to -13.9%**. High-tick outliers (>1ms) dropped from 270 → 24 → 8 in the Garrison scenario, demonstrating reduced GC stalls.

---

# Changes

## 1. Remove Dead `UpdateOvercapColor()` Calls (Critical)

**Files:** Character.lua, Druid.lua

`UpdateOvercapColor()` built a `C_CurveUtil.CreateColorCurve()` + 2× `CreateColor()`, called `UnitPowerPercent()`, and stored the result in `snapshotData.attributes.overcapColor` — a field with **zero consumers** anywhere in the codebase. This ran on every `UNIT_POWER_UPDATE`/`UNIT_POWER_FREQUENT` event (60+/sec for energy/mana specs).

- Removed call sites from `CharacterChange` in Character.lua and `DruidPowerEvent` in Druid.lua.
- Kept the function definition with a comment noting it's unused, for potential future use.
- **Impact:** Eliminates 3 C-side object allocations + 1 `UnitPowerPercent` API call per resource-change event.

## 2. Cache Health Color Curve (High)

**Files:** Character.lua

`UpdateHealthValues()` was creating `C_CurveUtil.CreateColorCurve()` + up to 3× `CreateColor()` + 3× `curve:AddPoint()` on **every** health event (5–20×/sec in combat). All inputs are non-secret saved-variable settings that only change via the options panel.

- Built a composite cache key from all color/threshold/type settings.
- Stored the curve in `TRB.Data.cache.healthCurve`; only rebuilt when the key changes.
- Invalidated in `ResetColorCaches()`.
- **Impact:** Eliminates ~4 C-side object allocations per health event.

## 3. Replace `= {}` with `wipe()` Everywhere (High)

**Files:** Aura.lua, Character.lua, Bar.lua, BarText.lua

The addon used **zero** `wipe()` calls — every cache invalidation created new garbage tables via `= {}`. This was the largest source of GC pressure.

Converted 17 sites across 4 files. The heaviest offenders were in Aura.lua, where a single `UNIT_AURA` event with 3 `addedAuras` was creating **8 new empty tables**. After this change: 0.

All sites were verified to have no captured local references to the table containers — all access goes through `TRB.Data.cache.values.resource[key]` etc., making `wipe()` safe.

## 4. Add Hex-to-RGBA Parse Cache (Medium)

**Files:** Color.lua

`GetRGBAFromString()` performs 4× `string.sub` + 4× `tonumber` + 4× `RoundTo` + 4× `min` per call. It's called ~11–18 times per tick (primary bar + secondary nodes + health bar), plus from `UpdateHealthValues` on events.

- Added a memoization table keyed by `(hexString, normalizeFlag)` for the common case where `percentColorAdjust` and `percentAlphaAdjust` are both nil/1.
- Falls through to the full parse path when adjustment factors are non-default.
- Cache cleared in `ResetColorCaches()` via the new `ClearRGBACache()` method.
- **Impact:** Eliminates ~11–18 instances of 16 string/math operations per 50ms tick.

## 5. Cache Format Strings in `UpdateResourceValues`/`UpdateHealthValues` (Medium)

**Files:** Character.lua

`"%." .. precision .. "f"` was rebuilt via string concatenation on every `UNIT_POWER_UPDATE`/`UNIT_POWER_FREQUENT` and health event. The precision value only changes when settings are modified.

- Added file-local upvalues (`cachedResourcePercentFmt`, `cachedHealthPercentFmt`) that rebuild only when the precision value changes.
- **Impact:** Eliminates 1–2 string concatenations per resource/health event.

## 6. Hoist Per-Tick Table Literal in Holy Priest (Medium)

**Files:** `ClassModules/Priest.lua`

`holyWordDefs` created a 3-element array of table literals (1 array + 3 inner tables = 4 allocations) inside `UpdateResourceBar` every 50ms tick for Holy Priests.

- Moved to a file-level pre-allocated `holyWordDefsCache` table.
- Static fields (`spell`, `key`) populated once in `FillSpellData_Holy()`.
- Only mutable fields (`color`, `enabled`) refreshed per-tick from settings.
- **Impact:** Eliminates 4 table allocations per 50ms tick for Holy Priest.

## 7. Localize Hot-Path Namespace Lookups (Low-Medium)

**Files:** All 13 class modules

Inside `UpdateResourceBar`, deeply-nested paths like `TRB.Functions.Threshold:AdjustThresholdDisplay(...)` traverse 3 hash-table lookups (`TRB` → Functions → `Threshold` → method) before the function call. This happens N times per threshold per tick.

- Added file-level local aliases in all 13 class modules:
  ```lua
  local Threshold = TRB.Functions.Threshold
  local Bar = TRB.Functions.Bar
  local Color = TRB.Functions.Color
  local Character = TRB.Functions.Character
  local frameLevels = TRB.Data.constants.frameLevels
  ```
- Replaced all corresponding `TRB.Functions.X:` and `TRB.Data.constants.frameLevels` references.
- **Impact:** Eliminates 2N+ hash lookups per tick per spec, where N is the number of thresholds.

## 8. Replace `self.attributes = {}` with `wipe(self.attributes)` in `SnapshotBuff:Reset` (Low)

**Files:** Snapshot.lua

`SnapshotBuff:Reset()` created a fresh table each time a buff expired. All consumers use `attributes["key"] or 0` patterns, handling nil returns from `wipe()` gracefully.

- **Impact:** Eliminates 1 table allocation per buff expiration.

---

# What Was *Not* Changed

These were investigated and deliberately excluded (see performance-non-bartext.md for rationale):

- `BarVisibilityEntry:New()` — already gated behind dirty-flag system
- `SnapshotCooldown:Refresh()` — low impact (1–4 calls/tick)
- Pre-computed `"comboPoint" .. x` keys — trivial string concat cost
- `showFrameCache` in BarText.lua — excluded per scope (bar-text-specific)