### PR TITLE
Bar Visibility: Alpha-Based Fade System & Table-Based Options UI

### DIFF
--- a/ClassModules/DeathKnight.lua
+++ b/ClassModules/DeathKnight.lua
@@ -725,7 +725,7 @@ local function UpdateResourceBar()
 				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 
 				local pairOffset = 0
 				for thresholdId, spell in ipairs(TRB.Data.cache.thresholdSpells--[=[@as TRB.Classes.SpellThreshold[]]=]) do
@@ -830,7 +830,7 @@ local function UpdateResourceBar()
 				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 
 				local pairOffset = 0
 				for thresholdId, spell in ipairs(TRB.Data.cache.thresholdSpells--[=[@as TRB.Classes.SpellThreshold[]]=]) do
@@ -935,7 +935,7 @@ local function UpdateResourceBar()
 				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 
 				local pairOffset = 0
 				for thresholdId, spell in ipairs(TRB.Data.cache.thresholdSpells--[=[@as TRB.Classes.SpellThreshold[]]=]) do

--- a/ClassModules/DemonHunter.lua
+++ b/ClassModules/DemonHunter.lua
@@ -1131,7 +1131,7 @@ local function UpdateResourceBar()
 
 					local barBorderColor = specSettings.colors.bar.border.color
 
-					barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+					barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 					-- Apply overcap border color if enabled
 					if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
 						local overcapBorderCurve = Color:BuildResourceThresholdCurve(specSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
@@ -1260,7 +1260,7 @@ local function UpdateResourceBar()
 
 					local barBorderColor = specSettings.colors.bar.border.color
 
-					barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+					barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 					-- Apply overcap border color if enabled
 					if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
 						local overcapBorderCurve = Color:BuildResourceThresholdCurve(specSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
@@ -1419,7 +1419,7 @@ local function UpdateResourceBar()
 
 					local barBorderColor = specSettings.colors.bar.border.color
 
-					barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+					barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 					-- Apply overcap border color if enabled
 					if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
 						local overcapBorderCurve = Color:BuildResourceThresholdCurve(specSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)

--- a/ClassModules/Druid.lua
+++ b/ClassModules/Druid.lua
@@ -1934,10 +1934,10 @@ local function UpdateResourceBar()
 
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 
 				if flashBar then
-					Bar:PulseFrame(barGroups.primary:GetContainerFrame(), specSettings.colors.bar.flashAlpha, specSettings.colors.bar.flashPeriod)
+					Bar:PulseFrame(barGroups.primary:GetContainerFrame(), specSettings.colors.bar.flashAlpha, specSettings.colors.bar.flashPeriod, barGroups.primary.currentAlpha)
 				end
 				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
@@ -2265,7 +2265,7 @@ local function UpdateResourceBar()
 					primaryNode:SetColor(barColor)
 				end
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
@@ -2523,7 +2523,7 @@ local function UpdateResourceBar()
 
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
 				primaryNode:SetColor(barColor)
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
@@ -2609,7 +2609,7 @@ local function UpdateResourceBar()
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 

--- a/ClassModules/Evoker.lua
+++ b/ClassModules/Evoker.lua
@@ -789,7 +789,7 @@ local function UpdateResourceBar()
 				local barBorderColor = specSettings.colors.bar.border.color
 
 				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 
 				-- Dragonrage bar color changes
 				if specSettings.colors.bar.dragonrage.enabled and snapshots[spells.dragonrage.id].buff.isActive then
@@ -902,7 +902,7 @@ local function UpdateResourceBar()
 				local barBorderColor = specSettings.colors.bar.border.color
 
 				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 
 				-- Ebon Might bar color changes
 				if snapshots[spells.ebonMight.id].buff.isActive then

--- a/ClassModules/Hunter.lua
+++ b/ClassModules/Hunter.lua
@@ -916,12 +916,12 @@ local function UpdateResourceBar()
 
 				if spells.bestialWrath:IsUsable() then
 					if specSettings.colors.bar.flashEnabled and TRB.Data.character.inCombat then
-						Bar:PulseFrame(barGroups.primary:GetContainerFrame(), specSettings.colors.bar.flashAlpha, specSettings.colors.bar.flashPeriod)
+						Bar:PulseFrame(barGroups.primary:GetContainerFrame(), specSettings.colors.bar.flashAlpha, specSettings.colors.bar.flashPeriod, barGroups.primary.currentAlpha)
 					else
-						barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+						barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 					end
 				else
-					barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+					barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				end
 
 				-- Apply overcap border color if enabled
@@ -1100,7 +1100,7 @@ local function UpdateResourceBar()
 					end
 				end
 
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				-- Apply overcap border color if enabled
 				if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
 					local overcapBorderCurve = Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
@@ -1231,7 +1231,7 @@ local function UpdateResourceBar()
 					end
 				end
 
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				-- Apply overcap border color if enabled
 				if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
 					local overcapBorderCurve = Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)

--- a/ClassModules/Mage.lua
+++ b/ClassModules/Mage.lua
@@ -651,7 +651,7 @@ local function UpdateResourceBar()
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
@@ -754,7 +754,7 @@ local function UpdateResourceBar()
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
@@ -787,7 +787,7 @@ local function UpdateResourceBar()
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 

--- a/ClassModules/Monk.lua
+++ b/ClassModules/Monk.lua
@@ -1088,7 +1088,7 @@ local function UpdateResourceBar()
 						end
 					end
 
-					barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+					barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 					-- Apply overcap border color if enabled
 					if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
 						local overcapBorderCurve = Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
@@ -1215,7 +1215,7 @@ local function UpdateResourceBar()
 						barColor = specSettings.colors.bar.vivaciousVivification.color
 					end
 
-					barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+					barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 					primaryNode:SetBorderColor(barBorderColor)
 					primaryNode:SetColor(barColor)
 					primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
@@ -1346,7 +1346,7 @@ local function UpdateResourceBar()
 						barBorderColor = specSettings.colors.bar.danceOfChiJi.color
 					end
 
-					barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+					barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 					-- Apply overcap border color if enabled
 					if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
 						local overcapBorderCurve = Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)

--- a/ClassModules/Options/DeathKnightOptions.lua
+++ b/ClassModules/Options/DeathKnightOptions.lua
@@ -934,7 +934,7 @@ local function BloodConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.deathknight_blood
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 6, 1, yCoord, L["ResourceRunicPower"], "notEmpty", false, nil, nil, true, L["ResourceRunes"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 6, 1, yCoord, L["ResourceRunicPower"], "notEmpty", true, L["ResourceRunes"], true)
 end
 
 local function BloodConstructThresholdPanel(parent)
@@ -1384,7 +1384,7 @@ local function FrostConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.deathknight_frost
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 6, 2, yCoord, L["ResourceRunicPower"], "notEmpty", false, nil, nil, true, L["ResourceRunes"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 6, 2, yCoord, L["ResourceRunicPower"], "notEmpty", true, L["ResourceRunes"], true)
 end
 
 local function FrostConstructThresholdPanel(parent)
@@ -1856,7 +1856,7 @@ local function UnholyConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.deathknight_unholy
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 6, 3, yCoord, L["ResourceRunicPower"], "notEmpty", false, nil, nil, true, L["ResourceRunes"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 6, 3, yCoord, L["ResourceRunicPower"], "notEmpty", true, L["ResourceRunes"], true)
 end
 
 local function UnholyConstructThresholdPanel(parent)

--- a/ClassModules/Options/DeathKnightOptions.lua
+++ b/ClassModules/Options/DeathKnightOptions.lua
@@ -219,9 +219,9 @@ local function BloodLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",
@@ -390,9 +390,9 @@ local function FrostLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",
@@ -557,9 +557,9 @@ local function UnholyLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",

--- a/ClassModules/Options/DemonHunterOptions.lua
+++ b/ClassModules/Options/DemonHunterOptions.lua
@@ -814,7 +814,7 @@ local function HavocConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.demonhunter_havoc
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 12, 1, yCoord, L["ResourceFury"], "notEmpty", false, nil, nil, false, nil, true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 12, 1, yCoord, L["ResourceFury"], "notEmpty", false, nil, true)
 
 	TRB.Frames.interfaceSettingsFrameContainer.controls.demonhunter_havoc = controls
 end
@@ -1321,7 +1321,7 @@ local function VengeanceConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.demonhunter_vengeance
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 12, 2, yCoord, L["ResourceFury"], "notEmpty", false, nil, nil, true, L["ResourceSoulFragments"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 12, 2, yCoord, L["ResourceFury"], "notEmpty", true, L["ResourceSoulFragments"], true)
 
 	TRB.Frames.interfaceSettingsFrameContainer.controls.demonhunter_vengeance = controls
 end
@@ -1862,7 +1862,7 @@ local function DevourerConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.demonhunter_devourer
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 12, 3, yCoord, L["ResourceFury"], "notEmpty", false, nil, nil, true, L["ResourceSoulFragments"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 12, 3, yCoord, L["ResourceFury"], "notEmpty", true, L["ResourceSoulFragments"], true)
 end
 
 local function DevourerConstructThresholdPanel(parent)

--- a/ClassModules/Options/DemonHunterOptions.lua
+++ b/ClassModules/Options/DemonHunterOptions.lua
@@ -112,9 +112,9 @@ local function HavocLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		endOf = {
 			metamorphosis = TRB.Functions.Settings:DefaultEndOfSettings("gcd", 2, 3.0)
@@ -271,9 +271,9 @@ local function VengeanceLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		endOf = {
 			metamorphosis = TRB.Functions.Settings:DefaultEndOfSettings("gcd", 2, 3.0)
@@ -465,9 +465,9 @@ local function DevourerLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		endOf = {
 			metamorphosis = TRB.Functions.Settings:DefaultEndOfSettings("gcd", 2, 3.0)

--- a/ClassModules/Options/DruidOptions.lua
+++ b/ClassModules/Options/DruidOptions.lua
@@ -287,10 +287,10 @@ local function BalanceLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			mana = { neverShow = true, alwaysShow = false, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			mana = { neverShow = true, alwaysShow = false, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 			enableFormSwitching = true,
 			showComboPoints = false
 		},
@@ -623,9 +623,9 @@ local function FeralLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 			enableFormSwitching = true,
 			showComboPoints = true
 		},
@@ -805,9 +805,9 @@ local function GuardianLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 			enableFormSwitching = true,
 			showComboPoints = false
 		},
@@ -926,9 +926,9 @@ local function RestorationLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 			enableFormSwitching = true,
 			showComboPoints = false
 		},

--- a/ClassModules/Options/DruidOptions.lua
+++ b/ClassModules/Options/DruidOptions.lua
@@ -1236,6 +1236,9 @@ local function BalanceConstructAstralPowerBarPanel(parent)
 
 	yCoord = yCoord - 40
 	yCoord = TRB.Functions.OptionsUi:GenerateMaxResourceOptions(parent, controls, spec, 11, 1, yCoord, L["ResourceAstralPower"], 1, BALANCE_MAX_ASTRAL_POWER)
+
+	yCoord = yCoord - 40
+	yCoord = TRB.Functions.OptionsUi:GenerateFlashOptions(parent, controls, spec, 11, 1, yCoord, L["DruidBalanceStarsurge"], L["DruidBalanceStarsurge"])
 end
 
 local function BalanceConstructManaBarPanel(parent)
@@ -1298,9 +1301,6 @@ local function BalanceConstructBarVisibilityPanel(parent)
 	local yCoord = 5
 	local f = nil
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 11, 1, yCoord, L["ResourceAstralPower"], "balance", true, L["DruidBalanceStarsurge"], L["DruidBalanceStarsurge"], true, L["ResourceComboPoints"], true, true)
-
-	yCoord = yCoord - 70
 	controls.checkBoxes.enableFormSwitching = CreateFrame("CheckButton", "TwintopResourceBar_Druid_Balance_Checkbox_FormSwitching", parent, "ChatConfigCheckButtonTemplate")
 	f = controls.checkBoxes.enableFormSwitching
 	f:SetPoint("TOPLEFT", oUi.xCoord, yCoord)
@@ -1360,6 +1360,9 @@ local function BalanceConstructBarVisibilityPanel(parent)
 			TRB.Data.cache.values.frame = {}
 		end
 	end)
+
+	yCoord = yCoord - 30
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 11, 1, yCoord, L["ResourceAstralPower"], "balance", true, L["ResourceComboPoints"], true, true)
 end
 
 local function BalanceConstructThresholdPanel(parent)
@@ -1994,9 +1997,6 @@ local function FeralConstructBarVisibilityPanel(parent)
 	local yCoord = 5
 	local f = nil
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 11, 2, yCoord, L["ResourceEnergy"], "notFull", false, nil, nil, true, L["ResourceComboPoints"], true)
-
-	yCoord = yCoord - 70
 	controls.checkBoxes.enableFormSwitching = CreateFrame("CheckButton", "TwintopResourceBar_Druid_Feral_Checkbox_FormSwitching", parent, "ChatConfigCheckButtonTemplate")
 	f = controls.checkBoxes.enableFormSwitching
 	f:SetPoint("TOPLEFT", oUi.xCoord, yCoord)
@@ -2054,6 +2054,9 @@ local function FeralConstructBarVisibilityPanel(parent)
 			TRB.Data.cache.values.frame = {}
 		end
 	end)
+
+	yCoord = yCoord - 30
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 11, 2, yCoord, L["ResourceEnergy"], "notFull", true, L["ResourceComboPoints"], true)
 end
 
 local function FeralConstructThresholdPanel(parent)
@@ -2612,9 +2615,6 @@ local function GuardianConstructBarVisibilityPanel(parent)
 	local yCoord = 5
 	local f = nil
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 11, 3, yCoord, L["ResourceRage"], "guardian", false, nil, nil, true, L["ResourceComboPoints"], true)
-
-	yCoord = yCoord - 70
 	controls.checkBoxes.enableFormSwitching = CreateFrame("CheckButton", "TwintopResourceBar_Druid_Guardian_Checkbox_FormSwitching", parent, "ChatConfigCheckButtonTemplate")
 	f = controls.checkBoxes.enableFormSwitching
 	f:SetPoint("TOPLEFT", oUi.xCoord, yCoord)
@@ -2674,6 +2674,9 @@ local function GuardianConstructBarVisibilityPanel(parent)
 			TRB.Data.cache.values.frame = {}
 		end
 	end)
+
+	yCoord = yCoord - 30
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 11, 3, yCoord, L["ResourceRage"], "guardian", true, L["ResourceComboPoints"], true)
 end
 
 local function GuardianConstructThresholdPanel(parent)
@@ -3119,9 +3122,6 @@ local function RestorationConstructBarVisibilityPanel(parent)
 	local yCoord = 5
 	local f = nil
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 11, 4, yCoord, L["ResourceMana"], "notFull", false, nil, nil, true, L["ResourceComboPoints"], true)
-
-	yCoord = yCoord - 70
 	controls.checkBoxes.enableFormSwitching = CreateFrame("CheckButton", "TwintopResourceBar_Druid_Restoration_Checkbox_FormSwitching", parent, "ChatConfigCheckButtonTemplate")
 	f = controls.checkBoxes.enableFormSwitching
 	f:SetPoint("TOPLEFT", oUi.xCoord, yCoord)
@@ -3181,6 +3181,9 @@ local function RestorationConstructBarVisibilityPanel(parent)
 			TRB.Data.cache.values.frame = {}
 		end
 	end)
+
+	yCoord = yCoord - 30
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 11, 4, yCoord, L["ResourceMana"], "notFull", true, L["ResourceComboPoints"], true)
 end
 
 local function RestorationConstructThresholdPanel(parent)

--- a/ClassModules/Options/EvokerOptions.lua
+++ b/ClassModules/Options/EvokerOptions.lua
@@ -902,7 +902,7 @@ local function DevastationConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.evoker_devastation
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 13, 1, yCoord, L["ResourceMana"], "notFull", false, nil, nil, true, L["ResourceEssence"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 13, 1, yCoord, L["ResourceMana"], "notFull", true, L["ResourceEssence"], true)
 end
 
 local function DevastationConstructFontAndTextPanel(parent)
@@ -1290,7 +1290,7 @@ local function PreservationConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.evoker_preservation
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 13, 2, yCoord, L["ResourceMana"], "notFull", false, nil, nil, true, L["ResourceEssence"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 13, 2, yCoord, L["ResourceMana"], "notFull", true, L["ResourceEssence"], true)
 end
 
 local function PreservationConstructThresholdPanel(parent)
@@ -1746,7 +1746,7 @@ local function AugmentationConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.evoker_augmentation
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 13, 3, yCoord, L["ResourceMana"], "notFull", false, nil, nil, true, L["ResourceEssence"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 13, 3, yCoord, L["ResourceMana"], "notFull", true, L["ResourceEssence"], true)
 end
 
 local function AugmentationConstructFontAndTextPanel(parent)

