### PR TITLE
Add "Collapse border width" option for multi-node bar groups

### DIFF
--- a/Classes/Bar.lua
+++ b/Classes/Bar.lua
@@ -662,7 +662,7 @@ function TRB.Classes.BarGroup:RebuildNodes(displayNodes, settings)
 
 	-- Set node count and apply layout
 	self:SetNodeCount(displayNodes)
-	self:SetLayout(settings.comboPoints.spacing, TRB.Functions.Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
+	self:SetLayout(TRB.Functions.Bar:GetEffectiveSpacing(settings.comboPoints), TRB.Functions.Bar:GetMatchWidth(settings.comboPoints), "HORIZONTAL")
 	self:Show()
 
 	-- Use effectiveWidth (CDM-matched) if available, otherwise fall back to settings.bar.width

--- a/Functions/Bar.lua
+++ b/Functions/Bar.lua
@@ -138,6 +138,18 @@ local function GetComboPointNodeWidth(settings)
 	return 0
 end
 
+---Returns the effective spacing for a bar group, accounting for collapseBorderWidth.
+---When collapseBorderWidth is enabled, adjacent node borders overlap by using negative
+---spacing equal to the border width, producing pixel-perfect single-width borders.
+---@param barSettings table # The bar's settings (e.g., settings.comboPoints or settings.bars.<key>)
+---@return number # The effective spacing value to use for layout
+function TRB.Functions.Bar:GetEffectiveSpacing(barSettings)
+	if barSettings and barSettings.collapseBorderWidth then
+		return -(barSettings.border or 0)
+	end
+	return (barSettings and barSettings.spacing) or 0
+end
+
 ---Calculates the total rendered width of a multi-node bar group (e.g., combo points).
 ---For multi-node bars, `barSettings.width` is per-node width, not total width.
 ---The total width is:  nodeCount * nodeWidth + (nodeCount - 1) * spacing
@@ -180,7 +192,7 @@ function TRB.Functions.Bar:GetMultiNodeBarTotalWidth(barKey, barSettings, barGro
 		nodeCount = barGroup.nodeCount
 	end
 	local nodeWidth = barSettings.width or 10
-	local nodeSpacing = barSettings.spacing or 2
+	local nodeSpacing = self:GetEffectiveSpacing(barSettings)
 	return (nodeWidth * nodeCount) + (nodeSpacing * (nodeCount - 1))
 end
 
@@ -2493,7 +2505,7 @@ function TRB.Functions.Bar:ConstructAnchoredBarGroup(settings, anchorGroup, targ
 
 	-- Set layout parameters (use anchor.matchWidth with fallback)
 	local matchWidth = self:GetMatchWidth(groupSettings)
-	targetGroup:SetLayout(groupSettings.spacing or 0, matchWidth, "HORIZONTAL")
+	targetGroup:SetLayout(self:GetEffectiveSpacing(groupSettings), matchWidth, "HORIZONTAL")
 
 	-- Set frame strata
 	targetGroup:SetFrameStrata(strata)

--- a/Functions/News.lua
+++ b/Functions/News.lua
@@ -15,6 +15,7 @@ local content = [====[
 # 12.0.1.35-release (2026-03-14)
 ## General
 
+- [#696](#696) Allow bar groups that are made up of many individual nodes (e.g. Combo Points) to be configured to have their node borders overlap each other.
 - Fix an issue where trying to reset bar text to defaults when you had no current bar text entries would cause Lua errors.
 
 ---

--- a/Functions/Settings.lua
+++ b/Functions/Settings.lua
@@ -5290,7 +5290,7 @@ function TRB.Functions.Settings:DefaultUtilityBarDimensions(classic)
 			yPos = 4,
 			border = 1,
 			spacing = 14,
-			collapseBorderWidth = true,
+			collapseBorderWidth = false,
 			relativeTo = "BOTTOM",
 			relativeToName = L["PositionBelowMiddle"],
 			fullWidth = true,

--- a/Functions/Settings.lua
+++ b/Functions/Settings.lua
@@ -4986,7 +4986,7 @@ function TRB.Functions.Settings:DefaultComboPointsDimensions(classic)
 			yPos = 4,
 			border = 1,
 			spacing = 14,
-			collapseBorderWidth = true,
+			collapseBorderWidth = false,
 			relativeTo = "TOP",
 			relativeToName = L["PositionAboveMiddle"],
 			fullWidth = true,

--- a/Functions/Settings.lua
+++ b/Functions/Settings.lua
@@ -5228,7 +5228,7 @@ function TRB.Functions.Settings:DefaultDefensivesBarDimensions(classic)
 			yPos = 4,
 			border = 1,
 			spacing = 14,
-			collapseBorderWidth = true,
+			collapseBorderWidth = false,
 			relativeTo = "TOP",
 			relativeToName = L["PositionAboveMiddle"],
 			fullWidth = true,

--- a/Functions/Settings.lua
+++ b/Functions/Settings.lua
@@ -4854,6 +4854,31 @@ function TRB.Functions.Settings:PortForwardSettings()
 
 		TwintopInsanityBarSettings.core.displayText.migrations.healthBarText = true
 	end
+
+	-- Migrate collapseBorderWidth for all specs
+	-- If spacing was 0 (or nil), enable collapse by default (the new behavior).
+	-- If spacing was > 0, preserve the user's explicit spacing and disable collapse.
+	for _, className in ipairs(classes) do
+		if TwintopInsanityBarSettings and TwintopInsanityBarSettings[className] then
+			for specName, specSettings in pairs(TwintopInsanityBarSettings[className]) do
+				if type(specSettings) == "table" then
+					-- Migrate comboPoints (secondary bar)
+					if specSettings.comboPoints and specSettings.comboPoints.collapseBorderWidth == nil then
+						specSettings.comboPoints.collapseBorderWidth = (specSettings.comboPoints.spacing or 0) == 0
+					end
+
+					-- Migrate custom bars (bars.<key>)
+					if specSettings.bars then
+						for barKey, barSettings in pairs(specSettings.bars) do
+							if type(barSettings) == "table" and barSettings.collapseBorderWidth == nil and barSettings.spacing ~= nil then
+								barSettings.collapseBorderWidth = (barSettings.spacing or 0) == 0
+							end
+						end
+					end
+				end
+			end
+		end
+	end
 end
 
 function TRB.Functions.Settings:CleanupSettings(oldSettings)
@@ -4961,6 +4986,7 @@ function TRB.Functions.Settings:DefaultComboPointsDimensions(classic)
 			yPos = 4,
 			border = 1,
 			spacing = 14,
+			collapseBorderWidth = true,
 			relativeTo = "TOP",
 			relativeToName = L["PositionAboveMiddle"],
 			fullWidth = true,
@@ -4982,6 +5008,7 @@ function TRB.Functions.Settings:DefaultComboPointsDimensions(classic)
 		yPos = 0,
 		border = 2,
 		spacing = 0,
+		collapseBorderWidth = true,
 		relativeTo ="TOP",
 		relativeToName = L["PositionAboveMiddle"],
 		fullWidth = true,
@@ -5021,6 +5048,7 @@ function TRB.Functions.Settings:DefaultManaBarDimensions(classic)
 			yPos = 4,
 			border = 1,
 			spacing = 0,
+			collapseBorderWidth = true,
 			relativeTo = "TOP",
 			relativeToName = L["PositionAboveMiddle"],
 			fullWidth = true,
@@ -5042,6 +5070,7 @@ function TRB.Functions.Settings:DefaultManaBarDimensions(classic)
 		yPos = 0,
 		border = 2,
 		spacing = 0,
+		collapseBorderWidth = true,
 		relativeTo = "TOP",
 		relativeToName = L["PositionAboveMiddle"],
 		fullWidth = true,
@@ -5084,6 +5113,7 @@ function TRB.Functions.Settings:DefaultCustomBarDimensions(classic)
 			yPos = 4,
 			border = 1,
 			spacing = 0,
+			collapseBorderWidth = true,
 			relativeTo = "TOP",
 			relativeToName = L["PositionAboveMiddle"],
 			fullWidth = true,
@@ -5105,6 +5135,7 @@ function TRB.Functions.Settings:DefaultCustomBarDimensions(classic)
 		yPos = 0,
 		border = 2,
 		spacing = 0,
+		collapseBorderWidth = true,
 		relativeTo = "TOP",
 		relativeToName = L["PositionAboveMiddle"],
 		fullWidth = true,
@@ -5197,6 +5228,7 @@ function TRB.Functions.Settings:DefaultDefensivesBarDimensions(classic)
 			yPos = 4,
 			border = 1,
 			spacing = 14,
+			collapseBorderWidth = true,
 			relativeTo = "TOP",
 			relativeToName = L["PositionAboveMiddle"],
 			fullWidth = true,
@@ -5218,6 +5250,7 @@ function TRB.Functions.Settings:DefaultDefensivesBarDimensions(classic)
 		yPos = 0,
 		border = 2,
 		spacing = 0,
+		collapseBorderWidth = true,
 		relativeTo = "TOP",
 		relativeToName = L["PositionAboveMiddle"],
 		fullWidth = true,
@@ -5257,6 +5290,7 @@ function TRB.Functions.Settings:DefaultUtilityBarDimensions(classic)
 			yPos = 4,
 			border = 1,
 			spacing = 14,
+			collapseBorderWidth = true,
 			relativeTo = "BOTTOM",
 			relativeToName = L["PositionBelowMiddle"],
 			fullWidth = true,
@@ -5278,6 +5312,7 @@ function TRB.Functions.Settings:DefaultUtilityBarDimensions(classic)
 		yPos = 0,
 		border = 2,
 		spacing = 0,
+		collapseBorderWidth = true,
 		relativeTo = "BOTTOM",
 		relativeToName = L["PositionBelowMiddle"],
 		fullWidth = true,

--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -2173,3 +2173,7 @@ L["BarVisibilityBarNameMana"] = "Mana Bar"
 L["BarVisibilityDetailHeader"] = "%s Settings"
 L["BarVisibilityConditionsLabel"] = "Visibility"
 L["FlashSectionHeader"] = "Bar Flash"
+
+-- Collapse Border Width
+L["CollapseBorderWidth"] = "Collapse border width"
+L["CollapseBorderWidthTooltip"] = "When enabled, overlaps adjacent node borders so they appear as a single border width instead of doubling up. This disables the spacing slider and sets node spacing to the negative of the border width."

--- a/Options/OptionsUi.lua
+++ b/Options/OptionsUi.lua
@@ -2278,6 +2278,59 @@ function TRB.Functions.OptionsUi:ToggleCheckboxEnabled(checkbox, enable)
 	end
 end
 
+---Enables or disables a slider built with BuildSlider, including its EditBox and labels.
+---@param slider Slider # The slider frame returned by BuildSlider
+---@param enable boolean # Whether to enable or disable the slider
+function TRB.Functions.OptionsUi:ToggleSliderEnabled(slider, enable)
+	if enable then
+		slider:Enable()
+		slider:SetAlpha(1.0)
+		slider:EnableMouseWheel(true)
+		if slider.EditBox then
+			slider.EditBox:Enable()
+			slider.EditBox:EnableMouseWheel(true)
+		end
+		if slider.Plus then
+			slider.Plus:Enable()
+		end
+		if slider.Minus then
+			slider.Minus:Enable()
+		end
+		if slider.Title then
+			slider.Title:SetFontObject(GameFontNormal)
+		end
+		if slider.MinLabel then
+			slider.MinLabel:SetFontObject(GameFontHighlightSmall)
+		end
+		if slider.MaxLabel then
+			slider.MaxLabel:SetFontObject(GameFontHighlightSmall)
+		end
+	else
+		slider:Disable()
+		slider:SetAlpha(0.5)
+		slider:EnableMouseWheel(false)
+		if slider.EditBox then
+			slider.EditBox:Disable()
+			slider.EditBox:EnableMouseWheel(false)
+		end
+		if slider.Plus then
+			slider.Plus:Disable()
+		end
+		if slider.Minus then
+			slider.Minus:Disable()
+		end
+		if slider.Title then
+			slider.Title:SetFontObject(GameFontDisable)
+		end
+		if slider.MinLabel then
+			slider.MinLabel:SetFontObject(GameFontDisableSMALL)
+		end
+		if slider.MaxLabel then
+			slider.MaxLabel:SetFontObject(GameFontDisableSMALL)
+		end
+	end
+end
+
 function TRB.Functions.OptionsUi:ToggleCheckboxOnOff(checkbox, enable, changeText)
 	if enable then
 		getglobal(checkbox:GetName().."Text"):SetTextColor(0, 1, 0)
@@ -2898,6 +2951,28 @@ function TRB.Functions.OptionsUi:GenerateAncillaryBarDimensionsOptions(parent, c
 				TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
 			end
 		end)
+
+		-- Collapse border width checkbox (below spacing slider)
+		controls.checkBoxes.collapseBorderWidth = CreateFrame("CheckButton", "TwintopResourceBar_" .. namePrefix .. "_" .. settingKey .. "CollapseBorderWidth", parent, "ChatConfigCheckButtonTemplate")
+		local cbCollapse = controls.checkBoxes.collapseBorderWidth
+		cbCollapse:SetPoint("TOPLEFT", oUi.xCoord2, yCoord - 40)
+		getglobal(cbCollapse:GetName() .. 'Text'):SetText(L["CollapseBorderWidth"])
+		---@diagnostic disable-next-line: inject-field
+		cbCollapse.tooltip = L["CollapseBorderWidthTooltip"]
+		cbCollapse:SetChecked(spec.comboPoints.collapseBorderWidth)
+		TRB.Functions.OptionsUi:ToggleSliderEnabled(controls.comboPointSpacing, not spec.comboPoints.collapseBorderWidth)
+		cbCollapse:SetScript("OnClick", function(self, ...)
+			spec.comboPoints.collapseBorderWidth = self:GetChecked()
+			TRB.Functions.OptionsUi:ToggleSliderEnabled(controls.comboPointSpacing, not spec.comboPoints.collapseBorderWidth)
+
+			if TRB.Data.character.classId == 11 or -- HACK: Workaround for Druids sharing settings across forms
+			(TRB.Data.character.classId == classId and TRB.Data.character.specId == specId) or
+			(classId == nil and specId == nil and TRB.Data.settings.core.global[TRB.Data.character.className][TRB.Data.character.specName].bar) then
+				if TRB.Frames.barGroups ~= nil then
+					TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
+				end
+			end
+		end)
 	end
 
 	-- Anchor To dropdown + Match Width checkbox
@@ -3283,6 +3358,24 @@ function TRB.Functions.OptionsUi:GenerateCustomBarDimensionsOptions(parent, cont
 			value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
 			barSettings.spacing = value
 			
+			if TRB.Frames.barGroups ~= nil then
+				TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
+			end
+		end)
+
+		-- Collapse border width checkbox (below spacing slider)
+		controls[barTypeDef.key .. "CollapseBorderWidth"] = CreateFrame("CheckButton", "TwintopResourceBar_" .. namePrefix .. "_" .. barTypeDef.key .. "CollapseBorderWidth", parent, "ChatConfigCheckButtonTemplate")
+		local cbCollapse = controls[barTypeDef.key .. "CollapseBorderWidth"]
+		cbCollapse:SetPoint("TOPLEFT", oUi.xCoord2, yCoord - 40)
+		getglobal(cbCollapse:GetName() .. 'Text'):SetText(L["CollapseBorderWidth"])
+		---@diagnostic disable-next-line: inject-field
+		cbCollapse.tooltip = L["CollapseBorderWidthTooltip"]
+		cbCollapse:SetChecked(barSettings.collapseBorderWidth)
+		TRB.Functions.OptionsUi:ToggleSliderEnabled(controls[barTypeDef.key .. "Spacing"], not barSettings.collapseBorderWidth)
+		cbCollapse:SetScript("OnClick", function(self, ...)
+			barSettings.collapseBorderWidth = self:GetChecked()
+			TRB.Functions.OptionsUi:ToggleSliderEnabled(controls[barTypeDef.key .. "Spacing"], not barSettings.collapseBorderWidth)
+
 			if TRB.Frames.barGroups ~= nil then
 				TRB.Functions.Bar:ApplyBarGroupsLayout(TRB.Data.specCache[TRB.Data.character.compositeKey].settings, TRB.Frames.barGroups)
 			end

--- a/Options/OptionsUi.lua
+++ b/Options/OptionsUi.lua
@@ -2323,10 +2323,10 @@ function TRB.Functions.OptionsUi:ToggleSliderEnabled(slider, enable)
 			slider.Title:SetFontObject(GameFontDisable)
 		end
 		if slider.MinLabel then
-			slider.MinLabel:SetFontObject(GameFontDisableSMALL)
+			slider.MinLabel:SetFontObject(GameFontDisableSmall)
 		end
 		if slider.MaxLabel then
-			slider.MaxLabel:SetFontObject(GameFontDisableSMALL)
+			slider.MaxLabel:SetFontObject(GameFontDisableSmall)
 		end
 	end
 end


### PR DESCRIPTION
Closes #696

### Problem

When multi-node bar groups (Combo Points, Chi, Defensive charges, etc.) are configured with zero spacing, adjacent node borders render side-by-side, producing a visually doubled border that looks inconsistent compared to a single continuous bar.

### Solution

Adds a **Collapse border width** checkbox beneath the spacing slider for all multi-node bar groups (secondary/combo points bars, and custom bars registered via BarTypeRegistry such as Stagger, Defensives, Utility, and Mana). When enabled:

- The spacing slider is fully disabled (including its +/− buttons, edit box, and mouse wheel)
- Layout spacing is set to the negative of the node border width, causing adjacent borders to overlap into a single pixel-perfect border
- The visual result is seamless single-width borders between nodes

### Migration behavior

- **Existing users with `spacing = 0`**: automatically opt in to collapse (same visual result, now with proper border overlap)
- **Existing users with `spacing > 0`**: collapse is disabled, spacing preserved as-is
- **New installs**: collapse enabled by default in all dimension factories