### PR TITLE
Holy Priest Audio Cue Improvements

### DIFF
--- a/ClassModules/Options/PriestOptions.lua
+++ b/ClassModules/Options/PriestOptions.lua
@@ -670,13 +670,58 @@ local function HolyLoadDefaultSettings(includeBarText, classic)
 				name = L["PriestAudioSurgeOfLight"],
 				enabled=false,
 				sound="Interface\\Addons\\TwintopInsanityBar\\Sounds\\BoxingArenaSound.ogg",
-				soundName = L["LSMSoundBoxingArenaGong"]
+				soundName = L["LSMSoundBoxingArenaGong"],
+				configuration = {
+					requireSpiritwellTalent = false
+				}
 			},
 			lightweaver={
-				name = L["PriestHolyAudioLightweaver"],
+				name = L["PriestHolyAudioLightweaverThreshold1"],
 				enabled=false,
 				sound="Interface\\Addons\\TwintopInsanityBar\\Sounds\\AirHorn.ogg",
-				soundName = L["LSMSoundAirHorn"]
+				soundName = L["LSMSoundAirHorn"],
+				configuration = {
+					thresholdValue = 1
+				}
+			},
+			lightweaverMaxStacks={
+				name = L["PriestHolyAudioLightweaverThreshold2"],
+				enabled=false,
+				sound="Interface\\Addons\\TwintopInsanityBar\\Sounds\\AirHorn.ogg",
+				soundName = L["LSMSoundAirHorn"],
+				configuration = {
+					thresholdValue = 4
+				}
+			},
+			holyWordChastiseReady={
+				name = L["PriestHolyAudioHolyWordChastiseReady"],
+				enabled=false,
+				sound="Interface\\Addons\\TwintopInsanityBar\\Sounds\\BoxingArenaSound.ogg",
+				soundName = L["LSMSoundBoxingArenaGong"]
+			},
+			holyWordSerenityCharge1={
+				name = L["PriestHolyAudioHolyWordSerenityCharge1"],
+				enabled=false,
+				sound="Interface\\Addons\\TwintopInsanityBar\\Sounds\\BoxingArenaSound.ogg",
+				soundName = L["LSMSoundBoxingArenaGong"]
+			},
+			holyWordSerenityCharge2={
+				name = L["PriestHolyAudioHolyWordSerenityCharge2"],
+				enabled=false,
+				sound="Interface\\Addons\\TwintopInsanityBar\\Sounds\\BoxingArenaSound.ogg",
+				soundName = L["LSMSoundBoxingArenaGong"]
+			},
+			holyWordSanctifyCharge1={
+				name = L["PriestHolyAudioHolyWordSanctifyCharge1"],
+				enabled=false,
+				sound="Interface\\Addons\\TwintopInsanityBar\\Sounds\\BoxingArenaSound.ogg",
+				soundName = L["LSMSoundBoxingArenaGong"]
+			},
+			holyWordSanctifyCharge2={
+				name = L["PriestHolyAudioHolyWordSanctifyCharge2"],
+				enabled=false,
+				sound="Interface\\Addons\\TwintopInsanityBar\\Sounds\\BoxingArenaSound.ogg",
+				soundName = L["LSMSoundBoxingArenaGong"]
 			}
 		},
 		textures = TRB.Functions.Settings:DefaultTextures(false, nil, {
@@ -1857,8 +1902,54 @@ local function HolyConstructAudioAndTrackingPanel(parent)
 	--yCoord = TRB.Functions.OptionsUi:CreateAudioOption(parent, controls, "innervate", spec, classId, specId, yCoord, L["HealerAudioCheckboxInnervate"], L["HealerAudioCheckboxInnervateTooltip"])
 
 	yCoord = TRB.Functions.OptionsUi:CreateAudioOption(parent, controls, "surgeOfLight", spec, classId, specId, yCoord, L["PriestAudioCheckboxSurgeOfLight"], L["PriestAudioCheckboxSurgeOfLightTooltip"])
-	
-	yCoord = TRB.Functions.OptionsUi:CreateAudioOption(parent, controls, "lightweaver", spec, classId, specId, yCoord, L["PriestHolyAudioCheckboxLightweaver"], L["PriestHolyAudioCheckboxLightweaverTooltip"])
+
+	-- Spiritwell-only restriction checkbox for Surge of Light
+	spec.audio.surgeOfLight.configuration = spec.audio.surgeOfLight.configuration or {}
+	controls.checkBoxes.surgeOfLightSpiritwellOnly = CreateFrame("CheckButton", nil, parent, "ChatConfigCheckButtonTemplate")
+	f = controls.checkBoxes.surgeOfLightSpiritwellOnly
+	f:SetPoint("TOPLEFT", oUi.xCoord + 20, yCoord+15)
+	f:SetChecked(spec.audio.surgeOfLight.configuration.requireSpiritwellTalent)
+	f.Text:SetText(L["PriestAudioCheckboxSurgeOfLightSpiritwellOnly"])
+	f.tooltip = L["PriestAudioCheckboxSurgeOfLightSpiritwellOnlyTooltip"]
+	f:SetScript("OnClick", function(self, ...)
+		spec.audio.surgeOfLight.configuration.requireSpiritwellTalent = self:GetChecked()
+	end)
+	yCoord = yCoord - 10
+
+	local yCoord2 = yCoord - 20
+	yCoord = TRB.Functions.OptionsUi:CreateAudioOption(parent, controls, "lightweaver", spec, classId, specId, yCoord, L["PriestHolyAudioCheckboxLightweaverThreshold1"], L["PriestHolyAudioCheckboxLightweaverThreshold1Tooltip"])
+
+	spec.audio.lightweaver.configuration = spec.audio.lightweaver.configuration or {}
+	controls.priest_lightweaverSlider = TRB.Functions.OptionsUi:BuildSlider(parent, L["PriestHolyAudioLightweaverThresholdSliderTitle"], 1, 4, spec.audio["lightweaver"].configuration.thresholdValue, 1, 0,
+									oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord2, yCoord2)
+	controls.priest_lightweaverSlider:SetScript("OnValueChanged", function(self, value)
+		value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
+		value = TRB.Functions.Number:RoundTo(value, 0, nil, true)
+		self.EditBox:SetText(value)
+		spec.audio["lightweaver"].configuration.thresholdValue = value
+	end)
+
+	yCoord2 = yCoord - 20
+	yCoord = TRB.Functions.OptionsUi:CreateAudioOption(parent, controls, "lightweaverMaxStacks", spec, classId, specId, yCoord, L["PriestHolyAudioCheckboxLightweaverThreshold2"], L["PriestHolyAudioCheckboxLightweaverThreshold2Tooltip"])
+
+	spec.audio.lightweaverMaxStacks.configuration = spec.audio.lightweaverMaxStacks.configuration or {}
+	controls.priest_lightweaverMaxStacksSlider = TRB.Functions.OptionsUi:BuildSlider(parent, L["PriestHolyAudioLightweaverThresholdSliderTitle"], 1, 4, spec.audio["lightweaverMaxStacks"].configuration.thresholdValue, 1, 0,
+									oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord2, yCoord2)
+	controls.priest_lightweaverMaxStacksSlider:SetScript("OnValueChanged", function(self, value)
+		value = TRB.Functions.OptionsUi:EditBoxSetTextMinMax(self, value)
+		value = TRB.Functions.Number:RoundTo(value, 0, nil, true)
+		self.EditBox:SetText(value)
+		spec.audio["lightweaverMaxStacks"].configuration.thresholdValue = value
+	end)
+
+	controls.textSection = TRB.Functions.OptionsUi:BuildSectionHeader(parent, L["PriestHolyAudioHolyWordsHeader"], oUi.xCoord, yCoord)
+	yCoord = yCoord - 30
+
+	yCoord = TRB.Functions.OptionsUi:CreateAudioOption(parent, controls, "holyWordChastiseReady", spec, classId, specId, yCoord, L["PriestHolyAudioCheckboxHolyWordChastiseReady"], L["PriestHolyAudioCheckboxHolyWordChastiseReadyTooltip"])
+	yCoord = TRB.Functions.OptionsUi:CreateAudioOption(parent, controls, "holyWordSerenityCharge1", spec, classId, specId, yCoord, L["PriestHolyAudioCheckboxHolyWordSerenityCharge1"], L["PriestHolyAudioCheckboxHolyWordSerenityCharge1Tooltip"])
+	yCoord = TRB.Functions.OptionsUi:CreateAudioOption(parent, controls, "holyWordSerenityCharge2", spec, classId, specId, yCoord, L["PriestHolyAudioCheckboxHolyWordSerenityCharge2"], L["PriestHolyAudioCheckboxHolyWordSerenityCharge2Tooltip"])
+	yCoord = TRB.Functions.OptionsUi:CreateAudioOption(parent, controls, "holyWordSanctifyCharge1", spec, classId, specId, yCoord, L["PriestHolyAudioCheckboxHolyWordSanctifyCharge1"], L["PriestHolyAudioCheckboxHolyWordSanctifyCharge1Tooltip"])
+	yCoord = TRB.Functions.OptionsUi:CreateAudioOption(parent, controls, "holyWordSanctifyCharge2", spec, classId, specId, yCoord, L["PriestHolyAudioCheckboxHolyWordSanctifyCharge2"], L["PriestHolyAudioCheckboxHolyWordSanctifyCharge2Tooltip"])
 end
 
 local function HolyConstructBarTextDisplayPanel(parent, cache)

--- a/ClassModules/Priest.lua
+++ b/ClassModules/Priest.lua
@@ -247,7 +247,11 @@ local function FillSpecializationCache()
 	specCache.priest_holy.snapshotData.audio = {
 		innervateCue = false,
 		lightweaverCue = false,
+		lightweaverMaxStacksCue = false,
 		surgeOfLightPlayed = false,
+		holyWordChastisePrevCharges = nil,
+		holyWordSerenityPrevCharges = nil,
+		holyWordSanctifyPrevCharges = nil,
 	}
 	---@type TRB.Classes.Snapshot
 	specCache.priest_holy.snapshotData.snapshots[spells.apotheosis.id] = TRB.Classes.Snapshot:New(spells.apotheosis, nil, "sometimes")
@@ -1495,8 +1499,16 @@ local function HandleSpellEvents(self, event, ...)
 				if snapshotData.attributes.surgeOfLightActive ~= true then
 					local specSettings = TRB.Data.settings.priest[TRB.Data.character.specName]
 					if specSettings.audio.surgeOfLight.enabled and not snapshotData.audio.surgeOfLightPlayed then
-						PlaySoundFile(specSettings.audio.surgeOfLight.sound, TRB.Data.settings.core.audio.channel.channel)
-						snapshotData.audio.surgeOfLightPlayed = true
+						local shouldPlay = true
+						if specSettings.audio.surgeOfLight.configuration and specSettings.audio.surgeOfLight.configuration.requireSpiritwellTalent then
+							if not talents or not talents:IsTalentActive(spells.spiritwell) then
+								shouldPlay = false
+							end
+						end
+						if shouldPlay then
+							PlaySoundFile(specSettings.audio.surgeOfLight.sound, TRB.Data.settings.core.audio.channel.channel)
+							snapshotData.audio.surgeOfLightPlayed = true
+						end
 					end
 				end
 				snapshotData.attributes.surgeOfLightActive = true
@@ -2001,6 +2013,81 @@ local function UpdateResourceBar()
 				end
 			end
 		end
+
+		-- Lightweaver audio cues (independent of bar visibility)
+		do
+			local lightweaverStacks = snapshots[spells.lightweaver.id].buff.applications or 0
+			local audioChannel = TRB.Data.settings.core.audio.channel.channel
+
+			-- Threshold 1 cue: fires when stacks == configured value
+			local threshold1Value = specSettings.audio.lightweaver.configuration.thresholdValue
+			if lightweaverStacks == threshold1Value then
+				if specSettings.audio.lightweaver ~= nil and specSettings.audio.lightweaver.enabled and not snapshotData.audio.lightweaverCue then
+					PlaySoundFile(specSettings.audio.lightweaver.sound, audioChannel)
+					snapshotData.audio.lightweaverCue = true
+				end
+			else
+				snapshotData.audio.lightweaverCue = false
+			end
+
+			-- Threshold 2 cue: fires when stacks == configured value
+			local threshold2Value = specSettings.audio.lightweaverMaxStacks.configuration.thresholdValue
+			if lightweaverStacks == threshold2Value then
+				if specSettings.audio.lightweaverMaxStacks ~= nil and specSettings.audio.lightweaverMaxStacks.enabled and not snapshotData.audio.lightweaverMaxStacksCue then
+					PlaySoundFile(specSettings.audio.lightweaverMaxStacks.sound, audioChannel)
+					snapshotData.audio.lightweaverMaxStacksCue = true
+				end
+			else
+				snapshotData.audio.lightweaverMaxStacksCue = false
+			end
+		end
+
+		-- Holy Word charge-ready audio cues (independent of bar visibility, combat-only)
+		do
+			local chastiseCharges = snapshots[spells.holyWordChastise.id].cooldown.charges or 0
+			local serenityCharges = snapshots[spells.holyWordSerenity.id].cooldown.charges or 0
+			local sanctifyCharges = snapshots[spells.holyWordSanctify.id].cooldown.charges or 0
+			local audioChannel = TRB.Data.settings.core.audio.channel.channel
+
+			-- Chastise: single charge, fire on 0->1 transition
+			if snapshotData.audio.holyWordChastisePrevCharges ~= nil then
+				if TRB.Data.character.inCombat and chastiseCharges > snapshotData.audio.holyWordChastisePrevCharges then
+					if specSettings.audio.holyWordChastiseReady ~= nil and specSettings.audio.holyWordChastiseReady.enabled then
+						PlaySoundFile(specSettings.audio.holyWordChastiseReady.sound, audioChannel)
+					end
+				end
+			end
+			snapshotData.audio.holyWordChastisePrevCharges = chastiseCharges
+
+			-- Serenity: up to 2 charges with Miracle Worker
+			if snapshotData.audio.holyWordSerenityPrevCharges ~= nil then
+				if TRB.Data.character.inCombat and serenityCharges > snapshotData.audio.holyWordSerenityPrevCharges then
+					local prevCharges = snapshotData.audio.holyWordSerenityPrevCharges
+					-- Fire highest applicable cue (charge 2 takes priority if both thresholds crossed)
+					if serenityCharges >= 2 and prevCharges < 2 and specSettings.audio.holyWordSerenityCharge2 ~= nil and specSettings.audio.holyWordSerenityCharge2.enabled then
+						PlaySoundFile(specSettings.audio.holyWordSerenityCharge2.sound, audioChannel)
+					elseif serenityCharges >= 1 and prevCharges < 1 and specSettings.audio.holyWordSerenityCharge1 ~= nil and specSettings.audio.holyWordSerenityCharge1.enabled then
+						PlaySoundFile(specSettings.audio.holyWordSerenityCharge1.sound, audioChannel)
+					end
+				end
+			end
+			snapshotData.audio.holyWordSerenityPrevCharges = serenityCharges
+
+			-- Sanctify: up to 2 charges with Miracle Worker
+			if snapshotData.audio.holyWordSanctifyPrevCharges ~= nil then
+				if TRB.Data.character.inCombat and sanctifyCharges > snapshotData.audio.holyWordSanctifyPrevCharges then
+					local prevCharges = snapshotData.audio.holyWordSanctifyPrevCharges
+					-- Fire highest applicable cue (charge 2 takes priority if both thresholds crossed)
+					if sanctifyCharges >= 2 and prevCharges < 2 and specSettings.audio.holyWordSanctifyCharge2 ~= nil and specSettings.audio.holyWordSanctifyCharge2.enabled then
+						PlaySoundFile(specSettings.audio.holyWordSanctifyCharge2.sound, audioChannel)
+					elseif sanctifyCharges >= 1 and prevCharges < 1 and specSettings.audio.holyWordSanctifyCharge1 ~= nil and specSettings.audio.holyWordSanctifyCharge1.enabled then
+						PlaySoundFile(specSettings.audio.holyWordSanctifyCharge1.sound, audioChannel)
+					end
+				end
+			end
+			snapshotData.audio.holyWordSanctifyPrevCharges = sanctifyCharges
+		end
+
 		TRB.Functions.BarText:UpdateResourceBarText(specCacheSettings, refreshText)
 	elseif TRB.Data.character.specId == 3 then
 		local spells = spellsData.spells --[[@as TRB.Classes.Priest.ShadowSpells]]

--- a/Functions/News.lua
+++ b/Functions/News.lua
@@ -12,6 +12,17 @@ local content = [====[
 
 ---
 
+# 12.0.1.38-release (2026-03-17)
+## Priest
+### Holy
+
+- Fix Lightweaver audio cue not playing when enabled (setting existed but had no runtime code).
+- Add audio cue option for reaching maximum Lightweaver stacks.
+- Add audio cue options for when Holy Word: Chastise, Serenity, and Sanctify come off cooldown (per-charge). These only play during combat.
+- Add an optional restriction for the Surge of Light audio cue to only play when the Spiritwell talent is active.
+
+---
+
 # 12.0.1.37-release (2026-03-17)
 ## General
 

--- a/Functions/News.lua
+++ b/Functions/News.lua
@@ -16,10 +16,9 @@ local content = [====[
 ## Priest
 ### Holy
 
-- Fix Lightweaver audio cue not playing when enabled (setting existed but had no runtime code).
-- Add audio cue option for reaching maximum Lightweaver stacks.
-- Add audio cue options for when Holy Word: Chastise, Serenity, and Sanctify come off cooldown (per-charge). These only play during combat.
-- Add an optional restriction for the Surge of Light audio cue to only play when the Spiritwell talent is active.
+- [#706](#706) Add an optional restriction for the Surge of Light audio cue to only play when the Spiritwell talent is active.
+- [#707](#707) Add audio cue options for when Holy Word: Chastise, Serenity, and Sanctify come off cooldown (per-charge). These only play during combat.
+- [#709](#709) Update Lightweaver audio cues to add a second cue and change it to be configurable for how many Lightweaver stacks are required to trigger it.
 
 ---
 

--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -545,7 +545,7 @@ L["MonkWindwalkerThresholdCheckboxVivify"] = "Vivify"
 L["MonkWindwalkerThresholdCheckboxVivifyTooltip"] = "This will show the vertical line on the bar denoting how much Energy is required to use Vivify."
 
 -- PriestOptions
-L["PriestHolyAudioLightweaver"] = "Lightweaver"
+-- REMOVED: L["PriestHolyAudioLightweaver"] - replaced by PriestHolyAudioLightweaverThreshold1
 L["PriestShadowAudioMindDevourer"] = "Mind Devourer Proc"
 L["PriestShadowAudioShadowWordMadness"] = "Shadow Word: Madness Ready"
 L["PriestDisciplinePowerWords"] = "Power Words"
@@ -592,8 +592,8 @@ L["PriestHolyCheckboxApotheosisGcds"] = "GCDs until Apotheosis ends"
 L["PriestHolyApotheosisGcds"] = "Apotheosis GCDs - 0.75sec Floor"
 L["PriestHolyCheckboxApotheosisTime"] = "Time until Apotheosis ends"
 L["PriestHolyApotheosisTime"] = "Apotheosis Time Remaining (sec)"
-L["PriestHolyAudioCheckboxLightweaver"] = "Play audio cue when you gain Lightweaver"
-L["PriestHolyAudioCheckboxLightweaverTooltip"] = "Play audio cue when you gain Lightweaver."
+-- REMOVED: L["PriestHolyAudioCheckboxLightweaver"] - replaced by PriestHolyAudioCheckboxLightweaverThreshold1
+-- REMOVED: L["PriestHolyAudioCheckboxLightweaverTooltip"] - replaced by PriestHolyAudioCheckboxLightweaverThreshold1Tooltip
 L["PriestShadowShadowWordMadness"] = "Shadow Word: Madness"
 L["PriestShadowShadowWordMadnessAbbreviation"] = "SWM"
 L["PriestShadowColorPickerVoidform"] = "Insanity while in Voidform"
@@ -2264,3 +2264,35 @@ L["BarVisibilityThresholdHealthValueValue"] = "Health Value"
 
 -- Shaman Enhancement: 5-stack Maelstrom Weapon color
 L["ShamanEnhancementMaelstromWeaponColorPickerFiveStack"] = "5 Stack Maelstrom Weapon"
+
+-- Holy Priest: Audio cues for Lightweaver max stacks, Holy Word charge-ready, Surge of Light Spiritwell restriction
+-- REMOVED: L["PriestHolyAudioLightweaverMaxStacks"] - replaced by PriestHolyAudioLightweaverThreshold2
+-- REMOVED: L["PriestHolyAudioCheckboxLightweaverMaxStacks"] - replaced by PriestHolyAudioCheckboxLightweaverThreshold2
+-- REMOVED: L["PriestHolyAudioCheckboxLightweaverMaxStacksTooltip"] - replaced by PriestHolyAudioCheckboxLightweaverThreshold2Tooltip
+L["PriestHolyAudioHolyWordChastiseReady"] = "Holy Word: Chastise Ready"
+L["PriestHolyAudioCheckboxHolyWordChastiseReady"] = "Play audio cue when Holy Word: Chastise comes off cooldown"
+L["PriestHolyAudioCheckboxHolyWordChastiseReadyTooltip"] = "Play audio cue when Holy Word: Chastise comes off cooldown. Only plays during combat."
+L["PriestHolyAudioHolyWordSerenityCharge1"] = "Holy Word: Serenity (1 Charge)"
+L["PriestHolyAudioCheckboxHolyWordSerenityCharge1"] = "Play audio cue when Holy Word: Serenity gains its first charge"
+L["PriestHolyAudioCheckboxHolyWordSerenityCharge1Tooltip"] = "Play audio cue when Holy Word: Serenity gains its first charge. Only plays during combat."
+L["PriestHolyAudioHolyWordSerenityCharge2"] = "Holy Word: Serenity (2 Charges)"
+L["PriestHolyAudioCheckboxHolyWordSerenityCharge2"] = "Play audio cue when Holy Word: Serenity gains its second charge"
+L["PriestHolyAudioCheckboxHolyWordSerenityCharge2Tooltip"] = "Play audio cue when Holy Word: Serenity gains its second charge. Requires Miracle Worker talent. Only plays during combat."
+L["PriestHolyAudioHolyWordSanctifyCharge1"] = "Holy Word: Sanctify (1 Charge)"
+L["PriestHolyAudioCheckboxHolyWordSanctifyCharge1"] = "Play audio cue when Holy Word: Sanctify gains its first charge"
+L["PriestHolyAudioCheckboxHolyWordSanctifyCharge1Tooltip"] = "Play audio cue when Holy Word: Sanctify gains its first charge. Only plays during combat."
+L["PriestHolyAudioHolyWordSanctifyCharge2"] = "Holy Word: Sanctify (2 Charges)"
+L["PriestHolyAudioCheckboxHolyWordSanctifyCharge2"] = "Play audio cue when Holy Word: Sanctify gains its second charge"
+L["PriestHolyAudioCheckboxHolyWordSanctifyCharge2Tooltip"] = "Play audio cue when Holy Word: Sanctify gains its second charge. Requires Miracle Worker talent. Only plays during combat."
+L["PriestAudioCheckboxSurgeOfLightSpiritwellOnly"] = "Only play when Spiritwell is talented"
+L["PriestAudioCheckboxSurgeOfLightSpiritwellOnlyTooltip"] = "When enabled, the Surge of Light audio cue will only play if you have the Spiritwell talent active."
+L["PriestHolyAudioHolyWordsHeader"] = "Holy Word Audio Cues"
+
+-- Holy Priest: Configurable Lightweaver audio thresholds (replaces fixed gain/max-stacks cues)
+L["PriestHolyAudioLightweaverThreshold1"] = "Lightweaver Threshold 1"
+L["PriestHolyAudioCheckboxLightweaverThreshold1"] = "Play when at X stacks of Lightweaver (Threshold 1)"
+L["PriestHolyAudioCheckboxLightweaverThreshold1Tooltip"] = "Play an audio cue when you have exactly this many stacks of Lightweaver."
+L["PriestHolyAudioLightweaverThreshold2"] = "Lightweaver Threshold 2"
+L["PriestHolyAudioCheckboxLightweaverThreshold2"] = "Play when at X stacks of Lightweaver (Threshold 2)"
+L["PriestHolyAudioCheckboxLightweaverThreshold2Tooltip"] = "Play an audio cue when you have exactly this many stacks of Lightweaver."
+L["PriestHolyAudioLightweaverThresholdSliderTitle"] = "At X Stacks of Lightweaver"

--- a/TwintopInsanityBar.toc
+++ b/TwintopInsanityBar.toc
@@ -13,7 +13,7 @@
 ## Title-zhTW: Twintop 的資源欄
 ## Author: Twintop
 ## X-AuthorServer: Frostmourne-US/OCE
-## Version: 12.0.1.37
+## Version: 12.0.1.38
 ## X-ReleaseType: release
 ## X-ReleaseDate: 2026-03-17
 ## SavedVariables: TwintopInsanityBarSettings


### PR DESCRIPTION
Adds new audio cues for Holy Priest and makes existing ones configurable. Also fixes a bug where the Surge of Light audio cue played unconditionally even when disabled.

# Changes

## Bug Fix: Surge of Light Audio Cue (#706)
- Fixed the Surge of Light audio cue always playing regardless of talent configuration
- The code was creating a local `talents` variable from `TRB.Data.character.talents` (which could be nil) instead of using the module-level `talents` variable populated during `SwitchSpec`
- Added an optional **Spiritwell-only restriction** checkbox — when enabled, the Surge of Light cue only plays if the player has the Spiritwell talent active

## New: Configurable Lightweaver Audio Thresholds (#709)
- Replaced the two fixed Lightweaver audio cues ("any gain" at 1+ stacks and "max stacks" at 4) with two **configurable threshold cues**
- Each threshold has a slider (range 1–4) to select the exact stack count that triggers the cue
- Uses exact match (`==`) rather than at-or-above (`>=`) — the cue fires only when stacks equal the configured value
- Default values preserve the original behavior: Threshold 1 = 1, Threshold 2 = 4
- Follows the same pattern as Paladin Holy Power audio thresholds

## New: Holy Word Charge-Ready Audio Cues (#707)
- **Holy Word: Chastise** — plays when it comes off cooldown (combat only)
- **Holy Word: Serenity** — separate cues for 1st and 2nd charge (2nd charge requires Miracle Worker talent, combat only)
- **Holy Word: Sanctify** — separate cues for 1st and 2nd charge (2nd charge requires Miracle Worker talent, combat only)
- All Holy Word cues use charge-gain detection (fires on `prevCharges < N` → `currentCharges >= N` transitions)
- When multiple charge thresholds are crossed simultaneously, the highest applicable cue plays

## Localization
- Old Lightweaver localization strings commented out with `-- REMOVED:` notes pointing to replacements
- All new strings appended at the end of enUS.lua per the append-only convention