--- a/ClassModules/Options/EvokerOptions.lua
+++ b/ClassModules/Options/EvokerOptions.lua
@@ -196,9 +196,9 @@ local function DevastationLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		endOf = {
 			dragonrage = TRB.Functions.Settings:DefaultEndOfSettings("gcd", 2, 3.0)
@@ -333,9 +333,9 @@ local function PreservationLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		comboPoints = TRB.Functions.Settings:DefaultComboPointsDimensions(classic),
@@ -501,9 +501,9 @@ local function AugmentationLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		comboPoints = TRB.Functions.Settings:DefaultComboPointsDimensions(classic),

--- a/ClassModules/Options/HunterOptions.lua
+++ b/ClassModules/Options/HunterOptions.lua
@@ -755,6 +755,9 @@ local function BeastMasteryConstructFocusBarPanel(parent)
 
 	yCoord = yCoord - 40
 	yCoord = TRB.Functions.OptionsUi:GenerateMaxResourceOptions(parent, controls, spec, 3, 1, yCoord, L["ResourceFocus"], 1, BEAST_MASTERY_MAX_FOCUS)
+
+	yCoord = yCoord - 40
+	yCoord = TRB.Functions.OptionsUi:GenerateFlashOptions(parent, controls, spec, 3, 1, yCoord, L["HunterBeastMasteryBestialWrath"], L["HunterBeastMasteryBestialWrath"])
 end
 
 local function BeastMasteryConstructHealthBarPanel(parent)
@@ -800,7 +803,7 @@ local function BeastMasteryConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.hunter_beastMastery
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 3, 1, yCoord, L["ResourceFocus"], "notFull", true, L["HunterBeastMasteryBestialWrath"], L["HunterBeastMasteryBestialWrath"], false, nil, true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 3, 1, yCoord, L["ResourceFocus"], "notFull", false, nil, true)
 end
 
 local function BeastMasteryConstructThresholdPanel(parent)
@@ -1306,7 +1309,7 @@ local function MarksmanshipConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.hunter_marksmanship
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 3, 2, yCoord, L["ResourceFocus"], "notFull", false, nil, nil, false, nil, true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 3, 2, yCoord, L["ResourceFocus"], "notFull", false, nil, true)
 end
 
 local function MarksmanshipConstructThresholdPanel(parent)
@@ -1933,7 +1936,7 @@ local function SurvivalConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.hunter_survival
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 3, 3, yCoord, L["ResourceFocus"], "notFull", false, nil, nil, true, L["ResourceTipOfTheSpear"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 3, 3, yCoord, L["ResourceFocus"], "notFull", true, L["ResourceTipOfTheSpear"], true)
 end
 
 local function SurvivalConstructThresholdPanel(parent)

--- a/ClassModules/Options/HunterOptions.lua
+++ b/ClassModules/Options/HunterOptions.lua
@@ -83,9 +83,9 @@ local function BeastMasteryLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		endOf = {
 			bestialWrath = TRB.Functions.Settings:DefaultEndOfSettings("gcd", 2, 3.0),
@@ -270,9 +270,9 @@ local function MarksmanshipLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		endOf = {
 			trueshot = TRB.Functions.Settings:DefaultEndOfSettings("gcd", 2, 3.0),
@@ -442,9 +442,9 @@ local function SurvivalLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		endOf = {
 			takedown = TRB.Functions.Settings:DefaultEndOfSettings("gcd", 2, 3.0),

--- a/ClassModules/Options/MageOptions.lua
+++ b/ClassModules/Options/MageOptions.lua
@@ -583,7 +583,7 @@ local function ArcaneConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.mage_arcane
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 8, 1, yCoord, L["ResourceMana"], "notFull", false, nil, nil, true, L["ResourceArcaneCharges"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 8, 1, yCoord, L["ResourceMana"], "notFull", true, L["ResourceArcaneCharges"], true)
 end
 
 local function ArcaneConstructFontAndTextPanel(parent)
@@ -902,7 +902,7 @@ local function FireConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.mage_fire
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 8, 2, yCoord, L["ResourceMana"], "notFull", false, nil, nil, false, nil, true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 8, 2, yCoord, L["ResourceMana"], "notFull", false, nil, true)
 end
 
 local function FireConstructFontAndTextPanel(parent)
@@ -1256,7 +1256,7 @@ local function FrostConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.mage_frost
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 8, 3, yCoord, L["ResourceMana"], "notFull", false, nil, nil, true, L["ResourceIcicles"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 8, 3, yCoord, L["ResourceMana"], "notFull", true, L["ResourceIcicles"], true)
 end
 
 local function FrostConstructFontAndTextPanel(parent)

--- a/ClassModules/Options/MageOptions.lua
+++ b/ClassModules/Options/MageOptions.lua
@@ -40,9 +40,9 @@ local function ArcaneLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		comboPoints = TRB.Functions.Settings:DefaultComboPointsDimensions(classic),
@@ -165,9 +165,9 @@ local function FireLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		healthBar = TRB.Functions.Settings:DefaultHealthDimensions(classic),
@@ -252,9 +252,9 @@ local function FrostLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		comboPoints = TRB.Functions.Settings:DefaultComboPointsDimensions(classic),

--- a/ClassModules/Options/MonkOptions.lua
+++ b/ClassModules/Options/MonkOptions.lua
@@ -860,7 +860,7 @@ local function BrewmasterConstructBarVisibilityPanel(parent)
 		table.insert(customBars, staggerBarDef)
 	end
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 10, 1, yCoord, L["ResourceEnergy"], nil, false, nil, nil, false, nil, true, nil, customBars)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 10, 1, yCoord, L["ResourceEnergy"], nil, false, nil, true, nil, customBars)
 end
 
 local function BrewmasterConstructThresholdPanel(parent)
@@ -1446,7 +1446,7 @@ local function MistweaverConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.monk_mistweaver
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 10, 2, yCoord, L["ResourceMana"], "notFull", false, nil, nil, false, nil, true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 10, 2, yCoord, L["ResourceMana"], "notFull", false, nil, true)
 end
 
 local function MistweaverConstructThresholdPanel(parent)
@@ -1883,7 +1883,7 @@ local function WindwalkerConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.monk_windwalker
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 10, 3, yCoord, L["ResourceEnergy"], "notFull", false, nil, nil, true, L["ResourceChi"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 10, 3, yCoord, L["ResourceEnergy"], "notFull", true, L["ResourceChi"], true)
 end
 
 local function WindwalkerConstructThresholdPanel(parent)

--- a/ClassModules/Options/MonkOptions.lua
+++ b/ClassModules/Options/MonkOptions.lua
@@ -146,9 +146,9 @@ local function BrewmasterLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			stagger = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			stagger = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		endOf = {
 			invokeNiuzao = TRB.Functions.Settings:DefaultEndOfSettings("gcd", 2, 3.0)
@@ -296,9 +296,9 @@ local function MistweaverLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		healthBar = TRB.Functions.Settings:DefaultHealthDimensions(classic),
@@ -437,9 +437,9 @@ local function WindwalkerLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",

--- a/ClassModules/Options/PaladinOptions.lua
+++ b/ClassModules/Options/PaladinOptions.lua
@@ -712,7 +712,7 @@ local function HolyConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.paladin_holy
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 2, 1, yCoord, L["ResourceMana"], "notFull", false, nil, nil, true, L["ResourceHolyPower"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 2, 1, yCoord, L["ResourceMana"], "notFull", true, L["ResourceHolyPower"], true)
 end
 
 local function HolyConstructThresholdPanel(parent)
@@ -1144,7 +1144,7 @@ local function ProtectionConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.paladin_protection
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 2, 2, yCoord, L["ResourceMana"], "notFull", false, nil, nil, true, L["ResourceHolyPower"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 2, 2, yCoord, L["ResourceMana"], "notFull", true, L["ResourceHolyPower"], true)
 end
 
 local function ProtectionConstructThresholdPanel(parent)
@@ -1573,7 +1573,7 @@ local function RetributionConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.paladin_retribution
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 2, 3, yCoord, L["ResourceMana"], "notFull", false, nil, nil, true, L["ResourceHolyPower"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 2, 3, yCoord, L["ResourceMana"], "notFull", true, L["ResourceHolyPower"], true)
 end
 
 local function RetributionConstructThresholdPanel(parent)

--- a/ClassModules/Options/PaladinOptions.lua
+++ b/ClassModules/Options/PaladinOptions.lua
@@ -40,9 +40,9 @@ local function HolyLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		comboPoints = TRB.Functions.Settings:DefaultComboPointsDimensions(classic),
@@ -188,9 +188,9 @@ local function ProtectionLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		comboPoints = TRB.Functions.Settings:DefaultComboPointsDimensions(classic),
@@ -325,9 +325,9 @@ local function RetributionLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		comboPoints = TRB.Functions.Settings:DefaultComboPointsDimensions(classic),

--- a/ClassModules/Options/PriestOptions.lua
+++ b/ClassModules/Options/PriestOptions.lua
@@ -1177,7 +1177,7 @@ local function DisciplineConstructBarVisibilityPanel(parent)
 		table.insert(customBars, utilityBarDef)
 	end
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 5, 1, yCoord, L["ResourceMana"], "notFull", false, nil, nil, true, L["PriestDisciplinePowerWords"], true, nil, customBars)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 5, 1, yCoord, L["ResourceMana"], "notFull", true, L["PriestDisciplinePowerWords"], true, nil, customBars)
 end
 
 local function DisciplineConstructThresholdPanel(parent)
@@ -1660,7 +1660,7 @@ local function HolyConstructBarVisibilityPanel(parent)
 		table.insert(customBars, utilityBarDef)
 	end
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 5, 2, yCoord, L["ResourceMana"], "notFull", false, nil, nil, true, L["PriestHolyHolyWords"], true, nil, customBars)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 5, 2, yCoord, L["ResourceMana"], "notFull", true, L["PriestHolyHolyWords"], true, nil, customBars)
 end
 
 local function HolyConstructHolyWordsPanel(parent)
@@ -2223,6 +2223,9 @@ local function ShadowConstructInsanityBarPanel(parent)
 
 	yCoord = yCoord - 40
 	yCoord = TRB.Functions.OptionsUi:GenerateMaxResourceOptions(parent, controls, spec, 5, 3, yCoord, L["ResourceInsanity"], 1, SHADOW_MAX_INSANITY)
+
+	yCoord = yCoord - 40
+	yCoord = TRB.Functions.OptionsUi:GenerateFlashOptions(parent, controls, spec, 5, 3, yCoord, L["PriestShadowShadowWordMadness"], L["PriestShadowShadowWordMadnessAbbreviation"])
 end
 
 local function ShadowConstructManaBarPanel(parent)
@@ -2290,7 +2293,7 @@ local function ShadowConstructBarVisibilityPanel(parent)
 		table.insert(customBars, utilityBarDef)
 	end
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 5, 3, yCoord, L["ResourceInsanity"], "notEmpty", true, L["PriestShadowShadowWordMadness"], L["PriestShadowShadowWordMadnessAbbreviation"], false, nil, true, true, customBars)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 5, 3, yCoord, L["ResourceInsanity"], "notEmpty", false, nil, true, true, customBars)
 end
 
 local function ShadowConstructThresholdPanel(parent)

--- a/ClassModules/Options/PriestOptions.lua
+++ b/ClassModules/Options/PriestOptions.lua
@@ -207,10 +207,10 @@ local function DisciplineLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			utility = { neverShow = true, alwaysShow = false, conditions = {}, smooth = false },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			utility = { neverShow = true, alwaysShow = false, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		comboPoints = TRB.Functions.Settings:DefaultComboPointsDimensions(classic),
@@ -483,10 +483,10 @@ local function HolyLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			utility = { neverShow = true, alwaysShow = false, conditions = {}, smooth = false },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			utility = { neverShow = true, alwaysShow = false, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		comboPoints = TRB.Functions.Settings:DefaultComboPointsDimensions(classic),
@@ -703,11 +703,11 @@ local function ShadowLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			mana = { neverShow = true, alwaysShow = false, conditions = {}, smooth = true },
-			utility = { neverShow = true, alwaysShow = false, conditions = {}, smooth = false },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			mana = { neverShow = true, alwaysShow = false, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			utility = { neverShow = true, alwaysShow = false, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",

--- a/ClassModules/Options/RogueOptions.lua
+++ b/ClassModules/Options/RogueOptions.lua
@@ -1094,7 +1094,7 @@ local function AssassinationConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.rogue_assassination
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 4, 1, yCoord, L["ResourceEnergy"], "notFull", false, nil, nil, true, L["ResourceComboPoints"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 4, 1, yCoord, L["ResourceEnergy"], "notFull", true, L["ResourceComboPoints"], true)
 end
 
 local function AssassinationConstructThresholdPanel(parent)
@@ -1867,7 +1867,7 @@ local function OutlawConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.rogue_outlaw
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 4, 2, yCoord, L["ResourceEnergy"], "notFull", false, nil, nil, true, L["ResourceComboPoints"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 4, 2, yCoord, L["ResourceEnergy"], "notFull", true, L["ResourceComboPoints"], true)
 end
 
 local function OutlawConstructThresholdPanel(parent)
@@ -2640,7 +2640,7 @@ local function SubtletyConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.rogue_subtlety
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 4, 3, yCoord, L["ResourceEnergy"], "notFull", false, nil, nil, true, L["ResourceComboPoints"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 4, 3, yCoord, L["ResourceEnergy"], "notFull", true, L["ResourceComboPoints"], true)
 end
 
 local function SubtletyConstructThresholdPanel(parent)

--- a/ClassModules/Options/RogueOptions.lua
+++ b/ClassModules/Options/RogueOptions.lua
@@ -118,9 +118,9 @@ local function AssassinationLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",
@@ -371,9 +371,9 @@ local function OutlawLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",
@@ -641,9 +641,9 @@ local function SubtletyLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",

--- a/ClassModules/Options/ShamanOptions.lua
+++ b/ClassModules/Options/ShamanOptions.lua
@@ -74,10 +74,10 @@ local function ElementalLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			mana = { neverShow = true, alwaysShow = false, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			mana = { neverShow = true, alwaysShow = false, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		endOf = {
 			ascendance = TRB.Functions.Settings:DefaultEndOfSettings("gcd", 2, 3.0)
@@ -228,9 +228,9 @@ local function EnhancementLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		healthBar = TRB.Functions.Settings:DefaultHealthDimensions(classic),
@@ -383,9 +383,9 @@ local function RestorationLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		healthBar = TRB.Functions.Settings:DefaultHealthDimensions(classic),

--- a/ClassModules/Options/ShamanOptions.lua
+++ b/ClassModules/Options/ShamanOptions.lua
@@ -656,6 +656,9 @@ local function ElementalConstructMaelstromBarPanel(parent)
 
 	yCoord = yCoord - 40
 	yCoord = TRB.Functions.OptionsUi:GenerateMaxResourceOptions(parent, controls, spec, 7, 1, yCoord, L["ResourceMaelstrom"], 1, ELEMENTAL_MAX_MAELSTROM)
+
+	yCoord = yCoord - 40
+	yCoord = TRB.Functions.OptionsUi:GenerateFlashOptions(parent, controls, spec, 7, 1, yCoord, L["ShamanElementalEarthShockElementalBlast"], L["ShamanElementalEarthShockElementalBlastAbbreviation"])
 end
 
 local function ElementalConstructManaBarPanel(parent)
@@ -713,7 +716,7 @@ local function ElementalConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.shaman_elemental
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 7, 1, yCoord, L["ResourceMaelstrom"], "notEmpty", true, L["ShamanElementalEarthShockElementalBlast"], L["ShamanElementalEarthShockElementalBlastAbbreviation"], false, nil, true, true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 7, 1, yCoord, L["ResourceMaelstrom"], "notEmpty", false, nil, true, true)
 end
 
 local function ElementalConstructThresholdPanel(parent)
@@ -1241,7 +1244,7 @@ local function EnhancementConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.shaman_enhancement
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 7, 2, yCoord, L["ResourceMana"], "notFull", false, nil, nil, true, L["ResourceMaelstromWeapon"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 7, 2, yCoord, L["ResourceMana"], "notFull", true, L["ResourceMaelstromWeapon"], true)
 end
 
 local function EnhancementConstructFontAndTextPanel(parent)
@@ -1591,7 +1594,7 @@ local function RestorationConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.shaman_restoration
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 7, 3, yCoord, L["ResourceMana"], "notFull", false, nil, nil, false, nil, true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 7, 3, yCoord, L["ResourceMana"], "notFull", false, nil, true)
 end
 
 local function RestorationConstructThresholdPanel(parent)

--- a/ClassModules/Options/WarlockOptions.lua
+++ b/ClassModules/Options/WarlockOptions.lua
@@ -657,7 +657,7 @@ local function AfflictionConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.warlock_affliction
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 9, 1, yCoord, L["ResourceMana"], "notFull", false, nil, nil, true, L["ResourceSoulShards"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 9, 1, yCoord, L["ResourceMana"], "notFull", true, L["ResourceSoulShards"], true)
 end
 
 local function AfflictionConstructFontAndTextPanel(parent)
@@ -965,7 +965,7 @@ local function DemonologyConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.warlock_demonology
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 9, 2, yCoord, L["ResourceMana"], "notFull", false, nil, nil, true, L["ResourceSoulShards"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 9, 2, yCoord, L["ResourceMana"], "notFull", true, L["ResourceSoulShards"], true)
 end
 
 local function DemonologyConstructFontAndTextPanel(parent)
@@ -1458,7 +1458,7 @@ local function DestructionConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.warlock_destruction
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 9, 3, yCoord, L["ResourceMana"], "notFull", false, nil, nil, true, L["ResourceSoulShards"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 9, 3, yCoord, L["ResourceMana"], "notFull", true, L["ResourceSoulShards"], true)
 end
 
 local function DestructionConstructFontAndTextPanel(parent)

--- a/ClassModules/Options/WarlockOptions.lua
+++ b/ClassModules/Options/WarlockOptions.lua
@@ -36,9 +36,9 @@ local function AfflictionLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		healthBar = TRB.Functions.Settings:DefaultHealthDimensions(classic),
@@ -160,9 +160,9 @@ local function DemonologyLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		healthBar = TRB.Functions.Settings:DefaultHealthDimensions(classic),
@@ -284,9 +284,9 @@ local function DestructionLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		healthBar = TRB.Functions.Settings:DefaultHealthDimensions(classic),

--- a/ClassModules/Options/WarriorOptions.lua
+++ b/ClassModules/Options/WarriorOptions.lua
@@ -95,9 +95,9 @@ local function ArmsLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",
@@ -364,9 +364,9 @@ local function FuryLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",
@@ -627,10 +627,10 @@ local function ProtectionLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
-			defensives = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			defensives = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",

--- a/ClassModules/Options/WarriorOptions.lua
+++ b/ClassModules/Options/WarriorOptions.lua
@@ -935,7 +935,7 @@ local function ArmsConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.warrior_arms
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 1, 1, yCoord, L["ResourceRage"], "notEmpty", false, nil, nil, false, nil, true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 1, 1, yCoord, L["ResourceRage"], "notEmpty", false, nil, true)
 end
 
 local function ArmsConstructThresholdPanel(parent)
@@ -1533,7 +1533,7 @@ local function FuryConstructBarVisibilityPanel(parent)
 	local controls = interfaceSettingsFrame.controls.warrior_fury
 	local yCoord = 5
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 1, 2, yCoord, L["ResourceRage"], "notEmpty", false, nil, nil, true, L["ResourceWarriorWhirlwind"], true)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 1, 2, yCoord, L["ResourceRage"], "notEmpty", true, L["ResourceWarriorWhirlwind"], true)
 end
 
 local function FuryConstructThresholdPanel(parent)
@@ -2028,7 +2028,7 @@ local function ProtectionConstructBarVisibilityPanel(parent)
 		table.insert(customBars, defensivesBarDef)
 	end
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, 1, 3, yCoord, L["ResourceRage"], "notEmpty", false, nil, nil, false, nil, true, nil, customBars)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, 1, 3, yCoord, L["ResourceRage"], "notEmpty", false, nil, true, nil, customBars)
 end
 
 local function ProtectionConstructThresholdPanel(parent)

--- a/ClassModules/Paladin.lua
+++ b/ClassModules/Paladin.lua
@@ -732,7 +732,7 @@ local function UpdateResourceBar()
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
@@ -776,7 +776,7 @@ local function UpdateResourceBar()
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
@@ -820,7 +820,7 @@ local function UpdateResourceBar()
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 

--- a/ClassModules/Priest.lua
+++ b/ClassModules/Priest.lua
@@ -1597,7 +1597,7 @@ local function UpdateResourceBar()
 				
 				local barColor = specSettings.colors.bar.base.color
 
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
@@ -1791,7 +1791,7 @@ local function UpdateResourceBar()
 					barColor = specSettings.colors.bar.base.color
 				end
 
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
@@ -2066,9 +2066,9 @@ local function UpdateResourceBar()
 
 				if spells.shadowWordMadness:IsFree() or spells.shadowWordMadness:IsUsable() then
 					if specSettings.colors.bar.flashEnabled then
-						Bar:PulseFrame(barGroups.primary:GetContainerFrame(), specSettings.colors.bar.flashAlpha, specSettings.colors.bar.flashPeriod)
+						Bar:PulseFrame(barGroups.primary:GetContainerFrame(), specSettings.colors.bar.flashAlpha, specSettings.colors.bar.flashPeriod, barGroups.primary.currentAlpha)
 					else
-						barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+						barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 					end
 
 					if spells.shadowWordMadness:IsFree() and specSettings.audio.mdProc.enabled and snapshotData.audio.playedMdCue == false then
@@ -2080,7 +2080,7 @@ local function UpdateResourceBar()
 						PlaySoundFile(specSettings.audio.dpReady.sound, coreSettings.audio.channel.channel)
 					end
 				else
-					barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+					barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 					snapshotData.audio.playedDpCue = false
 					snapshotData.audio.playedMdCue = false
 				end

--- a/ClassModules/Rogue.lua
+++ b/ClassModules/Rogue.lua
@@ -1019,7 +1019,7 @@ local function UpdateResourceBar()
 				local barBorderColor = specSettings.colors.bar.border.color
 
 				if barGroups and barGroups.primary then
-					barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+					barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				end
 
 				if primaryNode then
@@ -1319,7 +1319,7 @@ local function UpdateResourceBar()
 				local barBorderColor = specSettings.colors.bar.border.color
 
 				if barGroups and barGroups.primary then
-					barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+					barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				end
 
 				if primaryNode then
@@ -1605,7 +1605,7 @@ local function UpdateResourceBar()
 				local barBorderColor = specSettings.colors.bar.border.color
 				
 				if barGroups and barGroups.primary then
-					barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+					barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				end
 
 				if primaryNode then

--- a/ClassModules/Shaman.lua
+++ b/ClassModules/Shaman.lua
@@ -829,9 +829,9 @@ local function UpdateResourceBar()
 				if anyUsable and specSettings.colors.bar.earthShock.enabled then
 					barColor = specSettings.colors.bar.earthShock.color
 					if specSettings.colors.bar.flashEnabled then
-						Bar:PulseFrame(barGroups.primary:GetContainerFrame(), specSettings.colors.bar.flashAlpha, specSettings.colors.bar.flashPeriod)
+						Bar:PulseFrame(barGroups.primary:GetContainerFrame(), specSettings.colors.bar.flashAlpha, specSettings.colors.bar.flashPeriod, barGroups.primary.currentAlpha)
 					else
-						barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+						barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 					end
 
 					if specSettings.audio.esReady.enabled and snapshotData.audio.playedEsCue == false then
@@ -839,7 +839,7 @@ local function UpdateResourceBar()
 						PlaySoundFile(specSettings.audio.esReady.sound, coreSettings.audio.channel.channel)
 					end
 				else
-					barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+					barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 					snapshotData.audio.playedEsCue = false
 				end
 
@@ -932,7 +932,7 @@ local function UpdateResourceBar()
 
 				Bar:SetBarNodePrimaryValue(specCacheSettings, "resource", primaryNode, currentResource)
 
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				
 				if snapshots[spells.ascendance.id].buff.isActive then
 					local timeLeft = snapshots[spells.ascendance.id].buff:GetRemainingTime(currentTime)

--- a/ClassModules/Warlock.lua
+++ b/ClassModules/Warlock.lua
@@ -740,7 +740,7 @@ local function UpdateResourceBar()
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
@@ -786,7 +786,7 @@ local function UpdateResourceBar()
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 
@@ -831,7 +831,7 @@ local function UpdateResourceBar()
 				primaryNode:SetBorderColor(barBorderColor)
 				primaryNode:SetColor(barColor)
 				primaryNode:SetBackgroundColorFromString(specSettings.colors.bar.background.color)
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				Bar:UpdateCastingResourceOverlay(primaryNode, snapshotData, specCacheSettings)
 			end
 

--- a/ClassModules/Warrior.lua
+++ b/ClassModules/Warrior.lua
@@ -1071,7 +1071,7 @@ local function UpdateResourceBar()
 				local barColor = specSettings.colors.bar.base.color
 				local barBorderColor = specSettings.colors.bar.border.color
 
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				-- Apply overcap border color if enabled
 				if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
 					local overcapBorderCurve = Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
@@ -1217,7 +1217,7 @@ local function UpdateResourceBar()
 
 				local barBorderColor = specSettings.colors.bar.border.color
 
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				-- Apply overcap border color if enabled
 				if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
 					local overcapBorderCurve = Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)
@@ -1359,7 +1359,7 @@ local function UpdateResourceBar()
 				local barColor = specSettings.colors.bar.base.color
 				local barBorderColor = specSettings.colors.bar.border.color
 
-				barGroups.primary:GetContainerFrame():SetAlpha(1.0)
+				barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 				-- Apply overcap border color if enabled
 				if specSettings.colors.bar.borderOvercap.enabled and affectingCombat then
 					local overcapBorderCurve = Color:BuildResourceThresholdCurve(specCacheSettings, barBorderColor, specSettings.colors.bar.borderOvercap.color)

--- a/Classes/Bar.lua
+++ b/Classes/Bar.lua
@@ -405,6 +405,7 @@ end
 ---@field public currentAlpha number # Current interpolated alpha (0.0–1.0)
 ---@field public lastAlphaTime number # GetTime() of last fade interpolation step
 ---@field public fadeDuration number # Seconds for fade transition (0 = instant)
+---@field public fadeStartAlpha number # Alpha at the moment a fade began (used for normalized progress)
 ---@field public fadeDelayUntil number # GetTime() timestamp when the fade delay expires (0 = no delay active)
 TRB.Classes.BarGroup = {}
 TRB.Classes.BarGroup.__index = TRB.Classes.BarGroup
@@ -433,6 +434,7 @@ function TRB.Classes.BarGroup:New(parent, name, maxNodes, isPrimary)
 	self.currentAlpha = 0
 	self.lastAlphaTime = GetTime()
 	self.fadeDuration = 0
+	self.fadeStartAlpha = 0
 	self.fadeDelayUntil = 0
 
 	-- Create container frame for the group
@@ -743,6 +745,7 @@ function TRB.Classes.BarGroup:SetTargetAlpha(target, duration, delay)
 	end
 	self.targetAlpha = target
 	self.fadeDuration = duration or 0
+	self.fadeStartAlpha = self.currentAlpha
 	local now = GetTime()
 	local fadeDelay = delay or 0
 	if fadeDelay > 0 then
@@ -785,18 +788,19 @@ function TRB.Classes.BarGroup:UpdateFade()
 	end
 
 	local elapsed = now - self.lastAlphaTime
-	self.lastAlphaTime = now
 
 	if elapsed <= 0 then
 		return self.currentAlpha, true
 	end
 
-	-- Linear interpolation: move toward target by (elapsed / duration) of the full range
-	local step = elapsed / duration
-	if self.currentAlpha < self.targetAlpha then
-		self.currentAlpha = math.min(self.currentAlpha + step, self.targetAlpha)
-	else
-		self.currentAlpha = math.max(self.currentAlpha - step, self.targetAlpha)
+	-- Normalized linear interpolation: progress is elapsed / duration over the
+	-- start→target range, so fadeDuration is always the total transition time
+	-- regardless of the alpha delta (e.g. 1.0→0.5 takes the same time as 1.0→0.0).
+	local progress = math.min(elapsed / duration, 1.0)
+	self.currentAlpha = self.fadeStartAlpha + (self.targetAlpha - self.fadeStartAlpha) * progress
+
+	if progress >= 1.0 then
+		self.currentAlpha = self.targetAlpha
 	end
 
 	return self.currentAlpha, (self.currentAlpha ~= self.targetAlpha)

--- a/Classes/Bar.lua
+++ b/Classes/Bar.lua
@@ -310,14 +310,8 @@ function TRB.Classes.BarNode:SetAlpha(alpha)
 	self.frame:SetAlpha(alpha)
 end
 
----Shows the node
+---Shows the node. Alpha is managed by the parent BarGroup's visibility/fade system.
 function TRB.Classes.BarNode:Show()
-	if TRB.Functions and TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
-		self.frame:SetAlpha(0)
-	else
-		self.frame:SetAlpha(1)
-	end
-
 	self.frame:Show()
 	self.isVisible = true
 end
@@ -407,6 +401,11 @@ end
 ---@field public orientation string
 ---@field public isVisible boolean
 ---@field public isPrimary boolean
+---@field public targetAlpha number # Target alpha from visibility system (0.0–1.0)
+---@field public currentAlpha number # Current interpolated alpha (0.0–1.0)
+---@field public lastAlphaTime number # GetTime() of last fade interpolation step
+---@field public fadeDuration number # Seconds for fade transition (0 = instant)
+---@field public fadeDelayUntil number # GetTime() timestamp when the fade delay expires (0 = no delay active)
 TRB.Classes.BarGroup = {}
 TRB.Classes.BarGroup.__index = TRB.Classes.BarGroup
 
@@ -430,6 +429,11 @@ function TRB.Classes.BarGroup:New(parent, name, maxNodes, isPrimary)
 	self.isVisible = false
 	self.isPrimary = isPrimary or false
 	self.smooth = nil
+	self.targetAlpha = 0
+	self.currentAlpha = 0
+	self.lastAlphaTime = GetTime()
+	self.fadeDuration = 0
+	self.fadeDelayUntil = 0
 
 	-- Create container frame for the group
 	local containerName = self.name
@@ -717,22 +721,85 @@ function TRB.Classes.BarGroup:HideAllNodes()
 	end
 end
 
----Shows the group container
+---Shows the group container. Alpha is managed by the visibility/fade system, not here.
 function TRB.Classes.BarGroup:Show()
-	if TRB.Functions and TRB.Functions.Bar and TRB.Functions.Bar.IsRenderTransitionActive and TRB.Functions.Bar:IsRenderTransitionActive() then
-		self.containerFrame:SetAlpha(0)
-	else
-		self.containerFrame:SetAlpha(1)
-	end
-
 	self.containerFrame:Show()
 	self.isVisible = true
 end
 
----Hides the group container
+---Hides the group container (fully hidden, alpha irrelevant)
 function TRB.Classes.BarGroup:Hide()
 	self.containerFrame:Hide()
 	self.isVisible = false
+end
+
+---Sets the target alpha and fade duration for the visibility fade system.
+---@param target number # Target alpha (0.0–1.0)
+---@param duration number # Seconds for the fade transition (0 = instant snap)
+---@param delay number? # Seconds to wait before starting the fade (default 0)
+function TRB.Classes.BarGroup:SetTargetAlpha(target, duration, delay)
+	if self.targetAlpha == target then
+		return
+	end
+	self.targetAlpha = target
+	self.fadeDuration = duration or 0
+	local now = GetTime()
+	local fadeDelay = delay or 0
+	if fadeDelay > 0 then
+		self.fadeDelayUntil = now + fadeDelay
+	else
+		self.fadeDelayUntil = 0
+	end
+	self.lastAlphaTime = now
+end
+
+---Interpolates currentAlpha toward targetAlpha based on elapsed time.
+---Respects fadeDelayUntil: while the current time is before that timestamp,
+---the fade has not yet started but we report as still fading (in-progress).
+---@return number currentAlpha # The current interpolated alpha
+---@return boolean fading # true if the fade is still in progress
+function TRB.Classes.BarGroup:UpdateFade()
+	if self.currentAlpha == self.targetAlpha then
+		return self.currentAlpha, false
+	end
+
+	local now = GetTime()
+
+	-- Respect fade delay: don't start fading until delay expires
+	if self.fadeDelayUntil > 0 and now < self.fadeDelayUntil then
+		self.lastAlphaTime = now
+		return self.currentAlpha, true -- still "fading" (waiting)
+	end
+	-- Clear the delay once expired
+	if self.fadeDelayUntil > 0 then
+		self.fadeDelayUntil = 0
+	end
+
+	local duration = self.fadeDuration or 0
+
+	if duration <= 0 then
+		-- Instant snap
+		self.currentAlpha = self.targetAlpha
+		self.lastAlphaTime = now
+		return self.currentAlpha, false
+	end
+
+	local elapsed = now - self.lastAlphaTime
+	self.lastAlphaTime = now
+
+	if elapsed <= 0 then
+		return self.currentAlpha, true
+	end
+
+	-- Linear interpolation: move toward target by (elapsed / duration) of the full range
+	local step = elapsed / duration
+	if self.currentAlpha < self.targetAlpha then
+		self.currentAlpha = math.min(self.currentAlpha + step, self.targetAlpha)
+	else
+		self.currentAlpha = math.max(self.currentAlpha - step, self.targetAlpha)
+	end
+
+	return self.currentAlpha, (self.currentAlpha ~= self.targetAlpha)
 end
 
 ---Destroys the group and all its nodes

--- a/Classes/BarVisibility.lua
+++ b/Classes/BarVisibility.lua
@@ -152,6 +152,8 @@ TRB.Functions.BarVisibility = {}
 -- We skip re-evaluation unless an input has changed (MarkDirty was called).
 TRB.Functions.BarVisibility.dirtyToken = 0
 TRB.Functions.BarVisibility.lastAppliedToken = -1
+-- When true, at least one bar is mid-fade and needs per-tick interpolation.
+TRB.Functions.BarVisibility.fading = false
 
 ---Marks visibility state as dirty, forcing the next ProcessBars call to re-evaluate.
 ---Call this whenever any input to visibility evaluation changes:
@@ -168,6 +170,9 @@ end
 ---@return boolean
 function TRB.Functions.BarVisibility:IsDirty(force)
 	if force then
+		return true
+	end
+	if self.fading then
 		return true
 	end
 	return self.dirtyToken ~= self.lastAppliedToken
@@ -283,6 +288,7 @@ function TRB.Functions.BarVisibility:ShouldShowBar(context, entry)
 end
 
 ---Evaluates and applies visibility for all bar entries. Sets isTracking and controls BarText.
+---Uses alpha-based visibility with fade interpolation instead of binary Show/Hide.
 ---@param context TRB.Classes.BarVisibilityContext # The shared environment snapshot
 ---@param entries TRB.Classes.BarVisibilityEntry[] # Array of bar entries to process
 ---@param snapshotData TRB.Classes.SnapshotData # The snapshot data to update isTracking on
@@ -290,34 +296,77 @@ end
 ---@return boolean # Whether any bar is showing (isTracking value)
 function TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData, settings)
 	local anyShowing = false
+	local anyFading = false
+	local conditionsChanged = (self.dirtyToken ~= self.lastAppliedToken) or context.force
+	local isRenderTransition = TRB.Functions.Bar:IsRenderTransitionActive()
 
 	for _, entry in ipairs(entries) do
 		if entry.barGroup ~= nil then
-			local show = self:ShouldShowBar(context, entry)
-			if show then
+			-- Phase 1: Evaluate conditions and compute target alpha (only when conditions changed)
+			if conditionsChanged then
+				local show = self:ShouldShowBar(context, entry)
+				local visSettings = entry.visibilitySettings
+				local targetAlpha, fadeDuration
+
+				local fadeDelay = 0
+
+				if show then
+					-- Becoming active: snap instantly (no fade-in)
+					targetAlpha = (visSettings and visSettings.activeAlpha or 100) / 100
+					fadeDuration = 0
+				else
+					-- Becoming inactive: use configured fade duration and delay (fade-out only)
+					targetAlpha = (visSettings and visSettings.inactiveAlpha or 0) / 100
+					fadeDuration = visSettings and visSettings.fadeDuration or 0
+					fadeDelay = visSettings and visSettings.fadeDelay or 0
+				end
+
+				-- During render transitions, snap to 0 instantly (no fade)
+				if isRenderTransition then
+					targetAlpha = 0
+					fadeDuration = 0
+					fadeDelay = 0
+				end
+
+				entry.barGroup:SetTargetAlpha(targetAlpha, fadeDuration, fadeDelay)
+			end
+
+			-- Phase 2: Interpolate fade (runs every tick while fading)
+			local currentAlpha, stillFading = entry.barGroup:UpdateFade()
+			if stillFading then
+				anyFading = true
+			end
+
+			-- Phase 3: Apply alpha and show/hide based on current alpha
+			if currentAlpha > 0 then
 				anyShowing = true
-				if entry.setMaxNodes then
-					entry.barGroup:SetMaxNodes(entry.setMaxNodes)
+				if not entry.barGroup.isVisible then
+					if entry.setMaxNodes then
+						entry.barGroup:SetMaxNodes(entry.setMaxNodes)
+					end
+					entry.barGroup:Show()
+					if entry.showNodesCount then
+						entry.barGroup:ShowNodes(entry.showNodesCount)
+					end
 				end
-				entry.barGroup:Show()
-				if entry.showNodesCount then
-					entry.barGroup:ShowNodes(entry.showNodesCount)
-				end
+				entry.barGroup.containerFrame:SetAlpha(currentAlpha)
 			else
-				entry.barGroup:Hide()
+				if entry.barGroup.isVisible then
+					entry.barGroup:Hide()
+				end
 			end
 		end
 	end
 
+	self.fading = anyFading
+
 	-- Collapse/expand container frames based on resolved visibility.
 	-- Hidden bars' containers are shrunk to 0.001 so that bars anchored to them
-	-- slide together (no blank gap). Visible bars are expanded back to their
-	-- layout height (stored during ConstructAnchoredBarGroup / ApplyLayout).
-	-- This runs AFTER Show/Hide so it reflects the correct runtime state,
-	-- including Druid form-based visibility which isn't known at construction time.
+	-- slide together (no blank gap). Visible bars (including inactive-alpha bars
+	-- with alpha > 0) are expanded back to their layout height.
 	for _, entry in ipairs(entries) do
 		if entry.barGroup ~= nil and entry.barGroup.containerFrame then
-			if entry.barGroup.isVisible then
+			if entry.barGroup.currentAlpha > 0 then
 				if entry.barGroup.layoutHeight and entry.barGroup.layoutHeight > 0 then
 					entry.barGroup.containerFrame:SetHeight(entry.barGroup.layoutHeight)
 				end
@@ -329,17 +378,7 @@ function TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData,
 
 	-- Detect hidden→visible transition: when the bar was not tracking but is now
 	-- showing, fully invalidate the lookup memoization cache so that every
-	-- variable is recomputed on the next RefreshLookupData pass.  A simple
-	-- lookupDirty = true is not enough: the prevLookupState cache may still
-	-- consider values "unchanged" (same raw value + color as before the bar was
-	-- hidden) and skip rewriting lookup strings, leaving stale formatted text.
-	-- InvalidateLookupMemoization wipes prevLookupState AND sets lookupDirty.
-	--
-	-- Additionally, set barTextVisibilityRefreshNeeded so that the NEXT call to
-	-- UpdateResourceBarText unconditionally processes all bar text entries.
-	-- This covers edge cases where lookupDirty alone is insufficient (e.g.,
-	-- options panel toggling visibility without a subsequent TriggerResourceBarUpdates
-	-- on the same frame, or lookupDirty being consumed during the hidden period).
+	-- variable is recomputed on the next RefreshLookupData pass.
 	local wasTracking = snapshotData.attributes.isTracking
 	snapshotData.attributes.isTracking = anyShowing
 	if anyShowing and not wasTracking then
@@ -353,7 +392,9 @@ function TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData,
 		TRB.Functions.BarText:Hide(settings)
 	end
 
-	self:MarkClean()
+	if conditionsChanged then
+		self:MarkClean()
+	end
 	return anyShowing
 end
 
@@ -365,6 +406,8 @@ function TRB.Functions.BarVisibility:HideAllEntries(entries, snapshotData, setti
 	if entries then
 		for _, entry in ipairs(entries) do
 			if entry.barGroup ~= nil then
+				entry.barGroup.targetAlpha = 0
+				entry.barGroup.currentAlpha = 0
 				entry.barGroup:Hide()
 				-- Collapse container so anchored children slide together
 				if entry.barGroup.containerFrame then
@@ -374,6 +417,7 @@ function TRB.Functions.BarVisibility:HideAllEntries(entries, snapshotData, setti
 		end
 	end
 
+	self.fading = false
 	snapshotData.attributes.isTracking = false
 	if settings ~= nil then
 		TRB.Functions.BarText:Hide(settings)
@@ -389,10 +433,13 @@ function TRB.Functions.BarVisibility:HideAllBarGroups(snapshotData)
 	if barGroups then
 		for _, group in pairs(barGroups) do
 			if type(group) == "table" and group.Hide then
+				group.targetAlpha = 0
+				group.currentAlpha = 0
 				group:Hide()
 			end
 		end
 	end
+	self.fading = false
 	snapshotData.attributes.isTracking = false
 
 	self:MarkClean()

--- a/Classes/Settings.lua
+++ b/Classes/Settings.lua
@@ -242,6 +242,10 @@ TRB.Classes.Settings = TRB.Classes.Settings or {}
 ---@field public alwaysShow boolean # When true, the bar is unconditionally shown (overrides conditions but not neverShow). Independent of individual conditions.
 ---@field public conditions trbBarVisibilityConditions # OR-combined conditions evaluated when alwaysShow is false
 ---@field public smooth boolean
+---@field public activeAlpha number # Opacity (0–100) when visibility conditions are met. Default 100.
+---@field public inactiveAlpha number # Opacity (0–100) when visibility conditions are NOT met. 0 = fully hidden. Default 0.
+---@field public fadeDuration number # Seconds to fade out to inactive opacity. 0 = instant. Default 0.
+---@field public fadeDelay number # Seconds to wait before starting the fade out. 0 = immediate. Default 0.
 ---@field public visibility trbBarVisibility? # DEPRECATED: Legacy field, migrated to neverShow+conditions
 
 ---@alias trbOverlayMode

--- a/Functions/Bar.lua
+++ b/Functions/Bar.lua
@@ -19,6 +19,11 @@ local function SetBarGroupsAlpha(alpha)
 	for _, group in pairs(barGroups) do
 		if type(group) == "table" and group.SetAlpha then
 			group:SetAlpha(alpha)
+			-- Sync fade state so the visibility system doesn't conflict
+			if group.currentAlpha ~= nil then
+				group.currentAlpha = alpha
+				group.targetAlpha = alpha
+			end
 		elseif type(group) == "table" and group.GetContainerFrame then
 			local container = group:GetContainerFrame()
 			if container and container.SetAlpha then
@@ -362,7 +367,8 @@ function TRB.Functions.Bar:HideResourceBar(force)
 	TRB.Functions.Class:HideResourceBar(force)
 end
 
-function TRB.Functions.Bar:PulseFrame(frame, alphaOffset, flashPeriod)
+function TRB.Functions.Bar:PulseFrame(frame, alphaOffset, flashPeriod, maxAlpha)
+	maxAlpha = maxAlpha or 1.0
 	if alphaOffset > 1.0 then
 		alphaOffset = 1.0
 	elseif alphaOffset < 0 then
@@ -373,7 +379,7 @@ function TRB.Functions.Bar:PulseFrame(frame, alphaOffset, flashPeriod)
 		flashPeriod = 0.5
 	end
 	
-	frame:SetAlpha(((1.0 - alphaOffset) * math.abs(math.sin(2 * (GetTime() / flashPeriod)))) + alphaOffset)
+	frame:SetAlpha(maxAlpha * (((1.0 - alphaOffset) * math.abs(math.sin(2 * (GetTime() / flashPeriod)))) + alphaOffset))
 end
 
 function TRB.Functions.Bar:SetPositionXY(xOfs, yOfs)

--- a/Functions/BarText.lua
+++ b/Functions/BarText.lua
@@ -1510,7 +1510,19 @@ function TRB.Functions.BarText:TimerPrecision(value, positiveOnly)
 	end
 end
 
----Hides all bar text, except UIParent-bound ("Screen") entries which remain visible
+---Returns the primary bar group's current visibility alpha (0.0–1.0).
+---Used for UIParent-attached bar text that doesn't inherit barGroup alpha.
+---@return number
+function TRB.Functions.BarText:GetPrimaryBarAlpha()
+	local barGroups = TRB.Frames.barGroups
+	if barGroups and barGroups.primary and barGroups.primary.currentAlpha then
+		return barGroups.primary.currentAlpha
+	end
+	return 1.0
+end
+
+---Hides all bar text, except UIParent-bound ("Screen") entries which remain visible.
+---UIParent-bound text gets explicit alpha from the primary bar's current visibility alpha.
 ---@param settings TRB.Classes.Settings.SpecializationSettingsBase
 function TRB.Functions.BarText:Hide(settings)
 	local textFrames = TRB.Frames.textFrames
@@ -1526,6 +1538,9 @@ function TRB.Functions.BarText:Hide(settings)
 				textFrames[i]:Show()
 				---@diagnostic disable-next-line: undefined-field
 				textFrames[i].font:Show()
+				-- UIParent text doesn't inherit barGroup alpha; apply it explicitly
+				local barAlpha = TRB.Functions.BarText:GetPrimaryBarAlpha()
+				textFrames[i]:SetAlpha(barAlpha)
 			else
 				textFrames[i]:Hide()
 				---@diagnostic disable-next-line: undefined-field
@@ -1590,6 +1605,11 @@ function TRB.Functions.BarText:Show(settings)
 					textFrames[i]:Show()
 					---@diagnostic disable-next-line: undefined-field
 					textFrames[i].font:Show()
+					-- UIParent-attached text doesn't inherit barGroup alpha; apply explicitly
+					if key == "UIParent" then
+						local barAlpha = TRB.Functions.BarText:GetPrimaryBarAlpha()
+						textFrames[i]:SetAlpha(barAlpha)
+					end
 				end
 			elseif textFrames[i] ~= nil then
 				textFrames[i]:Hide()

--- a/Functions/Settings.lua
+++ b/Functions/Settings.lua
@@ -83,25 +83,41 @@ function TRB.Functions.Settings:LoadDefaultSettings(classic)
 					neverShow = false,
 					alwaysShow = true,
 					conditions = {},
-					smooth = true
+					smooth = true,
+					activeAlpha = 100,
+					inactiveAlpha = 0,
+					fadeDuration = 0,
+					fadeDelay = 0
 				},
 				secondary = {
 					neverShow = false,
 					alwaysShow = true,
 					conditions = {},
-					smooth = false
+					smooth = false,
+					activeAlpha = 100,
+					inactiveAlpha = 0,
+					fadeDuration = 0,
+					fadeDelay = 0
 				},
 				health = {
 					neverShow = false,
 					alwaysShow = true,
 					conditions = {},
-					smooth = true
+					smooth = true,
+					activeAlpha = 100,
+					inactiveAlpha = 0,
+					fadeDuration = 0,
+					fadeDelay = 0
 				},
 				utility = {
 					neverShow = true,
 					alwaysShow = false,
 					conditions = {},
-					smooth = true
+					smooth = true,
+					activeAlpha = 100,
+					inactiveAlpha = 0,
+					fadeDuration = 0,
+					fadeDelay = 0
 				},
 			},
 			overcap = {
@@ -4442,6 +4458,48 @@ function TRB.Functions.Settings:PortForwardSettings()
 				for specName, specSettings in pairs(TwintopInsanityBarSettings[className]) do
 					if specSettings and type(specSettings) == "table" and specSettings.displayBar then
 						MigrateRenamedConditions(specSettings.displayBar)
+					end
+				end
+			end
+		end
+	end
+
+	-- Phase 3a: Backfill activeAlpha, inactiveAlpha, and fadeDuration for existing settings.
+	-- Existing users get matching-current-behavior defaults: active=100%, inactive=0%, fade=0s (instant).
+	do
+		local function MigrateAlphaSettings(displayBar)
+			if displayBar == nil then
+				return
+			end
+			for _, entry in pairs(displayBar) do
+				if type(entry) == "table" and entry.conditions ~= nil then
+					if entry.activeAlpha == nil then
+						entry.activeAlpha = 100
+					end
+					if entry.inactiveAlpha == nil then
+						entry.inactiveAlpha = 0
+					end
+					if entry.fadeDuration == nil then
+						entry.fadeDuration = 0
+					end
+					if entry.fadeDelay == nil then
+						entry.fadeDelay = 0
+					end
+				end
+			end
+		end
+
+		-- Migrate core.displayBar
+		if TwintopInsanityBarSettings and TwintopInsanityBarSettings.core and TwintopInsanityBarSettings.core.displayBar then
+			MigrateAlphaSettings(TwintopInsanityBarSettings.core.displayBar)
+		end
+
+		-- Migrate all class/spec displayBar settings
+		for _, className in ipairs(classes) do
+			if TwintopInsanityBarSettings and TwintopInsanityBarSettings[className] then
+				for specName, specSettings in pairs(TwintopInsanityBarSettings[className]) do
+					if specSettings and type(specSettings) == "table" and specSettings.displayBar then
+						MigrateAlphaSettings(specSettings.displayBar)
 					end
 				end
 			end

--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -2153,3 +2153,13 @@ L["ShowBarVisibilityConditionInDelve"] = "In Delve"
 L["ShowBarVisibilityConditionInRaidGroup"] = "In Raid Group"
 L["ShowBarVisibilityConditionInDungeon"] = "In Dungeon"
 L["ShowBarVisibilityConditionInRaidInstance"] = "In Raid"
+
+-- Phase 3a: Alpha-based bar visibility
+L["ShowBarVisibilityActiveAlpha"] = "Active Opacity"
+L["ShowBarVisibilityActiveAlphaTooltip"] = "The opacity of the bar when visibility conditions are met. 100%% is fully opaque."
+L["ShowBarVisibilityInactiveAlpha"] = "Inactive Opacity"
+L["ShowBarVisibilityInactiveAlphaTooltip"] = "The opacity of the bar when visibility conditions are NOT met. Set above 0%% to keep the bar partially visible when inactive."
+L["ShowBarVisibilityFadeDuration"] = "Fade Duration"
+L["ShowBarVisibilityFadeDurationTooltip"] = "How long (in seconds) the bar takes to fade out to inactive opacity. Set to 0 for instant transitions."
+L["ShowBarVisibilityFadeDelay"] = "Fade Delay"
+L["ShowBarVisibilityFadeDelayTooltip"] = "How long (in seconds) to wait before the bar starts fading out to inactive opacity. Set to 0 to start fading immediately."

--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -102,7 +102,7 @@ L["BackgroundTextures"] = "Background Textures"
 L["TextureLock"] = "Use the same texture for all bars, borders, and backgrounds (respectively)"
 L["TextureLockTooltip"] = "This will lock the texture for each type of texture to be the same for all parts of the bar. E.g.: All bar textures will be the same, all border textures will be the same, and all background textures will be the same."
 
---- GenerateBarDisplayOptions
+--- GenerateFlashOptions / GenerateBarVisibilityOptions
 L["BarDisplayHeader"] = "Bar Display"
 L["FlashAlpha"] = "%s Flash Alpha"
 L["FlashPeriod"] = "%s Flash Period (sec)"
@@ -2163,3 +2163,13 @@ L["ShowBarVisibilityFadeDuration"] = "Fade Duration"
 L["ShowBarVisibilityFadeDurationTooltip"] = "How long (in seconds) the bar takes to fade out to inactive opacity. Set to 0 for instant transitions."
 L["ShowBarVisibilityFadeDelay"] = "Fade Delay"
 L["ShowBarVisibilityFadeDelayTooltip"] = "How long (in seconds) to wait before the bar starts fading out to inactive opacity. Set to 0 to start fading immediately."
+
+-- Bar Visibility Table UI
+L["BarVisibilityTableHeaderBar"] = "Bar"
+L["BarVisibilityTableHeaderVisibility"] = "Visibility"
+L["BarVisibilityBarNamePrimary"] = "%s Bar"
+L["BarVisibilityBarNameHealth"] = "Health Bar"
+L["BarVisibilityBarNameMana"] = "Mana Bar"
+L["BarVisibilityDetailHeader"] = "%s Settings"
+L["BarVisibilityConditionsLabel"] = "Visibility"
+L["FlashSectionHeader"] = "Bar Flash"

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -99,7 +99,7 @@ local function ConstructBarVisibilityPanel(parent)
 		table.insert(customBars, utilityBarDef)
 	end
 
-	yCoord = TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, nil, nil, yCoord, L["Resource"], "notFull", false, nil, nil, true, L["ResourceComboPoints"], true, nil, customBars)
+	yCoord = TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, nil, nil, yCoord, L["Resource"], "notFull", true, L["ResourceComboPoints"], true, nil, customBars)
 end
 
 local function ConstructThresholdPanel(parent)

--- a/Options/OptionsUi.lua
+++ b/Options/OptionsUi.lua
@@ -4447,11 +4447,55 @@ function TRB.Functions.OptionsUi:GenerateBarTexturesOptions(parent, controls, sp
 	return yCoord
 end
 
-function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spec, classId, specId, yCoord, primaryResourceString, showWhenCategory, includeFlashAlpha, flashAlphaName, flashAlphaNameShort, includeSecondaryVisibility, secondaryResourceString, includeHealthVisibility, includeManaBarVisibility, customBars)
+function TRB.Functions.OptionsUi:GenerateFlashOptions(parent, controls, spec, classId, specId, yCoord, flashAlphaName, flashAlphaNameShort)
 	local className, specName = TRB.Functions.Character:GetClassAndSpecializationNames(classId, specId)
 	local namePrefix = className .. "_" .. specName
 	local f = nil
 	local title = ""
+
+	controls.flashSection = TRB.Functions.OptionsUi:BuildSectionHeader(parent, L["FlashSectionHeader"], oUi.xCoord, yCoord)
+
+	yCoord = yCoord - 40
+	title = string.format(L["FlashAlpha"], flashAlphaName)
+	controls.flashAlpha = TRB.Functions.OptionsUi:BuildSlider(parent, title, 0, 1, spec.colors.bar.flashAlpha, 0.01, 2,
+								oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord, yCoord)
+	controls.flashAlpha:SetScript("OnValueChanged", function(self, value)
+		value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
+		value = TRB.Functions.Number:RoundTo(value, 2, nil, true)
+		self.EditBox:SetText(value)
+		spec.colors.bar.flashAlpha = value
+	end)
+
+	title = string.format(L["FlashPeriod"], flashAlphaName)
+	controls.flashPeriod = TRB.Functions.OptionsUi:BuildSlider(parent, title, 0.05, 2, spec.colors.bar.flashPeriod, 0.05, 2,
+									oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord2, yCoord)
+	controls.flashPeriod:SetScript("OnValueChanged", function(self, value)
+		value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
+		value = TRB.Functions.Number:RoundTo(value, 2, nil, true)
+		self.EditBox:SetText(value)
+		spec.colors.bar.flashPeriod = value
+	end)
+
+	yCoord = yCoord - 50
+	controls.checkBoxes = controls.checkBoxes or {}
+	controls.checkBoxes.flashEnabled = CreateFrame("CheckButton", "TwintopResourceBar_".. namePrefix .."_Checkbox_FlashEnabled", parent, "ChatConfigCheckButtonTemplate")
+	f = controls.checkBoxes.flashEnabled
+	f:SetPoint("TOPLEFT", oUi.xCoord, yCoord)
+	getglobal(f:GetName() .. 'Text'):SetText(string.format(L["FlashBar"], flashAlphaNameShort))
+	---@diagnostic disable-next-line: inject-field
+	f.tooltip = string.format(L["FlashBarTooltip"], flashAlphaName)
+	f:SetChecked(spec.colors.bar.flashEnabled)
+	f:SetScript("OnClick", function(self, ...)
+		spec.colors.bar.flashEnabled = self:GetChecked()
+	end)
+
+	return yCoord
+end
+
+function TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, spec, classId, specId, yCoord, primaryResourceString, showWhenCategory, includeSecondaryVisibility, secondaryResourceString, includeHealthVisibility, includeManaBarVisibility, customBars)
+	local className, specName = TRB.Functions.Character:GetClassAndSpecializationNames(classId, specId)
+	local namePrefix = className .. "_" .. specName .. "_barVisibility"
+	local f = nil
 	if customBars == nil then
 		customBars = {}
 	end
@@ -4461,6 +4505,7 @@ function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spe
 	if classId ~= nil and specId ~= nil then
 		yCoord = yCoord - 30
 		local lowerClassName = string.lower(className)
+		controls.checkBoxes = controls.checkBoxes or {}
 		controls.checkBoxes.useGlobalDisplayBar = CreateFrame("CheckButton", "TwintopResourceBar_" .. namePrefix .."_useGlobal_displayBar", parent, "ChatConfigCheckButtonTemplate")
 		f = controls.checkBoxes.useGlobalDisplayBar
 		f:SetPoint("TOPLEFT", oUi.xCoord+oUi.xPadding, yCoord)
@@ -4493,7 +4538,7 @@ function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spe
 	end
 
 	yCoord = yCoord - 30
-	
+
 	-- Condition definitions for multi-select bar visibility
 	local conditionKeys = { "inCombat", "inVehicle", "hasFriendlyTarget", "hasUnfriendlyTarget", "isMountedAny", "isMountedGround", "isSkyriding", "isSteadyFlight", "inGroup", "inRaid", "inInstance", "inDungeon", "inRaidInstance", "inBattleground", "inArena", "inDelve", "isPvpFlagged", "isWarMode" }
 	local conditionLabels = {
@@ -4573,15 +4618,33 @@ function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spe
 
 	-- Override a dropdown's SetText so the framework's auto-concatenated
 	-- checkbox labels are always replaced with our custom summary text.
-	-- getTextFunc returns the desired display string each time SetText is called.
-	local function OverrideDropdownDisplayText(dropdown, getTextFunc)
-		local originalSetText = dropdown.SetText
-		dropdown.SetText = function(self, text)
-			originalSetText(self, getTextFunc())
+	-- The hook is installed once; call UpdateDropdownDisplayText() to change
+	-- the function that provides the display string and force a refresh.
+	local dropdownOriginalSetText = nil
+	local dropdownGetTextFunc = nil
+
+	local function InstallDropdownDisplayTextHook(dropdown)
+		if dropdownOriginalSetText == nil then
+			dropdownOriginalSetText = dropdown.SetText
+			dropdown.SetText = function(self, text)
+				if dropdownGetTextFunc then
+					dropdownOriginalSetText(self, dropdownGetTextFunc())
+				else
+					dropdownOriginalSetText(self, text)
+				end
+			end
 		end
 	end
 
-	-- Helper: refresh spec/global cache and re-evaluate bar visibility after alpha/fade changes.
+	local function UpdateDropdownDisplayText(dropdown, getTextFunc)
+		dropdownGetTextFunc = getTextFunc
+		-- Force an immediate visual refresh via the original SetText
+		if dropdownOriginalSetText then
+			dropdownOriginalSetText(dropdown, getTextFunc())
+		end
+	end
+
+	-- Helper: refresh spec/global cache and re-evaluate bar visibility after changes.
 	local function RefreshVisibilitySettings()
 		if classId ~= nil and specId ~= nil then
 			TRB.Functions.Character:FillSpecializationCacheSettings(string.lower(className), specName)
@@ -4612,6 +4675,46 @@ function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spe
 		end
 	end
 
+	-- Helper: refresh for changes that also need appearance (custom bars)
+	local function RefreshVisibilityAndAppearance()
+		if classId ~= nil and specId ~= nil then
+			TRB.Functions.Character:FillSpecializationCacheSettings(string.lower(className), specName)
+			TRB.Functions.Character:ResetCaches()
+			if TRB.Functions.OptionsUi:IsEditingActiveSpec(classId, specId) then
+				if TRB.Frames.barGroups ~= nil then
+					local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
+					TRB.Functions.Bar:ApplyBarGroupsLayout(settings, TRB.Frames.barGroups)
+					TRB.Functions.Bar:ApplyBarGroupsAppearance(settings, TRB.Frames.barGroups)
+					TRB.Functions.EditMode:UpdateWrapperSize(settings)
+					TRB.Functions.BarVisibility:MarkDirty()
+					TRB.Functions.Bar:HideResourceBar()
+					if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
+						TRB.Data.lookupDirty = true
+						TRB.Functions.Class:TriggerResourceBarUpdates()
+					end
+				else
+					TRB.Functions.BarVisibility:MarkDirty()
+					TRB.Functions.Bar:HideResourceBar()
+				end
+			end
+		else
+			if TRB.Data.character and TRB.Data.character.className and TRB.Data.character.specName then
+				local lowerClassName = string.lower(TRB.Data.character.className)
+				local currentSpecName = TRB.Data.character.specName
+				TRB.Functions.Character:FillSpecializationCacheSettings(lowerClassName, currentSpecName)
+				TRB.Functions.Character:ResetCaches()
+				if TRB.Frames.barGroups ~= nil then
+					local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
+					TRB.Functions.Bar:ApplyBarGroupsLayout(settings, TRB.Frames.barGroups)
+					TRB.Functions.Bar:ApplyBarGroupsAppearance(settings, TRB.Frames.barGroups)
+					TRB.Functions.EditMode:UpdateWrapperSize(settings)
+				end
+				TRB.Functions.BarVisibility:MarkDirty()
+				TRB.Functions.Bar:HideResourceBar()
+			end
+		end
+	end
+
 	local function BuildVisibilityDropdownItems(rootDescription, entry, onChange)
 		rootDescription:SetScrollMode(400)
 
@@ -4621,10 +4724,8 @@ function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spe
 			function() return entry.alwaysShow == true end,
 			function()
 				if entry.alwaysShow then
-					-- Uncheck Always
 					entry.alwaysShow = false
 				else
-					-- Check Always; clear Never (mutually exclusive)
 					entry.alwaysShow = true
 					entry.neverShow = false
 				end
@@ -4639,7 +4740,6 @@ function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spe
 			function()
 				entry.neverShow = not entry.neverShow
 				if entry.neverShow then
-					-- Mutually exclusive: uncheck Always
 					entry.alwaysShow = false
 				end
 				onChange()
@@ -4666,559 +4766,299 @@ function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spe
 						onChange()
 					end
 				)
-				-- Dynamically disable condition checkboxes when Always or Never is active.
 				checkbox:SetEnabled(function() return not entry.neverShow and not entry.alwaysShow end)
 			end
 		end
 	end
 
-	-- Primary bar visibility dropdown
-	local primaryLabel = string.format(L["ShowBarVisibilityPrimary"], primaryResourceString or L["ResourceMana"])
-	controls.dropDown = controls.dropDown or {}
-	controls.dropDown.primaryVisibility = CreateFrame("DropdownButton", "TwintopResourceBar_" .. namePrefix .. "_PrimaryVisibility", parent, "WowStyle1DropdownTemplate")
-	controls.dropDown.primaryVisibility:SetWidth(oUi.sliderWidth)
-	controls.dropDown.primaryVisibility.label = TRB.Functions.OptionsUi:BuildSectionHeader(parent, primaryLabel, oUi.xCoord, yCoord)
-	controls.dropDown.primaryVisibility.label.font:SetFontObject(GameFontNormal)
+	-- Build list of bar entries for the table
+	local barEntries = {}
 
-	local function PrimaryVisibilityOnChange()
-		local displayText = GetVisibilityDisplayName(spec.displayBar.primary)
-		controls.dropDown.primaryVisibility:SetDefaultText(displayText)
-		-- Force visual refresh: SetDefaultText alone may not update the displayed
-		-- text when the dropdown has internal selection state from prior interaction.
-		controls.dropDown.primaryVisibility:SetText(displayText)
-		if classId ~= nil and specId ~= nil then
-			-- Spec panel: rebuild cache so global/spec merge is applied correctly
-			TRB.Functions.Character:FillSpecializationCacheSettings(string.lower(className), specName)
-			if TRB.Functions.OptionsUi:IsEditingActiveSpec(classId, specId) then
-				TRB.Functions.Character:ResetCaches()
-				-- Reapply layout to adjust positioning for the visibility change
-				if TRB.Frames.barGroups ~= nil then
-					TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
-					TRB.Functions.EditMode:UpdateWrapperSize(TRB.Data.specCache[TRB.Data.character.compositeKey].settings)
-				end
-				TRB.Functions.BarVisibility:MarkDirty()
-				TRB.Functions.Bar:HideResourceBar()
-			end
-		else
-			-- Global panel: refresh current character's cache if using global displayBar
-			if TRB.Data.character and TRB.Data.character.className and TRB.Data.character.specName then
-				local lowerClassName = string.lower(TRB.Data.character.className)
-				local currentSpecName = TRB.Data.character.specName
-				TRB.Functions.Character:FillSpecializationCacheSettings(lowerClassName, currentSpecName)
-				TRB.Functions.Character:ResetCaches()
-				if TRB.Frames.barGroups ~= nil then
-					TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
-					TRB.Functions.EditMode:UpdateWrapperSize(TRB.Data.specCache[TRB.Data.character.compositeKey].settings)
-				end
-				TRB.Functions.BarVisibility:MarkDirty()
-				TRB.Functions.Bar:HideResourceBar()
-			end
-		end
-	end
+	-- Primary bar (always present)
+	table.insert(barEntries, {
+		key = "primary",
+		displayBarKey = "primary",
+		label = string.format(L["BarVisibilityBarNamePrimary"], primaryResourceString or L["ResourceMana"]),
+		isCustomBar = false,
+	})
 
-	local function PrimaryVisibilityGenerator(dropdown, rootDescription)
-		BuildVisibilityDropdownItems(rootDescription, spec.displayBar.primary, PrimaryVisibilityOnChange)
-	end
-
-	controls.dropDown.primaryVisibility:SetupMenu(PrimaryVisibilityGenerator)
-	OverrideDropdownDisplayText(controls.dropDown.primaryVisibility, function() return GetVisibilityDisplayName(spec.displayBar.primary) end)
-	controls.dropDown.primaryVisibility:SetDefaultText(GetVisibilityDisplayName(spec.displayBar.primary))
-	controls.dropDown.primaryVisibility:SetPoint("TOPLEFT", oUi.xCoord, yCoord - 30)
-
-	-- Health bar visibility dropdown (only if includeHealthVisibility is true)
+	-- Health bar
 	if includeHealthVisibility and spec.displayBar.health ~= nil then
-		local healthLabel = L["ShowBarVisibilityHealth"]
-		controls.dropDown.healthVisibility = CreateFrame("DropdownButton", "TwintopResourceBar_" .. namePrefix .. "_HealthVisibility", parent, "WowStyle1DropdownTemplate")
-		controls.dropDown.healthVisibility:SetWidth(oUi.sliderWidth)
-		controls.dropDown.healthVisibility.label = TRB.Functions.OptionsUi:BuildSectionHeader(parent, healthLabel, oUi.xCoord2, yCoord)
-		controls.dropDown.healthVisibility.label.font:SetFontObject(GameFontNormal)
-
-		local function HealthVisibilityOnChange()
-			local displayText = GetVisibilityDisplayName(spec.displayBar.health)
-			controls.dropDown.healthVisibility:SetDefaultText(displayText)
-			controls.dropDown.healthVisibility:SetText(displayText)
-			if classId ~= nil and specId ~= nil then
-				-- Spec panel: rebuild cache so global/spec merge is applied correctly
-				TRB.Functions.Character:FillSpecializationCacheSettings(string.lower(className), specName)
-				if TRB.Functions.OptionsUi:IsEditingActiveSpec(classId, specId) then
-					TRB.Functions.Character:ResetCaches()
-					-- Reapply layout to adjust positioning for the visibility change
-					if TRB.Frames.barGroups ~= nil then
-						TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
-						TRB.Functions.EditMode:UpdateWrapperSize(TRB.Data.specCache[TRB.Data.character.compositeKey].settings)
-					end
-					TRB.Functions.BarVisibility:MarkDirty()
-					TRB.Functions.Bar:HideResourceBar()
-				end
-			else
-				-- Global panel: refresh current character's cache if using global displayBar
-				if TRB.Data.character and TRB.Data.character.className and TRB.Data.character.specName then
-					local lowerClassName = string.lower(TRB.Data.character.className)
-					local currentSpecName = TRB.Data.character.specName
-					TRB.Functions.Character:FillSpecializationCacheSettings(lowerClassName, currentSpecName)
-					TRB.Functions.Character:ResetCaches()
-					if TRB.Frames.barGroups ~= nil then
-						TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
-						TRB.Functions.EditMode:UpdateWrapperSize(TRB.Data.specCache[TRB.Data.character.compositeKey].settings)
-					end
-					TRB.Functions.BarVisibility:MarkDirty()
-					TRB.Functions.Bar:HideResourceBar()
-				end
-			end
-		end
-
-		local function HealthVisibilityGenerator(dropdown, rootDescription)
-			BuildVisibilityDropdownItems(rootDescription, spec.displayBar.health, HealthVisibilityOnChange)
-		end
-
-		controls.dropDown.healthVisibility:SetupMenu(HealthVisibilityGenerator)
-		OverrideDropdownDisplayText(controls.dropDown.healthVisibility, function() return GetVisibilityDisplayName(spec.displayBar.health) end)
-		controls.dropDown.healthVisibility:SetDefaultText(GetVisibilityDisplayName(spec.displayBar.health))
-		controls.dropDown.healthVisibility:SetPoint("TOPLEFT", oUi.xCoord2, yCoord - 30)
+		table.insert(barEntries, {
+			key = "health",
+			displayBarKey = "health",
+			label = L["BarVisibilityBarNameHealth"],
+			isCustomBar = false,
+		})
 	end
 
-	-- Smooth animation checkboxes (same row, below the visibility dropdowns)
-	yCoord = yCoord - 65
-	controls.checkBoxes = controls.checkBoxes or {}
-	controls.checkBoxes.primarySmooth = CreateFrame("CheckButton", "TwintopResourceBar_" .. namePrefix .. "_PrimarySmooth", parent, "ChatConfigCheckButtonTemplate")
-	f = controls.checkBoxes.primarySmooth
-	f:SetPoint("TOPLEFT", oUi.xCoord + oUi.xPadding, yCoord)
-	getglobal(f:GetName() .. 'Text'):SetText(L["CheckboxSmoothBar"])
-	f.tooltip = L["CheckboxSmoothBarTooltip"]
-	f:SetChecked(spec.displayBar.primary.smooth)
-	f:SetScript("OnClick", function(self, ...)
-		spec.displayBar.primary.smooth = self:GetChecked()
-		-- Refresh cache to pick up the new smooth setting
-		if classId ~= nil and specId ~= nil then
-			-- Spec panel: refresh that spec's cache
-			TRB.Functions.Character:FillSpecializationCacheSettings(string.lower(className), specName)
-			if TRB.Functions.OptionsUi:IsEditingActiveSpec(classId, specId) then
-				TRB.Functions.Character:ResetCaches()
-				if TRB.Frames.barGroups ~= nil then
-					local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
-					TRB.Functions.Bar:ApplyBarGroupsLayout(settings, TRB.Frames.barGroups)
-				end
-			end
-		else
-			-- Global panel: refresh current character's cache if using global displayBar
-			if TRB.Data.character and TRB.Data.character.className and TRB.Data.character.specName then
-				local lowerClassName = string.lower(TRB.Data.character.className)
-				local currentSpecName = TRB.Data.character.specName
-				TRB.Functions.Character:FillSpecializationCacheSettings(lowerClassName, currentSpecName)
-				TRB.Functions.Character:ResetCaches()
-				if TRB.Frames.barGroups ~= nil then
-					local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
-					TRB.Functions.Bar:ApplyBarGroupsLayout(settings, TRB.Frames.barGroups)
-				end
-			end
-		end
-	end)
-
-	if includeHealthVisibility and spec.displayBar.health ~= nil then
-		controls.checkBoxes.healthSmooth = CreateFrame("CheckButton", "TwintopResourceBar_" .. namePrefix .. "_HealthSmooth", parent, "ChatConfigCheckButtonTemplate")
-		f = controls.checkBoxes.healthSmooth
-		f:SetPoint("TOPLEFT", oUi.xCoord2 + oUi.xPadding, yCoord)
-		getglobal(f:GetName() .. 'Text'):SetText(L["CheckboxSmoothBar"])
-		f.tooltip = L["CheckboxSmoothBarTooltip"]
-		f:SetChecked(spec.displayBar.health.smooth)
-		f:SetScript("OnClick", function(self, ...)
-			spec.displayBar.health.smooth = self:GetChecked()
-			-- Refresh cache to pick up the new smooth setting
-			if classId ~= nil and specId ~= nil then
-				-- Spec panel: refresh that spec's cache
-				TRB.Functions.Character:FillSpecializationCacheSettings(string.lower(className), specName)
-				if TRB.Functions.OptionsUi:IsEditingActiveSpec(classId, specId) then
-					TRB.Functions.Character:ResetCaches()
-					if TRB.Frames.barGroups ~= nil then
-						local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
-						TRB.Functions.Bar:ApplyBarGroupsLayout(settings, TRB.Frames.barGroups)
-					end
-				end
-			else
-				-- Global panel: refresh current character's cache if using global displayBar
-				if TRB.Data.character and TRB.Data.character.className and TRB.Data.character.specName then
-					local lowerClassName = string.lower(TRB.Data.character.className)
-					local currentSpecName = TRB.Data.character.specName
-					TRB.Functions.Character:FillSpecializationCacheSettings(lowerClassName, currentSpecName)
-					TRB.Functions.Character:ResetCaches()
-					if TRB.Frames.barGroups ~= nil then
-						local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
-						TRB.Functions.Bar:ApplyBarGroupsLayout(settings, TRB.Frames.barGroups)
-					end
-				end
-			end
-		end)
-	end
-
-	-- Active Opacity, Inactive Opacity, and Fade Duration sliders for primary (and health)
-	controls.sliders = controls.sliders or {}
-
-	yCoord = yCoord - 50
-	controls.sliders.primaryActiveAlpha = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityActiveAlpha"],
-		0, 100, spec.displayBar.primary.activeAlpha or 100, 1, 0,
-		oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord, yCoord)
-	controls.sliders.primaryActiveAlpha.MinLabel:SetText("0%")
-	controls.sliders.primaryActiveAlpha.MaxLabel:SetText("100%")
-	controls.sliders.primaryActiveAlpha:SetScript("OnValueChanged", function(self, value)
-		value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
-		value = TRB.Functions.Number:RoundTo(value, 0, nil, true)
-		self.EditBox:SetText(value)
-		spec.displayBar.primary.activeAlpha = value
-		RefreshVisibilitySettings()
-	end)
-
-	if includeHealthVisibility and spec.displayBar.health ~= nil then
-		controls.sliders.healthActiveAlpha = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityActiveAlpha"],
-			0, 100, spec.displayBar.health.activeAlpha or 100, 1, 0,
-			oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord2, yCoord)
-		controls.sliders.healthActiveAlpha.MinLabel:SetText("0%")
-		controls.sliders.healthActiveAlpha.MaxLabel:SetText("100%")
-		controls.sliders.healthActiveAlpha:SetScript("OnValueChanged", function(self, value)
-			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
-			value = TRB.Functions.Number:RoundTo(value, 0, nil, true)
-			self.EditBox:SetText(value)
-			spec.displayBar.health.activeAlpha = value
-			RefreshVisibilitySettings()
-		end)
-	end
-
-	yCoord = yCoord - 60
-	controls.sliders.primaryInactiveAlpha = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityInactiveAlpha"],
-		0, 100, spec.displayBar.primary.inactiveAlpha or 0, 1, 0,
-		oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord, yCoord)
-	controls.sliders.primaryInactiveAlpha.MinLabel:SetText("0%")
-	controls.sliders.primaryInactiveAlpha.MaxLabel:SetText("100%")
-	controls.sliders.primaryInactiveAlpha:SetScript("OnValueChanged", function(self, value)
-		value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
-		value = TRB.Functions.Number:RoundTo(value, 0, nil, true)
-		self.EditBox:SetText(value)
-		spec.displayBar.primary.inactiveAlpha = value
-		RefreshVisibilitySettings()
-	end)
-
-	if includeHealthVisibility and spec.displayBar.health ~= nil then
-		controls.sliders.healthInactiveAlpha = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityInactiveAlpha"],
-			0, 100, spec.displayBar.health.inactiveAlpha or 0, 1, 0,
-			oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord2, yCoord)
-		controls.sliders.healthInactiveAlpha.MinLabel:SetText("0%")
-		controls.sliders.healthInactiveAlpha.MaxLabel:SetText("100%")
-		controls.sliders.healthInactiveAlpha:SetScript("OnValueChanged", function(self, value)
-			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
-			value = TRB.Functions.Number:RoundTo(value, 0, nil, true)
-			self.EditBox:SetText(value)
-			spec.displayBar.health.inactiveAlpha = value
-			RefreshVisibilitySettings()
-		end)
-	end
-
-	yCoord = yCoord - 60
-	controls.sliders.primaryFadeDuration = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityFadeDuration"],
-		0, 10, spec.displayBar.primary.fadeDuration or 0, 0.25, 2,
-		oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord, yCoord)
-	controls.sliders.primaryFadeDuration:SetScript("OnValueChanged", function(self, value)
-		value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
-		value = TRB.Functions.Number:RoundTo(value, 2, nil, true)
-		self.EditBox:SetText(value)
-		spec.displayBar.primary.fadeDuration = value
-		RefreshVisibilitySettings()
-	end)
-
-	if includeHealthVisibility and spec.displayBar.health ~= nil then
-		controls.sliders.healthFadeDuration = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityFadeDuration"],
-			0, 10, spec.displayBar.health.fadeDuration or 0, 0.25, 2,
-			oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord2, yCoord)
-		controls.sliders.healthFadeDuration:SetScript("OnValueChanged", function(self, value)
-			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
-			value = TRB.Functions.Number:RoundTo(value, 2, nil, true)
-			self.EditBox:SetText(value)
-			spec.displayBar.health.fadeDuration = value
-			RefreshVisibilitySettings()
-		end)
-	end
-
-	yCoord = yCoord - 60
-	controls.sliders.primaryFadeDelay = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityFadeDelay"],
-		0, 10, spec.displayBar.primary.fadeDelay or 0, 0.25, 2,
-		oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord, yCoord)
-	controls.sliders.primaryFadeDelay:SetScript("OnValueChanged", function(self, value)
-		value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
-		value = TRB.Functions.Number:RoundTo(value, 2, nil, true)
-		self.EditBox:SetText(value)
-		spec.displayBar.primary.fadeDelay = value
-		RefreshVisibilitySettings()
-	end)
-
-	if includeHealthVisibility and spec.displayBar.health ~= nil then
-		controls.sliders.healthFadeDelay = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityFadeDelay"],
-			0, 10, spec.displayBar.health.fadeDelay or 0, 0.25, 2,
-			oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord2, yCoord)
-		controls.sliders.healthFadeDelay:SetScript("OnValueChanged", function(self, value)
-			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
-			value = TRB.Functions.Number:RoundTo(value, 2, nil, true)
-			self.EditBox:SetText(value)
-			spec.displayBar.health.fadeDelay = value
-			RefreshVisibilitySettings()
-		end)
-	end
-
-	-- Collect remaining visibility items, then place in two-column layout (left-to-right fill)
-	local visibilityItems = {}
+	-- Secondary resource
 	if includeSecondaryVisibility then
-		table.insert(visibilityItems, {
-			key = "Secondary",
+		table.insert(barEntries, {
+			key = "secondary",
 			displayBarKey = "secondary",
 			label = string.format(L["ShowBarVisibilitySecondary"], secondaryResourceString or L["ResourceComboPoints"]),
-			controlDropdownKey = "secondaryVisibility",
-			controlCheckboxKey = "secondarySmooth",
+			isCustomBar = false,
 		})
 	end
+
+	-- Mana bar (secondary)
 	if includeManaBarVisibility and spec.displayBar.mana ~= nil then
-		table.insert(visibilityItems, {
-			key = "Mana",
+		table.insert(barEntries, {
+			key = "mana",
 			displayBarKey = "mana",
-			label = L["ShowBarVisibilityMana"],
-			controlDropdownKey = "manaVisibility",
-			controlCheckboxKey = "manaSmooth",
-			isMana = true,
+			label = L["BarVisibilityBarNameMana"],
+			isCustomBar = false,
 		})
 	end
+
+	-- Custom bars (stagger, defensives, utility, etc.)
 	for _, barTypeDef in ipairs(customBars) do
 		if spec.displayBar and spec.displayBar[barTypeDef.visibilityKey] ~= nil then
-			table.insert(visibilityItems, {
+			table.insert(barEntries, {
 				key = barTypeDef.key,
 				displayBarKey = barTypeDef.visibilityKey,
 				label = string.format(L["ShowBarVisibilityCustom"], barTypeDef.displayName),
-				controlDropdownKey = barTypeDef.key .. "Visibility",
-				controlCheckboxKey = barTypeDef.key .. "Smooth",
 				isCustomBar = true,
 			})
 		end
 	end
 
-	for i, item in ipairs(visibilityItems) do
-		local isLeft = (i % 2 == 1)
-		if isLeft then
-			yCoord = yCoord - 30
+	-- Create the LibScrollingTable for bar selection
+	local columns = {
+		{
+			["name"] = "Key",
+			["width"] = 1,
+			["align"] = "CENTER",
+		},
+		{
+			["name"] = L["BarVisibilityTableHeaderBar"],
+			["width"] = 200,
+			["align"] = "LEFT",
+		},
+		{
+			["name"] = L["BarVisibilityTableHeaderVisibility"],
+			["width"] = 200,
+			["align"] = "LEFT",
+		},
+	}
+
+	controls.barVisibilityContainer = CreateFrame("Frame", nil, parent, "BackdropTemplate")
+	local bvc = controls.barVisibilityContainer
+	bvc:SetPoint("TOPLEFT", parent, "TOPLEFT", oUi.xCoord, yCoord)
+	bvc:SetPoint("RIGHT", parent, "RIGHT", -oUi.xCoord, 0)
+	local tableRowCount = math.max(#barEntries, 2)
+	bvc:SetHeight(35 + (tableRowCount * 15))
+
+	local barVisibilityTable = TRB.Details.addonData.libs.ScrollingTable:CreateST(columns, tableRowCount, 15, nil, bvc, false, false)
+
+	-- Dynamically resize the Visibility column to fill available width
+	bvc:HookScript("OnSizeChanged", function(self, w, h)
+		local fixedWidth = columns[1].width + columns[2].width
+		local newVisibilityWidth = math.max(100, w - fixedWidth - 30)
+		columns[3].width = newVisibilityWidth
+		barVisibilityTable:SetDisplayCols(columns)
+	end)
+
+	local function SetTableValues()
+		local dataTable = {}
+		for _, entry in ipairs(barEntries) do
+			local visSettings = spec.displayBar[entry.displayBarKey]
+			local statusText = ""
+			if visSettings then
+				statusText = GetVisibilityDisplayName(visSettings)
+			end
+			table.insert(dataTable, {
+				cols = {
+					{ value = entry.key },
+					{ value = entry.label },
+					{ value = statusText },
+				}
+			})
 		end
-		local xPos = isLeft and oUi.xCoord or oUi.xCoord2
-		local displayBarKey = item.displayBarKey
-		local controlDropdownKey = item.controlDropdownKey
-		local controlCheckboxKey = item.controlCheckboxKey
-		local isMana = item.isMana
-		local isCustom = item.isCustomBar
+		barVisibilityTable:SetData(dataTable)
+		barVisibilityTable:EnableSelection(true)
+	end
+
+	-- Detail panel below the table
+	local detailHeight = 300
+	controls.barVisibilityDetail = CreateFrame("Frame", "TwintopResourceBar_" .. namePrefix .. "_BarVisibilityDetail", parent, "BackdropTemplate")
+	local detailFrame = controls.barVisibilityDetail
+	detailFrame:SetPoint("TOPLEFT", bvc, "BOTTOMLEFT", 0, 0)
+	detailFrame:SetPoint("TOPRIGHT", bvc, "BOTTOMRIGHT", 0, 0)
+	detailFrame:SetHeight(detailHeight)
+	detailFrame:Hide()
+
+	local detailYCoord = 0
+	local selectedBarKey = nil
+
+	-- Detail panel contents: header, dropdown, smooth checkbox, sliders
+	local detailHeader = TRB.Functions.OptionsUi:BuildSectionHeader(detailFrame, "", oUi.xCoord, detailYCoord)
+
+	detailYCoord = detailYCoord - 30
+	controls.dropDown = controls.dropDown or {}
+	controls.dropDown.selectedBarVisibility = CreateFrame("DropdownButton", "TwintopResourceBar_" .. namePrefix .. "_SelectedBarVisibility", detailFrame, "WowStyle1DropdownTemplate")
+	controls.dropDown.selectedBarVisibility:SetWidth(oUi.sliderWidth)
+	controls.dropDown.selectedBarVisibility.label = TRB.Functions.OptionsUi:BuildSectionHeader(detailFrame, L["BarVisibilityConditionsLabel"], oUi.xCoord, detailYCoord)
+	controls.dropDown.selectedBarVisibility.label.font:SetFontObject(GameFontNormal)
+	controls.dropDown.selectedBarVisibility:SetPoint("TOPLEFT", oUi.xCoord, detailYCoord - 30)
+	InstallDropdownDisplayTextHook(controls.dropDown.selectedBarVisibility)
+
+	-- Smooth checkbox (to the right of the dropdown)
+	controls.checkBoxes = controls.checkBoxes or {}
+	controls.checkBoxes.selectedSmooth = CreateFrame("CheckButton", "TwintopResourceBar_" .. namePrefix .. "_SelectedSmooth", detailFrame, "ChatConfigCheckButtonTemplate")
+	f = controls.checkBoxes.selectedSmooth
+	f:SetPoint("TOPLEFT", oUi.xCoord2, detailYCoord - 30)
+	getglobal(f:GetName() .. 'Text'):SetText(L["CheckboxSmoothBar"])
+	f.tooltip = L["CheckboxSmoothBarTooltip"]
+
+	-- Alpha/fade sliders
+	controls.sliders = controls.sliders or {}
+
+	detailYCoord = detailYCoord - 70
+	controls.sliders.selectedActiveAlpha = TRB.Functions.OptionsUi:BuildSlider(detailFrame, L["ShowBarVisibilityActiveAlpha"],
+		0, 100, 100, 1, 0,
+		oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord, detailYCoord)
+	controls.sliders.selectedActiveAlpha.MinLabel:SetText("0%")
+	controls.sliders.selectedActiveAlpha.MaxLabel:SetText("100%")
+
+	controls.sliders.selectedInactiveAlpha = TRB.Functions.OptionsUi:BuildSlider(detailFrame, L["ShowBarVisibilityInactiveAlpha"],
+		0, 100, 0, 1, 0,
+		oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord2, detailYCoord)
+	controls.sliders.selectedInactiveAlpha.MinLabel:SetText("0%")
+	controls.sliders.selectedInactiveAlpha.MaxLabel:SetText("100%")
+
+	detailYCoord = detailYCoord - 60
+	controls.sliders.selectedFadeDuration = TRB.Functions.OptionsUi:BuildSlider(detailFrame, L["ShowBarVisibilityFadeDuration"],
+		0, 10, 0, 0.25, 2,
+		oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord, detailYCoord)
+
+	controls.sliders.selectedFadeDelay = TRB.Functions.OptionsUi:BuildSlider(detailFrame, L["ShowBarVisibilityFadeDelay"],
+		0, 10, 0, 0.25, 2,
+		oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord2, detailYCoord)
+
+	-- Fill the detail panel with data for the selected bar
+	local function FillDetailPanel(barKey)
+		selectedBarKey = barKey
+		local barEntry = nil
+		for _, e in ipairs(barEntries) do
+			if e.key == barKey then
+				barEntry = e
+				break
+			end
+		end
+		if barEntry == nil then
+			detailFrame:Hide()
+			return
+		end
+
+		local visSettings = spec.displayBar[barEntry.displayBarKey]
+		if visSettings == nil then
+			detailFrame:Hide()
+			return
+		end
+
+		-- Update header
+		detailHeader.font:SetText(string.format(L["BarVisibilityDetailHeader"], barEntry.label))
+
+		-- Determine if this bar needs the appearance refresh (custom bars)
+		local refreshFunc = barEntry.isCustomBar and RefreshVisibilityAndAppearance or RefreshVisibilitySettings
 
 		-- Visibility dropdown
-		controls.dropDown[controlDropdownKey] = CreateFrame("DropdownButton", "TwintopResourceBar_" .. namePrefix .. "_" .. item.key .. "Visibility", parent, "WowStyle1DropdownTemplate")
-		controls.dropDown[controlDropdownKey]:SetWidth(oUi.sliderWidth)
-		controls.dropDown[controlDropdownKey].label = TRB.Functions.OptionsUi:BuildSectionHeader(parent, item.label, xPos, yCoord)
-		controls.dropDown[controlDropdownKey].label.font:SetFontObject(GameFontNormal)
-
-		local function ItemVisibilityOnChange()
-			local displayText = GetVisibilityDisplayName(spec.displayBar[displayBarKey])
-			controls.dropDown[controlDropdownKey]:SetDefaultText(displayText)
-			controls.dropDown[controlDropdownKey]:SetText(displayText)
-
-			if isCustom then
-				if classId ~= nil and specId ~= nil then
-					TRB.Functions.Character:FillSpecializationCacheSettings(string.lower(className), specName)
-					TRB.Functions.Character:ResetCaches()
-					if TRB.Functions.OptionsUi:IsEditingActiveSpec(classId, specId) then
-						if TRB.Frames.barGroups ~= nil then
-							local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
-							TRB.Functions.Bar:ApplyBarGroupsLayout(settings, TRB.Frames.barGroups)
-							TRB.Functions.Bar:ApplyBarGroupsAppearance(settings, TRB.Frames.barGroups)
-							TRB.Functions.EditMode:UpdateWrapperSize(settings)
-							TRB.Functions.BarVisibility:MarkDirty()
-							TRB.Functions.Bar:HideResourceBar()
-							if TRB.Functions.Class and TRB.Functions.Class.TriggerResourceBarUpdates then
-								TRB.Data.lookupDirty = true
-								TRB.Functions.Class:TriggerResourceBarUpdates()
-							end
-						else
-							TRB.Functions.BarVisibility:MarkDirty()
-							TRB.Functions.Bar:HideResourceBar()
-						end
-					end
-				else
-					if TRB.Data.character and TRB.Data.character.className and TRB.Data.character.specName then
-						local lowerClassName = string.lower(TRB.Data.character.className)
-						local currentSpecName = TRB.Data.character.specName
-						TRB.Functions.Character:FillSpecializationCacheSettings(lowerClassName, currentSpecName)
-						TRB.Functions.Character:ResetCaches()
-						if TRB.Frames.barGroups ~= nil then
-							local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
-							TRB.Functions.Bar:ApplyBarGroupsLayout(settings, TRB.Frames.barGroups)
-							TRB.Functions.Bar:ApplyBarGroupsAppearance(settings, TRB.Frames.barGroups)
-							TRB.Functions.EditMode:UpdateWrapperSize(settings)
-						end
-						TRB.Functions.BarVisibility:MarkDirty()
-						TRB.Functions.Bar:HideResourceBar()
-					end
-				end
-			else
-				if classId ~= nil and specId ~= nil then
-					-- Spec panel: rebuild cache so global/spec merge is applied correctly
-					TRB.Functions.Character:FillSpecializationCacheSettings(string.lower(className), specName)
-					if TRB.Functions.OptionsUi:IsEditingActiveSpec(classId, specId) then
-						TRB.Functions.Character:ResetCaches()
-						if TRB.Frames.barGroups ~= nil then
-							TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
-							TRB.Functions.EditMode:UpdateWrapperSize(TRB.Data.specCache[TRB.Data.character.compositeKey].settings)
-						end
-						TRB.Functions.BarVisibility:MarkDirty()
-						TRB.Functions.Bar:HideResourceBar()
-					end
-				else
-					if TRB.Data.character and TRB.Data.character.className and TRB.Data.character.specName then
-						local lowerClassName = string.lower(TRB.Data.character.className)
-						local currentSpecName = TRB.Data.character.specName
-						TRB.Functions.Character:FillSpecializationCacheSettings(lowerClassName, currentSpecName)
-						TRB.Functions.Character:ResetCaches()
-						if TRB.Frames.barGroups ~= nil then
-							TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
-							TRB.Functions.EditMode:UpdateWrapperSize(TRB.Data.specCache[TRB.Data.character.compositeKey].settings)
-						end
-						TRB.Functions.BarVisibility:MarkDirty()
-						TRB.Functions.Bar:HideResourceBar()
-					end
+		local function OnVisibilityChange()
+			local displayText = GetVisibilityDisplayName(visSettings)
+			controls.dropDown.selectedBarVisibility:SetDefaultText(displayText)
+			controls.dropDown.selectedBarVisibility:SetText(displayText)
+			refreshFunc()
+			SetTableValues()
+			-- Re-select the current row
+			for i, e in ipairs(barEntries) do
+				if e.key == barKey then
+					barVisibilityTable:SetSelection(i)
+					break
 				end
 			end
 		end
 
-		local function ItemVisibilityGenerator(dropdown, rootDescription)
-			BuildVisibilityDropdownItems(rootDescription, spec.displayBar[displayBarKey], ItemVisibilityOnChange)
+		local function VisibilityGenerator(dropdown, rootDescription)
+			BuildVisibilityDropdownItems(rootDescription, visSettings, OnVisibilityChange)
 		end
 
-		controls.dropDown[controlDropdownKey]:SetupMenu(ItemVisibilityGenerator)
-		OverrideDropdownDisplayText(controls.dropDown[controlDropdownKey], function() return GetVisibilityDisplayName(spec.displayBar[displayBarKey]) end)
-		controls.dropDown[controlDropdownKey]:SetDefaultText(GetVisibilityDisplayName(spec.displayBar[displayBarKey]))
-		controls.dropDown[controlDropdownKey]:SetPoint("TOPLEFT", xPos, yCoord - 30)
+		controls.dropDown.selectedBarVisibility:SetupMenu(VisibilityGenerator)
+		UpdateDropdownDisplayText(controls.dropDown.selectedBarVisibility, function() return GetVisibilityDisplayName(visSettings) end)
 
 		-- Smooth checkbox
-		controls.checkBoxes[controlCheckboxKey] = CreateFrame("CheckButton", "TwintopResourceBar_" .. namePrefix .. "_" .. item.key .. "Smooth", parent, "ChatConfigCheckButtonTemplate")
-		f = controls.checkBoxes[controlCheckboxKey]
-		f:SetPoint("TOPLEFT", xPos + oUi.xPadding, yCoord - 65)
-		getglobal(f:GetName() .. 'Text'):SetText(L["CheckboxSmoothBar"])
-		f.tooltip = L["CheckboxSmoothBarTooltip"]
-		f:SetChecked(spec.displayBar[displayBarKey].smooth)
-		f:SetScript("OnClick", function(self, ...)
-			spec.displayBar[displayBarKey].smooth = self:GetChecked()
-			if classId ~= nil and specId ~= nil then
-				TRB.Functions.Character:FillSpecializationCacheSettings(string.lower(className), specName)
-				if TRB.Functions.OptionsUi:IsEditingActiveSpec(classId, specId) then
-					TRB.Functions.Character:ResetCaches()
-					if TRB.Frames.barGroups ~= nil then
-						local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
-						TRB.Functions.Bar:ApplyBarGroupsLayout(settings, TRB.Frames.barGroups)
-					end
-				end
-			else
-				if TRB.Data.character and TRB.Data.character.className and TRB.Data.character.specName then
-					local lowerClassName = string.lower(TRB.Data.character.className)
-					local currentSpecName = TRB.Data.character.specName
-					TRB.Functions.Character:FillSpecializationCacheSettings(lowerClassName, currentSpecName)
-					TRB.Functions.Character:ResetCaches()
-					if TRB.Frames.barGroups ~= nil then
-						local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
-						TRB.Functions.Bar:ApplyBarGroupsLayout(settings, TRB.Frames.barGroups)
-					end
+		controls.checkBoxes.selectedSmooth:SetChecked(visSettings.smooth)
+		controls.checkBoxes.selectedSmooth:SetScript("OnClick", function(self, ...)
+			visSettings.smooth = self:GetChecked()
+			refreshFunc()
+		end)
+
+		-- Alpha sliders — set scripts BEFORE values so SetValue doesn't write to the old entry
+		controls.sliders.selectedActiveAlpha:SetScript("OnValueChanged", function(self, value)
+			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
+			value = TRB.Functions.Number:RoundTo(value, 0, nil, true)
+			self.EditBox:SetText(value)
+			visSettings.activeAlpha = value
+			refreshFunc()
+		end)
+		controls.sliders.selectedActiveAlpha:SetValue(visSettings.activeAlpha or 100)
+
+		controls.sliders.selectedInactiveAlpha:SetScript("OnValueChanged", function(self, value)
+			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
+			value = TRB.Functions.Number:RoundTo(value, 0, nil, true)
+			self.EditBox:SetText(value)
+			visSettings.inactiveAlpha = value
+			refreshFunc()
+		end)
+		controls.sliders.selectedInactiveAlpha:SetValue(visSettings.inactiveAlpha or 0)
+
+		controls.sliders.selectedFadeDuration:SetScript("OnValueChanged", function(self, value)
+			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
+			value = TRB.Functions.Number:RoundTo(value, 2, nil, true)
+			self.EditBox:SetText(value)
+			visSettings.fadeDuration = value
+			refreshFunc()
+		end)
+		controls.sliders.selectedFadeDuration:SetValue(visSettings.fadeDuration or 0)
+
+		controls.sliders.selectedFadeDelay:SetScript("OnValueChanged", function(self, value)
+			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
+			value = TRB.Functions.Number:RoundTo(value, 2, nil, true)
+			self.EditBox:SetText(value)
+			visSettings.fadeDelay = value
+			refreshFunc()
+		end)
+		controls.sliders.selectedFadeDelay:SetValue(visSettings.fadeDelay or 0)
+
+		detailFrame:Show()
+	end
+
+	-- Table click handler
+	barVisibilityTable:RegisterEvents({
+		OnClick = function(rowFrame, cellFrame, data, cols, row, realrow, column, scrollingTable, button, ...)
+			if button == "LeftButton" then
+				if realrow ~= nil and realrow > 0 then
+					local barKey = data[realrow].cols[1].value
+					local currentSelection = scrollingTable:GetSelection()
+					FillDetailPanel(barKey)
+					C_Timer.After(0, function()
+						C_Timer.After(0.05, function()
+							local newSelection = scrollingTable:GetSelection()
+							if newSelection == nil then
+								barVisibilityTable:SetSelection(currentSelection)
+							end
+						end)
+					end)
 				end
 			end
-		end)
-
-		-- Alpha and fade sliders for this visibility item
-		controls.sliders[item.key .. "ActiveAlpha"] = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityActiveAlpha"],
-			0, 100, spec.displayBar[displayBarKey].activeAlpha or 100, 1, 0,
-			oUi.sliderWidth, oUi.sliderHeight, xPos, yCoord - 115)
-		controls.sliders[item.key .. "ActiveAlpha"].MinLabel:SetText("0%")
-		controls.sliders[item.key .. "ActiveAlpha"].MaxLabel:SetText("100%")
-		controls.sliders[item.key .. "ActiveAlpha"]:SetScript("OnValueChanged", function(self, value)
-			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
-			value = TRB.Functions.Number:RoundTo(value, 0, nil, true)
-			self.EditBox:SetText(value)
-			spec.displayBar[displayBarKey].activeAlpha = value
-			RefreshVisibilitySettings()
-		end)
-
-		controls.sliders[item.key .. "InactiveAlpha"] = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityInactiveAlpha"],
-			0, 100, spec.displayBar[displayBarKey].inactiveAlpha or 0, 1, 0,
-			oUi.sliderWidth, oUi.sliderHeight, xPos, yCoord - 175)
-		controls.sliders[item.key .. "InactiveAlpha"].MinLabel:SetText("0%")
-		controls.sliders[item.key .. "InactiveAlpha"].MaxLabel:SetText("100%")
-		controls.sliders[item.key .. "InactiveAlpha"]:SetScript("OnValueChanged", function(self, value)
-			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
-			value = TRB.Functions.Number:RoundTo(value, 0, nil, true)
-			self.EditBox:SetText(value)
-			spec.displayBar[displayBarKey].inactiveAlpha = value
-			RefreshVisibilitySettings()
-		end)
-
-		controls.sliders[item.key .. "FadeDuration"] = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityFadeDuration"],
-			0, 10, spec.displayBar[displayBarKey].fadeDuration or 0, 0.25, 2,
-			oUi.sliderWidth, oUi.sliderHeight, xPos, yCoord - 235)
-		controls.sliders[item.key .. "FadeDuration"]:SetScript("OnValueChanged", function(self, value)
-			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
-			value = TRB.Functions.Number:RoundTo(value, 2, nil, true)
-			self.EditBox:SetText(value)
-			spec.displayBar[displayBarKey].fadeDuration = value
-			RefreshVisibilitySettings()
-		end)
-
-		controls.sliders[item.key .. "FadeDelay"] = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityFadeDelay"],
-			0, 10, spec.displayBar[displayBarKey].fadeDelay or 0, 0.25, 2,
-			oUi.sliderWidth, oUi.sliderHeight, xPos, yCoord - 295)
-		controls.sliders[item.key .. "FadeDelay"]:SetScript("OnValueChanged", function(self, value)
-			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
-			value = TRB.Functions.Number:RoundTo(value, 2, nil, true)
-			self.EditBox:SetText(value)
-			spec.displayBar[displayBarKey].fadeDelay = value
-			RefreshVisibilitySettings()
-		end)
-
-		-- Advance yCoord after right column item or last item
-		if not isLeft or i == #visibilityItems then
-			yCoord = yCoord - 315
 		end
-	end
+	})
 
-	if includeFlashAlpha then
-		yCoord = yCoord - 50
-		title = string.format(L["FlashAlpha"], flashAlphaName)
-		controls.flashAlpha = TRB.Functions.OptionsUi:BuildSlider(parent, title, 0, 1, spec.colors.bar.flashAlpha, 0.01, 2,
-									oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord, yCoord)
-		controls.flashAlpha:SetScript("OnValueChanged", function(self, value)
-			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
-			value = TRB.Functions.Number:RoundTo(value, 2, nil, true)
-			self.EditBox:SetText(value)
-			spec.colors.bar.flashAlpha = value
-		end)
+	-- Initial table population
+	SetTableValues()
 
-		title = string.format(L["FlashPeriod"], flashAlphaName)
-		controls.flashPeriod = TRB.Functions.OptionsUi:BuildSlider(parent, title, 0.05, 2, spec.colors.bar.flashPeriod, 0.05, 2,
-										oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord2, yCoord)
-		controls.flashPeriod:SetScript("OnValueChanged", function(self, value)
-			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
-			value = TRB.Functions.Number:RoundTo(value, 2, nil, true)
-			self.EditBox:SetText(value)
-			spec.colors.bar.flashPeriod = value
-		end)
-		yCoord = yCoord - 10
-	end
-
-	local yCoord2 = yCoord - 40
-
-	if includeFlashAlpha then
-		controls.checkBoxes.flashEnabled = CreateFrame("CheckButton", "TwintopResourceBar_".. namePrefix .."_Checkbox_FlashEnabled", parent, "ChatConfigCheckButtonTemplate")
-		f = controls.checkBoxes.flashEnabled
-		f:SetPoint("TOPLEFT", oUi.xCoord, yCoord2)
-		getglobal(f:GetName() .. 'Text'):SetText(string.format(L["FlashBar"], flashAlphaNameShort))
-		---@diagnostic disable-next-line: inject-field
-		f.tooltip = string.format(L["FlashBarTooltip"], flashAlphaName)
-		f:SetChecked(spec.colors.bar.flashEnabled)
-		f:SetScript("OnClick", function(self, ...)
-			spec.colors.bar.flashEnabled = self:GetChecked()
-		end)
-	end
+	yCoord = yCoord - (35 + (tableRowCount * 15)) - 10 - detailHeight
 
 	return yCoord
 end

--- a/Options/OptionsUi.lua
+++ b/Options/OptionsUi.lua
@@ -4581,6 +4581,37 @@ function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spe
 		end
 	end
 
+	-- Helper: refresh spec/global cache and re-evaluate bar visibility after alpha/fade changes.
+	local function RefreshVisibilitySettings()
+		if classId ~= nil and specId ~= nil then
+			TRB.Functions.Character:FillSpecializationCacheSettings(string.lower(className), specName)
+			if TRB.Functions.OptionsUi:IsEditingActiveSpec(classId, specId) then
+				TRB.Functions.Character:ResetCaches()
+				if TRB.Frames.barGroups ~= nil then
+					local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
+					TRB.Functions.Bar:ApplyBarGroupsLayout(settings, TRB.Frames.barGroups)
+					TRB.Functions.EditMode:UpdateWrapperSize(settings)
+				end
+				TRB.Functions.BarVisibility:MarkDirty()
+				TRB.Functions.Bar:HideResourceBar()
+			end
+		else
+			if TRB.Data.character and TRB.Data.character.className and TRB.Data.character.specName then
+				local lowerClassName = string.lower(TRB.Data.character.className)
+				local currentSpecName = TRB.Data.character.specName
+				TRB.Functions.Character:FillSpecializationCacheSettings(lowerClassName, currentSpecName)
+				TRB.Functions.Character:ResetCaches()
+				if TRB.Frames.barGroups ~= nil then
+					local settings = TRB.Data.specCache[TRB.Data.character.compositeKey].settings
+					TRB.Functions.Bar:ApplyBarGroupsLayout(settings, TRB.Frames.barGroups)
+					TRB.Functions.EditMode:UpdateWrapperSize(settings)
+				end
+				TRB.Functions.BarVisibility:MarkDirty()
+				TRB.Functions.Bar:HideResourceBar()
+			end
+		end
+	end
+
 	local function BuildVisibilityDropdownItems(rootDescription, entry, onChange)
 		rootDescription:SetScrollMode(400)
 
@@ -4819,6 +4850,117 @@ function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spe
 		end)
 	end
 
+	-- Active Opacity, Inactive Opacity, and Fade Duration sliders for primary (and health)
+	controls.sliders = controls.sliders or {}
+
+	yCoord = yCoord - 50
+	controls.sliders.primaryActiveAlpha = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityActiveAlpha"],
+		0, 100, spec.displayBar.primary.activeAlpha or 100, 1, 0,
+		oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord, yCoord)
+	controls.sliders.primaryActiveAlpha.MinLabel:SetText("0%")
+	controls.sliders.primaryActiveAlpha.MaxLabel:SetText("100%")
+	controls.sliders.primaryActiveAlpha:SetScript("OnValueChanged", function(self, value)
+		value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
+		value = TRB.Functions.Number:RoundTo(value, 0, nil, true)
+		self.EditBox:SetText(value)
+		spec.displayBar.primary.activeAlpha = value
+		RefreshVisibilitySettings()
+	end)
+
+	if includeHealthVisibility and spec.displayBar.health ~= nil then
+		controls.sliders.healthActiveAlpha = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityActiveAlpha"],
+			0, 100, spec.displayBar.health.activeAlpha or 100, 1, 0,
+			oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord2, yCoord)
+		controls.sliders.healthActiveAlpha.MinLabel:SetText("0%")
+		controls.sliders.healthActiveAlpha.MaxLabel:SetText("100%")
+		controls.sliders.healthActiveAlpha:SetScript("OnValueChanged", function(self, value)
+			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
+			value = TRB.Functions.Number:RoundTo(value, 0, nil, true)
+			self.EditBox:SetText(value)
+			spec.displayBar.health.activeAlpha = value
+			RefreshVisibilitySettings()
+		end)
+	end
+
+	yCoord = yCoord - 60
+	controls.sliders.primaryInactiveAlpha = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityInactiveAlpha"],
+		0, 100, spec.displayBar.primary.inactiveAlpha or 0, 1, 0,
+		oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord, yCoord)
+	controls.sliders.primaryInactiveAlpha.MinLabel:SetText("0%")
+	controls.sliders.primaryInactiveAlpha.MaxLabel:SetText("100%")
+	controls.sliders.primaryInactiveAlpha:SetScript("OnValueChanged", function(self, value)
+		value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
+		value = TRB.Functions.Number:RoundTo(value, 0, nil, true)
+		self.EditBox:SetText(value)
+		spec.displayBar.primary.inactiveAlpha = value
+		RefreshVisibilitySettings()
+	end)
+
+	if includeHealthVisibility and spec.displayBar.health ~= nil then
+		controls.sliders.healthInactiveAlpha = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityInactiveAlpha"],
+			0, 100, spec.displayBar.health.inactiveAlpha or 0, 1, 0,
+			oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord2, yCoord)
+		controls.sliders.healthInactiveAlpha.MinLabel:SetText("0%")
+		controls.sliders.healthInactiveAlpha.MaxLabel:SetText("100%")
+		controls.sliders.healthInactiveAlpha:SetScript("OnValueChanged", function(self, value)
+			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
+			value = TRB.Functions.Number:RoundTo(value, 0, nil, true)
+			self.EditBox:SetText(value)
+			spec.displayBar.health.inactiveAlpha = value
+			RefreshVisibilitySettings()
+		end)
+	end
+
+	yCoord = yCoord - 60
+	controls.sliders.primaryFadeDuration = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityFadeDuration"],
+		0, 10, spec.displayBar.primary.fadeDuration or 0, 0.25, 2,
+		oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord, yCoord)
+	controls.sliders.primaryFadeDuration:SetScript("OnValueChanged", function(self, value)
+		value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
+		value = TRB.Functions.Number:RoundTo(value, 2, nil, true)
+		self.EditBox:SetText(value)
+		spec.displayBar.primary.fadeDuration = value
+		RefreshVisibilitySettings()
+	end)
+
+	if includeHealthVisibility and spec.displayBar.health ~= nil then
+		controls.sliders.healthFadeDuration = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityFadeDuration"],
+			0, 10, spec.displayBar.health.fadeDuration or 0, 0.25, 2,
+			oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord2, yCoord)
+		controls.sliders.healthFadeDuration:SetScript("OnValueChanged", function(self, value)
+			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
+			value = TRB.Functions.Number:RoundTo(value, 2, nil, true)
+			self.EditBox:SetText(value)
+			spec.displayBar.health.fadeDuration = value
+			RefreshVisibilitySettings()
+		end)
+	end
+
+	yCoord = yCoord - 60
+	controls.sliders.primaryFadeDelay = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityFadeDelay"],
+		0, 10, spec.displayBar.primary.fadeDelay or 0, 0.25, 2,
+		oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord, yCoord)
+	controls.sliders.primaryFadeDelay:SetScript("OnValueChanged", function(self, value)
+		value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
+		value = TRB.Functions.Number:RoundTo(value, 2, nil, true)
+		self.EditBox:SetText(value)
+		spec.displayBar.primary.fadeDelay = value
+		RefreshVisibilitySettings()
+	end)
+
+	if includeHealthVisibility and spec.displayBar.health ~= nil then
+		controls.sliders.healthFadeDelay = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityFadeDelay"],
+			0, 10, spec.displayBar.health.fadeDelay or 0, 0.25, 2,
+			oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord2, yCoord)
+		controls.sliders.healthFadeDelay:SetScript("OnValueChanged", function(self, value)
+			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
+			value = TRB.Functions.Number:RoundTo(value, 2, nil, true)
+			self.EditBox:SetText(value)
+			spec.displayBar.health.fadeDelay = value
+			RefreshVisibilitySettings()
+		end)
+	end
+
 	-- Collect remaining visibility items, then place in two-column layout (left-to-right fill)
 	local visibilityItems = {}
 	if includeSecondaryVisibility then
@@ -4984,9 +5126,58 @@ function TRB.Functions.OptionsUi:GenerateBarDisplayOptions(parent, controls, spe
 			end
 		end)
 
+		-- Alpha and fade sliders for this visibility item
+		controls.sliders[item.key .. "ActiveAlpha"] = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityActiveAlpha"],
+			0, 100, spec.displayBar[displayBarKey].activeAlpha or 100, 1, 0,
+			oUi.sliderWidth, oUi.sliderHeight, xPos, yCoord - 115)
+		controls.sliders[item.key .. "ActiveAlpha"].MinLabel:SetText("0%")
+		controls.sliders[item.key .. "ActiveAlpha"].MaxLabel:SetText("100%")
+		controls.sliders[item.key .. "ActiveAlpha"]:SetScript("OnValueChanged", function(self, value)
+			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
+			value = TRB.Functions.Number:RoundTo(value, 0, nil, true)
+			self.EditBox:SetText(value)
+			spec.displayBar[displayBarKey].activeAlpha = value
+			RefreshVisibilitySettings()
+		end)
+
+		controls.sliders[item.key .. "InactiveAlpha"] = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityInactiveAlpha"],
+			0, 100, spec.displayBar[displayBarKey].inactiveAlpha or 0, 1, 0,
+			oUi.sliderWidth, oUi.sliderHeight, xPos, yCoord - 175)
+		controls.sliders[item.key .. "InactiveAlpha"].MinLabel:SetText("0%")
+		controls.sliders[item.key .. "InactiveAlpha"].MaxLabel:SetText("100%")
+		controls.sliders[item.key .. "InactiveAlpha"]:SetScript("OnValueChanged", function(self, value)
+			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
+			value = TRB.Functions.Number:RoundTo(value, 0, nil, true)
+			self.EditBox:SetText(value)
+			spec.displayBar[displayBarKey].inactiveAlpha = value
+			RefreshVisibilitySettings()
+		end)
+
+		controls.sliders[item.key .. "FadeDuration"] = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityFadeDuration"],
+			0, 10, spec.displayBar[displayBarKey].fadeDuration or 0, 0.25, 2,
+			oUi.sliderWidth, oUi.sliderHeight, xPos, yCoord - 235)
+		controls.sliders[item.key .. "FadeDuration"]:SetScript("OnValueChanged", function(self, value)
+			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
+			value = TRB.Functions.Number:RoundTo(value, 2, nil, true)
+			self.EditBox:SetText(value)
+			spec.displayBar[displayBarKey].fadeDuration = value
+			RefreshVisibilitySettings()
+		end)
+
+		controls.sliders[item.key .. "FadeDelay"] = TRB.Functions.OptionsUi:BuildSlider(parent, L["ShowBarVisibilityFadeDelay"],
+			0, 10, spec.displayBar[displayBarKey].fadeDelay or 0, 0.25, 2,
+			oUi.sliderWidth, oUi.sliderHeight, xPos, yCoord - 295)
+		controls.sliders[item.key .. "FadeDelay"]:SetScript("OnValueChanged", function(self, value)
+			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
+			value = TRB.Functions.Number:RoundTo(value, 2, nil, true)
+			self.EditBox:SetText(value)
+			spec.displayBar[displayBarKey].fadeDelay = value
+			RefreshVisibilitySettings()
+		end)
+
 		-- Advance yCoord after right column item or last item
 		if not isLeft or i == #visibilityItems then
-			yCoord = yCoord - 65
+			yCoord = yCoord - 315
 		end
 	end
 


### PR DESCRIPTION
## Overview

This PR adds alpha-based visibility with configurable fade transitions for all bars, and redesigns the visibility options tab from a monolithic vertical layout into an interactive table-based selection UI. Together, these changes give users per-bar control over active/inactive opacity and fade timing, presented through a cleaner, more scalable interface.

## Features

### Alpha-Based Bar Visibility with Fade Transitions

Bars now use opacity interpolation instead of binary Show/Hide. Each bar's visibility entry gains four new settings:

| Setting | Range | Default | Description |
|---------|-------|---------|-------------|
| Active Opacity | 0–100% | 100% | Opacity when visibility conditions are met |
| Inactive Opacity | 0–100% | 0% | Opacity when conditions are NOT met (>0 keeps the bar partially visible) |
| Fade Duration | 0–10s | 0s | How long the bar takes to fade out to inactive opacity |
| Fade Delay | 0–10s | 0s | How long to wait before fading begins |

**Behavior details:**
- Fade-in is always instant (snap to active opacity) for responsiveness
- Fade-out respects the configured duration and delay
- Bars with inactive opacity > 0% remain visible (and interactive) even when conditions aren't met
- During render transitions (e.g., bar reconstruction), alpha snaps to 0 instantly
- UIParent-attached bar text (Screen-anchored) receives explicit alpha from the primary bar group since it doesn't inherit from the bar frame hierarchy
- `PulseFrame` (bar flash) respects the current visibility alpha as a ceiling

### Table-Based Visibility Options UI

Replaces the old `GenerateBarDisplayOptions` (~780-line monolithic function) with `GenerateBarVisibilityOptions`, a table-driven selection UI matching the Bar Text tab pattern:

- **LibScrollingTable** with two visible columns: Bar name and Visibility status summary
- Clicking a row reveals a **detail panel** with that bar's visibility controls:
  - Multi-select dropdown for visibility conditions (Always, Never, or 18 grouped conditions across 5 categories)
  - Smooth Bar Animation checkbox (inline with the dropdown)
  - Active/Inactive Opacity sliders
  - Fade Duration/Fade Delay sliders
- Detail panel starts hidden until a row is selected
- Visibility column auto-resizes to fill available width

### Flash Settings Relocated

`GenerateFlashOptions` extracted as a standalone helper. Flash Alpha, Flash Period, and Flash Enabled are now rendered on the **primary resource bar tab** (where they logically belong) instead of the visibility tab. Affects 4 specs: BM Hunter, Shadow Priest, Balance Druid, Elemental Shaman.

## Implementation

### Core Systems

#### Bar.lua — BarGroup fade state
- New fields on `BarGroup`: `targetAlpha`, `currentAlpha`, `lastAlphaTime`, `fadeDuration`, `fadeDelayUntil`
- `SetTargetAlpha(target, duration, delay)` — sets fade parameters; no-ops if target unchanged
- `UpdateFade()` — per-tick linear interpolation; returns current alpha and whether still fading
- `Show()`/`Hide()` no longer manipulate alpha directly; alpha is owned by the visibility system n
- `BarNode:Show()` likewise stops overriding alpha (parent BarGroup manages it)

#### BarVisibility.lua — ProcessBars rewrite
- Three-phase processing: (1) evaluate conditions & compute target alpha, (2) interpolate fade, (3) apply alpha and show/hide
- `self.fading` flag keeps `IsDirty()` returning true while any bar is mid-fade, ensuring per-tick updates
- Container frame height collapse uses `currentAlpha > 0` instead of `isVisible` so partially-visible bars retain layout space
- `HideAllEntries`/`HideAllBarGroups` reset alpha state to prevent stale fade-in on next show

#### Bar.lua — PulseFrame alpha ceiling
- `PulseFrame` accepts optional `maxAlpha` parameter; flash animation is scaled by the bar's current visibility alpha

#### BarText.lua — UIParent text alpha
- New `GetPrimaryBarAlpha()` helper returns the primary bar group's current alpha
- `Hide()` and `Show()` apply this alpha to UIParent-attached text frames that don't inherit from the bar frame hierarchy

### Settings & Migration

#### Settings.lua — Type annotations
- Added `@field` entries for `activeAlpha`, `inactiveAlpha`, `fadeDuration`, `fadeDelay` on `trbBarVisibilityEntry`

#### Settings.lua — Defaults & port-forward
- Default settings for all `displayBar` entries (primary, secondary, health, utility) include the 4 new fields
- `PortForwardSettings()` migration backfills existing users: `activeAlpha=100`, `inactiveAlpha=0`, `fadeDuration=0`, `fadeDelay=0` — matching previous binary behavior

### Options UI

#### OptionsUi.lua
- **Removed**: `GenerateBarDisplayOptions` (~780 lines, 16 parameters)
- **Added**: `GenerateFlashOptions` (flash alpha/period/enabled — standalone helper)
- **Added**: `GenerateBarVisibilityOptions` (table + detail panel, 13 parameters — 3 flash params removed)
- Dropdown display text uses a single persistent hook with swappable text-provider function (fixes chained-hook bug)
- Slider `OnValueChanged` scripts are bound *before* `SetValue` calls (fixes value corruption when switching rows)

### Class Modules

#### 13 `ClassModules/*.lua` files
- `SetAlpha(1.0)` calls in `UpdateResourceBar` replaced with `SetAlpha(barGroups.primary.currentAlpha or 1.0)` to respect visibility alpha during bar updates

#### 13 `ClassModules/Options/*Options.lua` files
- All 40 spec visibility panels updated from `GenerateBarDisplayOptions` to `GenerateBarVisibilityOptions`
- 4 specs gained `GenerateFlashOptions` on their primary resource bar tab
- 4 Druid specs: form switching / combo points checkboxes moved above the visibility table

### Localization
- 14 new strings in enUS.lua: opacity slider labels/tooltips, fade duration/delay labels/tooltips, table headers, detail panel labels, flash section header