### PR TITLE
Re-add Clearcasting Color Indication for Restoration and Feral Druid

### DIFF
--- a/ClassModules/Classes/DruidClasses.lua
+++ b/ClassModules/Classes/DruidClasses.lua
@@ -407,6 +407,7 @@ function TRB.Classes.Druid.FeralSpells:New()
         isSnowflake = true,
         isTalent = false,
         baseline = true,
+        rangeCheck = false,
         category = "offensive"
     })
 
@@ -582,6 +583,8 @@ function TRB.Classes.Druid.FeralSpells.FillBarTextVariables(specCacheEntry)
 		{ variable = "$incarnationTicks", description = L["DruidFeralBarTextVariable_incarnationTicks"], printInSettings = true, color = false },
 		{ variable = "$incarnationTickTime", description = L["DruidFeralBarTextVariable_incarnationTickTime"], printInSettings = true, color = false },
 		{ variable = "$incarnationNextCp", description = L["DruidFeralBarTextVariable_incarnationNextCp"], printInSettings = true, color = false },
+
+		{ variable = "$clearcastingActive", description = L["DruidFeralBarTextVariable_clearcastingActive"], printInSettings = true, color = false },
 	})
 end
 

--- a/ClassModules/Classes/DruidClasses.lua
+++ b/ClassModules/Classes/DruidClasses.lua
@@ -813,6 +813,8 @@ function TRB.Classes.Druid.RestorationSpells.FillBarTextVariables(specCacheEntry
 
 		{ variable = "$incarnationTime", description = L["DruidRestorationBarTextVariable_incarnationTime"], printInSettings = true, color = false },
 
+		{ variable = "$clearcastingActive", description = L["DruidRestorationBarTextVariable_clearcastingActive"], printInSettings = true, color = false },
+
 		{ variable = "$efflorescenceTime", description = L["DruidRestorationBarTextVariable_efflorescenceTime"], printInSettings = true, color = false },
 	})
 end

--- a/ClassModules/Druid.lua
+++ b/ClassModules/Druid.lua
@@ -118,6 +118,7 @@ local function FillSpecializationCache()
 
 	specCache.druid_feral.snapshotData.attributes.resourceRegen = 0
 	specCache.druid_feral.snapshotData.attributes.comboPoints = 0
+	specCache.druid_feral.snapshotData.attributes.clearcastingActive = false
 	specCache.druid_feral.snapshotData.audio = {
 		apexPredatorsCravingCue = false,
 		comboPointThreshold1Played = false,
@@ -375,7 +376,12 @@ local function HandleSpellEvents(self, event, ...)
 	if event == "SPELL_ACTIVATION_OVERLAY_SHOW" then
 		local snapshotData = TRB.Data.snapshotData
 		local spellId = ...
-		if TRB.Data.character.specId == 4 then
+		if TRB.Data.character.specId == 2 then
+			local spells = TRB.Data.spellsData.spells
+			if spellId == spells.clearcasting.id then
+				snapshotData.attributes.clearcastingActive = true
+			end
+		elseif TRB.Data.character.specId == 4 then
 			local spells = TRB.Data.spellsData.spells
 			if spellId == spells.clearcasting.id then
 				snapshotData.attributes.clearcastingActive = true
@@ -384,7 +390,12 @@ local function HandleSpellEvents(self, event, ...)
 	elseif event == "SPELL_ACTIVATION_OVERLAY_HIDE" then
 		local snapshotData = TRB.Data.snapshotData
 		local spellId = ...
-		if TRB.Data.character.specId == 4 then
+		if TRB.Data.character.specId == 2 then
+			local spells = TRB.Data.spellsData.spells
+			if spellId == spells.clearcasting.id then
+				snapshotData.attributes.clearcastingActive = false
+			end
+		elseif TRB.Data.character.specId == 4 then
 			local spells = TRB.Data.spellsData.spells
 			if spellId == spells.clearcasting.id then
 				snapshotData.attributes.clearcastingActive = false
@@ -930,6 +941,12 @@ local function RefreshLookupData_Feral()
 		if lookupChanged(prevState, "$incarnationTickTime", _incarnationTickTime) then
 			lookup["$incarnationTickTime"] = TRB.Functions.BarText:TimerPrecision(_incarnationTickTime)
 		end
+	end
+
+	-- Block D: Clearcasting ($clearcastingActive)
+	if not activeVars or activeVars["$clearcastingActive"] then
+		lookupLogic["$clearcastingActive"] = snapshotData.attributes.clearcastingActive or false
+		lookup["$clearcastingActive"] = ""
 	end
 
 	TRB.Data.lookup = lookup
@@ -2382,14 +2399,6 @@ local function UpdateResourceBar()
 						end
 					end
 
-					
-					-- Legacy clearcasting (not an indicator — stays in colors.bar)
-					if displaySpecId == TRB.Data.character.specId then
-						if specSettings.colors.bar.clearcasting.enabled and snapshots[spells.clearcasting.id].buff.remaining > 0 then
-							barColor = specSettings.colors.bar.clearcasting.color
-						end
-					end
-
 					-- Indicator color system
 					barBorderColor = specSettings.colors.bar.border.color
 					barBackgroundColor = specSettings.colors.bar.background.color
@@ -2402,6 +2411,7 @@ local function UpdateResourceBar()
 					local conditionMap = {
 						apexPredator = apcActive,
 						ravage = snapshots[spells.ravageMinimum.id].buff.isActive,
+						clearcasting = snapshotData.attributes.clearcastingActive,
 						borderStealth = isStealthed,
 						maxBite = snapshotData.attributes.resource2 == 5 and not apcActive,
 						borderOvercap = affectingCombat and not isStealthed and displaySpecId == TRB.Data.character.specId,
@@ -3737,6 +3747,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.resourceMana = Enum.PowerType.Mana
 		TRB.Data.resourceComboPoints = Enum.PowerType.ComboPoints
 	elseif TRB.Data.character.specId == 2 and TRB.Data.settings.core.enabled.druid.feral == true then
+		TRB.Functions.Class:EnableEvents()
 		TRB.Data.specSupported = true
 		TRB.Data.resource = Enum.PowerType.Energy -- Primary spec resource
 		TRB.Data.resourceFactor = ENERGY_RESOURCE_FACTOR

--- a/ClassModules/Druid.lua
+++ b/ClassModules/Druid.lua
@@ -376,12 +376,7 @@ local function HandleSpellEvents(self, event, ...)
 	if event == "SPELL_ACTIVATION_OVERLAY_SHOW" then
 		local snapshotData = TRB.Data.snapshotData
 		local spellId = ...
-		if TRB.Data.character.specId == 2 then
-			local spells = TRB.Data.spellsData.spells
-			if spellId == spells.clearcasting.id then
-				snapshotData.attributes.clearcastingActive = true
-			end
-		elseif TRB.Data.character.specId == 4 then
+		if TRB.Data.character.specId == 2 or TRB.Data.character.specId == 4 then
 			local spells = TRB.Data.spellsData.spells
 			if spellId == spells.clearcasting.id then
 				snapshotData.attributes.clearcastingActive = true
@@ -390,12 +385,7 @@ local function HandleSpellEvents(self, event, ...)
 	elseif event == "SPELL_ACTIVATION_OVERLAY_HIDE" then
 		local snapshotData = TRB.Data.snapshotData
 		local spellId = ...
-		if TRB.Data.character.specId == 2 then
-			local spells = TRB.Data.spellsData.spells
-			if spellId == spells.clearcasting.id then
-				snapshotData.attributes.clearcastingActive = false
-			end
-		elseif TRB.Data.character.specId == 4 then
+		if TRB.Data.character.specId == 2 or TRB.Data.character.specId == 4 then
 			local spells = TRB.Data.spellsData.spells
 			if spellId == spells.clearcasting.id then
 				snapshotData.attributes.clearcastingActive = false

--- a/ClassModules/Druid.lua
+++ b/ClassModules/Druid.lua
@@ -210,6 +210,7 @@ local function FillSpecializationCache()
 	local spells = specCache.druid_restoration.spellsData.spells --[[@as TRB.Classes.Druid.RestorationSpells]]
 
 	specCache.druid_restoration.snapshotData.attributes.manaRegen = 0
+	specCache.druid_restoration.snapshotData.attributes.clearcastingActive = false
 	specCache.druid_restoration.snapshotData.audio = {
 		innervateCue = false
 	}
@@ -221,6 +222,8 @@ local function FillSpecializationCache()
 	specCache.druid_restoration.snapshotData.snapshots[spells.frenziedRegeneration.id] = TRB.Classes.Snapshot:New(spells.frenziedRegeneration)
 	---@type TRB.Classes.Snapshot
 	specCache.druid_restoration.snapshotData.snapshots[spells.maim.id] = TRB.Classes.Snapshot:New(spells.maim)
+	---@type TRB.Classes.Snapshot
+	specCache.druid_restoration.snapshotData.snapshots[spells.clearcasting.id] = TRB.Classes.Snapshot:New(spells.clearcasting)
 
 	specCache.druid_restoration.barTextVariables = {
 		icons = {},
@@ -367,6 +370,41 @@ local function DruidPowerEvent(self, event, ...)
 	end
 end
 local druidPowerFrame = CreateFrame("Frame")
+
+local function HandleSpellEvents(self, event, ...)
+	if event == "SPELL_ACTIVATION_OVERLAY_SHOW" then
+		local snapshotData = TRB.Data.snapshotData
+		local spellId = ...
+		if TRB.Data.character.specId == 4 then
+			local spells = TRB.Data.spellsData.spells
+			if spellId == spells.clearcasting.id then
+				snapshotData.attributes.clearcastingActive = true
+			end
+		end
+	elseif event == "SPELL_ACTIVATION_OVERLAY_HIDE" then
+		local snapshotData = TRB.Data.snapshotData
+		local spellId = ...
+		if TRB.Data.character.specId == 4 then
+			local spells = TRB.Data.spellsData.spells
+			if spellId == spells.clearcasting.id then
+				snapshotData.attributes.clearcastingActive = false
+			end
+		end
+	end
+end
+
+local spellEventFrame = CreateFrame("Frame")
+spellEventFrame:SetScript("OnEvent", HandleSpellEvents)
+
+function TRB.Functions.Class:EnableEvents()
+	spellEventFrame:RegisterEvent("SPELL_ACTIVATION_OVERLAY_SHOW")
+	spellEventFrame:RegisterEvent("SPELL_ACTIVATION_OVERLAY_HIDE")
+end
+
+function TRB.Functions.Class:DisableEvents()
+	spellEventFrame:UnregisterEvent("SPELL_ACTIVATION_OVERLAY_SHOW")
+	spellEventFrame:UnregisterEvent("SPELL_ACTIVATION_OVERLAY_HIDE")
+end
 
 ---@alias trbDruidForm
 ---| '"humanoid"'		# nil
@@ -1055,6 +1093,12 @@ local function RefreshLookupData_Restoration()
 		if lookupChanged(prevState, "$incarnationTime", _incarnationTime) then
 			lookup["$incarnationTime"] = TRB.Functions.BarText:TimerPrecision(_incarnationTime)
 		end
+	end
+
+	-- Block D: Clearcasting ($clearcastingActive)
+	if not activeVars or activeVars["$clearcastingActive"] then
+		lookupLogic["$clearcastingActive"] = snapshotData.attributes.clearcastingActive or false
+		lookup["$clearcastingActive"] = ""
 	end
 
 	TRB.Data.lookup = lookup
@@ -3093,10 +3137,13 @@ local function UpdateResourceBar()
 					local indicatorColors = sharedColors and sharedColors.indicatorColors
 					local nodeOrder = sharedColors and sharedColors.nodeOrder
 
+					local clearcastingActive = snapshotData.attributes.clearcastingActive
+
 					local conditionMap = {
 						incarnationEnd = isNativeForm and incarnationActive and incarnationEndMet,
 						incarnation = isNativeForm and incarnationActive,
 						noEfflorescence = isNativeForm and affectingCombat and talents:IsTalentActive(spells.efflorescence) and not snapshots[spells.efflorescence.id].buff.isActive,
+						clearcasting = isNativeForm and clearcastingActive,
 					}
 
 					local manaBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
@@ -3673,6 +3720,7 @@ function TRB.Functions.Class:CheckCharacter()
 end
 
 function TRB.Functions.Class:EventRegistration()
+	TRB.Functions.Class:DisableEvents()
 	local primaryResourceToken
 	-- For Druids, we need to track ALL power types simultaneously for form-based switching
 	-- The actual displayed resource will be determined by current form in UpdateResourceBar
@@ -3712,6 +3760,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.resourceAstralPower = Enum.PowerType.LunarPower
 		TRB.Data.resourceComboPoints = Enum.PowerType.ComboPoints
 	elseif TRB.Data.character.specId == 4 and TRB.Data.settings.core.enabled.druid.restoration then
+		TRB.Functions.Class:EnableEvents()
 		TRB.Data.specSupported = true
 		TRB.Data.resource = Enum.PowerType.Mana -- Primary spec resource
 		TRB.Data.resourceFactor = MANA_RESOURCE_FACTOR

--- a/ClassModules/Options/DruidOptions.lua
+++ b/ClassModules/Options/DruidOptions.lua
@@ -1320,6 +1320,7 @@ local function RestorationLoadDefaultSettings(includeBarText, classic)
 					"incarnationEnd",
 					"incarnation",
 					"noEfflorescence",
+					"clearcasting",
 				},
 				gradientOrder = {},
 				indicatorColors = {
@@ -1344,6 +1345,15 @@ local function RestorationLoadDefaultSettings(includeBarText, classic)
 					noEfflorescence = {
 						color = "FFFF0000",
 						color2 = "FFFF0000",
+						gradientDirection = "disabled",
+						enabled = true,
+						targets = {
+							manaBar = { bar = true, border = false, background = false },
+						},
+					},
+					clearcasting = {
+						color = "FF4A95CE",
+						color2 = "FF4A95CE",
 						gradientDirection = "disabled",
 						enabled = true,
 						targets = {
@@ -3224,6 +3234,7 @@ local function RestorationConstructIndicatorColorsPanel(parent)
 			{ key = "incarnationEnd",    label = L["DruidRestorationCheckboxIncarnationEnding"],  tooltip = L["DruidRestorationIndicatorIncarnationEndTooltip"],      colorLabel = L["DruidRestorationIndicatorIncarnationEndColor"] },
 			{ key = "incarnation",       label = L["DruidRestorationCheckboxIncarnation"],        tooltip = L["DruidRestorationIndicatorIncarnationTooltip"],         colorLabel = L["DruidRestorationIndicatorIncarnationColor"] },
 			{ key = "noEfflorescence",   label = L["DruidRestorationCheckboxNoEfflorescence"],    tooltip = L["DruidRestorationIndicatorNoEfflorescenceTooltip"],     colorLabel = L["DruidRestorationIndicatorNoEfflorescenceColor"] },
+			{ key = "clearcasting",      label = L["DruidRestorationCheckboxClearcasting"],       tooltip = L["DruidRestorationIndicatorClearcastingTooltip"],        colorLabel = L["DruidRestorationIndicatorClearcastingColor"] },
 		},
 		barTargetDefs = {
 			{ key = "manaBar",      label = L["BarNameManaBar"] },

--- a/ClassModules/Options/DruidOptions.lua
+++ b/ClassModules/Options/DruidOptions.lua
@@ -1286,12 +1286,6 @@ local function RestorationLoadDefaultSettings(includeBarText, classic)
 					gradientDirection = "disabled",
 					enabled = true
 				},
-				clearcasting = {
-					color = "FF4A95CE",
-					color2 = "FF4A95CE",
-					gradientDirection = "disabled",
-					enabled = true
-				},
 				incarnation = {
 					color = "FF005500",
 					color2 = "FF005500",

--- a/ClassModules/Options/DruidOptions.lua
+++ b/ClassModules/Options/DruidOptions.lua
@@ -824,12 +824,6 @@ local function FeralLoadDefaultSettings(includeBarText, classic)
 					color2 = "FFFFFF00",
 					gradientDirection = "disabled"
 				},
-				clearcasting = {
-					color = "FF4A95CE",
-					color2 = "FF4A95CE",
-					gradientDirection = "disabled",
-					enabled = true
-				},
 				maxBite = {
 					color = "FF009900",
 					color2 = "FF009900",
@@ -891,6 +885,7 @@ local function FeralLoadDefaultSettings(includeBarText, classic)
 				nodeOrder = {
 					"apexPredator",
 					"ravage",
+					"clearcasting",
 					"borderStealth",
 				},
 				gradientOrder = {
@@ -914,6 +909,15 @@ local function FeralLoadDefaultSettings(includeBarText, classic)
 						enabled = true,
 						targets = {
 							comboPoints = { bar = true, border = false, background = false },
+						},
+					},
+					clearcasting = {
+						color = "FF4A95CE",
+						color2 = "FF4A95CE",
+						gradientDirection = "disabled",
+						enabled = true,
+						targets = {
+							energyBar = { bar = true, border = false, background = false },
 						},
 					},
 					borderStealth = {
@@ -2213,6 +2217,7 @@ local function FeralConstructIndicatorColorsPanel(parent)
 		indicatorDefs = {
 			{ key = "apexPredator",   label = L["DruidFeralCheckboxApexPredator"],  tooltip = L["DruidFeralIndicatorApexPredatorTooltip"],    colorLabel = L["DruidFeralIndicatorApexPredatorColor"] },
 			{ key = "ravage",        label = L["DruidFeralCheckboxRavage"],        tooltip = L["DruidFeralIndicatorRavageTooltip"],          colorLabel = L["DruidFeralIndicatorRavageColor"] },
+			{ key = "clearcasting",  label = L["DruidFeralCheckboxClearcasting"],  tooltip = L["DruidFeralIndicatorClearcastingTooltip"],    colorLabel = L["DruidFeralIndicatorClearcastingColor"] },
 			{ key = "borderStealth",  label = L["CheckboxBorderStealth"],           tooltip = L["DruidFeralIndicatorBorderStealthTooltip"],   colorLabel = L["DruidFeralIndicatorBorderStealthColor"] },
 		},
 		gradientDefs = {

--- a/Functions/News.lua
+++ b/Functions/News.lua
@@ -21,6 +21,15 @@ local content = [====[
 
 - [#737](#737) Updated translations for Simplified Chinese (zhCN) by M.O.S.S! Thank you so much for your help!
 
+## Druid
+### Feral
+
+- [#738](#738) Re-enable the color indicator for when you have a Clearcasting proc active and add a new logic-only bar text variable `$clearcastingActive` for conditional bar text logic.
+
+### Restoration
+
+- [#738](#738) Re-enable the color indicator for when you have a Clearcasting proc active and add a new logic-only bar text variable `$clearcastingActive` for conditional bar text logic.
+
 ## Paladin
 
 - Add new color indicator, audio cue, and bar text variable for when you have a Divine Purpose proc active.

--- a/Functions/Settings.lua
+++ b/Functions/Settings.lua
@@ -6575,6 +6575,29 @@ function TRB.Functions.Settings:PortForwardSettings()
 		end
 	end
 
+	-- Migrate Restoration Druid clearcasting from colors.bar.clearcasting to colors.shared.indicatorColors.clearcasting
+	if TwintopInsanityBarSettings and TwintopInsanityBarSettings.druid and TwintopInsanityBarSettings.druid.restoration then
+		local restoration = TwintopInsanityBarSettings.druid.restoration
+		if restoration.colors and restoration.colors.shared and restoration.colors.shared.indicatorColors
+			and restoration.colors.shared.indicatorColors.clearcasting == nil
+			and restoration.colors.bar and restoration.colors.bar.clearcasting ~= nil then
+
+			table.insert(restoration.colors.shared.nodeOrder, "clearcasting")
+
+			restoration.colors.shared.indicatorColors.clearcasting = {
+				color = restoration.colors.bar.clearcasting.color or "FF4A95CE",
+				color2 = restoration.colors.bar.clearcasting.color2 or "FF4A95CE",
+				gradientDirection = restoration.colors.bar.clearcasting.gradientDirection or "disabled",
+				enabled = restoration.colors.bar.clearcasting.enabled ~= false,
+				targets = {
+					manaBar = { bar = true, border = false, background = false },
+				},
+			}
+
+			restoration.colors.bar.clearcasting = nil
+		end
+	end
+
 	-- Migrate Hunter BeastMastery to indicator colors
 	if TwintopInsanityBarSettings and TwintopInsanityBarSettings.hunter and TwintopInsanityBarSettings.hunter.beastMastery then
 		local spec = TwintopInsanityBarSettings.hunter.beastMastery

--- a/Functions/Settings.lua
+++ b/Functions/Settings.lua
@@ -6598,6 +6598,40 @@ function TRB.Functions.Settings:PortForwardSettings()
 		end
 	end
 
+	-- Migrate Feral Druid clearcasting from colors.bar.clearcasting to colors.shared.indicatorColors.clearcasting
+	if TwintopInsanityBarSettings and TwintopInsanityBarSettings.druid and TwintopInsanityBarSettings.druid.feral then
+		local feral = TwintopInsanityBarSettings.druid.feral
+		if feral.colors and feral.colors.shared and feral.colors.shared.indicatorColors
+			and feral.colors.shared.indicatorColors.clearcasting == nil
+			and feral.colors.bar and feral.colors.bar.clearcasting ~= nil then
+
+			-- Insert clearcasting after ravage but before borderStealth in nodeOrder
+			local inserted = false
+			for i, key in ipairs(feral.colors.shared.nodeOrder) do
+				if key == "borderStealth" then
+					table.insert(feral.colors.shared.nodeOrder, i, "clearcasting")
+					inserted = true
+					break
+				end
+			end
+			if not inserted then
+				table.insert(feral.colors.shared.nodeOrder, "clearcasting")
+			end
+
+			feral.colors.shared.indicatorColors.clearcasting = {
+				color = feral.colors.bar.clearcasting.color or "FF4A95CE",
+				color2 = feral.colors.bar.clearcasting.color2 or "FF4A95CE",
+				gradientDirection = feral.colors.bar.clearcasting.gradientDirection or "disabled",
+				enabled = feral.colors.bar.clearcasting.enabled ~= false,
+				targets = {
+					energyBar = { bar = true, border = false, background = false },
+				},
+			}
+
+			feral.colors.bar.clearcasting = nil
+		end
+	end
+
 	-- Migrate Hunter BeastMastery to indicator colors
 	if TwintopInsanityBarSettings and TwintopInsanityBarSettings.hunter and TwintopInsanityBarSettings.hunter.beastMastery then
 		local spec = TwintopInsanityBarSettings.hunter.beastMastery

--- a/Functions/Settings.lua
+++ b/Functions/Settings.lua
@@ -6582,7 +6582,19 @@ function TRB.Functions.Settings:PortForwardSettings()
 			and restoration.colors.shared.indicatorColors.clearcasting == nil
 			and restoration.colors.bar and restoration.colors.bar.clearcasting ~= nil then
 
-			table.insert(restoration.colors.shared.nodeOrder, "clearcasting")
+			restoration.colors.shared.nodeOrder = restoration.colors.shared.nodeOrder or {}
+
+			local hasClearcasting = false
+			for _, key in ipairs(restoration.colors.shared.nodeOrder) do
+				if key == "clearcasting" then
+					hasClearcasting = true
+					break
+				end
+			end
+
+			if not hasClearcasting then
+				table.insert(restoration.colors.shared.nodeOrder, "clearcasting")
+			end
 
 			restoration.colors.shared.indicatorColors.clearcasting = {
 				color = restoration.colors.bar.clearcasting.color or "FF4A95CE",
@@ -6606,16 +6618,24 @@ function TRB.Functions.Settings:PortForwardSettings()
 			and feral.colors.bar and feral.colors.bar.clearcasting ~= nil then
 
 			-- Insert clearcasting after ravage but before borderStealth in nodeOrder
-			local inserted = false
-			for i, key in ipairs(feral.colors.shared.nodeOrder) do
-				if key == "borderStealth" then
-					table.insert(feral.colors.shared.nodeOrder, i, "clearcasting")
-					inserted = true
+			feral.colors.shared.nodeOrder = feral.colors.shared.nodeOrder or {}
+			local nodeOrder = feral.colors.shared.nodeOrder
+			local hasClearcasting = false
+			local borderStealthIndex = nil
+			for i, key in ipairs(nodeOrder) do
+				if key == "clearcasting" then
+					hasClearcasting = true
 					break
+				elseif key == "borderStealth" and borderStealthIndex == nil then
+					borderStealthIndex = i
 				end
 			end
-			if not inserted then
-				table.insert(feral.colors.shared.nodeOrder, "clearcasting")
+			if not hasClearcasting then
+				if borderStealthIndex ~= nil then
+					table.insert(nodeOrder, borderStealthIndex, "clearcasting")
+				else
+					table.insert(nodeOrder, "clearcasting")
+				end
 			end
 
 			feral.colors.shared.indicatorColors.clearcasting = {

--- a/Localization/enGB.lua
+++ b/Localization/enGB.lua
@@ -307,4 +307,6 @@ if locale == "enGB" then
     L["ThresholdDetailColorModeStaticColor"] = "Static Colour"
     -- Paladin Divine Purpose Indicator Colors
     L["PaladinIndicatorDivinePurposeTooltip"] = "Changes to this colour when you have Divine Purpose."
+    -- Druid Restoration Clearcasting Indicator Colors
+    L["DruidRestorationIndicatorClearcastingTooltip"] = "Changes to this colour when you have a Clearcasting proc."
 end

--- a/Localization/enGB.lua
+++ b/Localization/enGB.lua
@@ -309,4 +309,6 @@ if locale == "enGB" then
     L["PaladinIndicatorDivinePurposeTooltip"] = "Changes to this colour when you have Divine Purpose."
     -- Druid Restoration Clearcasting Indicator Colors
     L["DruidRestorationIndicatorClearcastingTooltip"] = "Changes to this colour when you have a Clearcasting proc."
+    -- Druid Feral Clearcasting Indicator Colors
+    L["DruidFeralIndicatorClearcastingTooltip"] = "Changes to this colour when you have a Clearcasting proc."
 end

--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -2625,3 +2625,9 @@ L["DruidRestorationBarTextVariable_clearcastingActive"] = "Is Clearcasting curre
 L["DruidRestorationCheckboxClearcasting"] = "Clearcasting"
 L["DruidRestorationIndicatorClearcastingTooltip"] = "Changes to this color when you have a Clearcasting proc."
 L["DruidRestorationIndicatorClearcastingColor"] = "Clearcasting proc is active"
+
+-- Druid Feral Clearcasting Indicator Colors
+L["DruidFeralBarTextVariable_clearcastingActive"] = "Is Clearcasting currently active? LOGIC VARIABLE ONLY!"
+L["DruidFeralCheckboxClearcasting"] = "Clearcasting"
+L["DruidFeralIndicatorClearcastingTooltip"] = "Changes to this color when you have a Clearcasting proc."
+L["DruidFeralIndicatorClearcastingColor"] = "Clearcasting proc is active"

--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -2619,3 +2619,9 @@ L["PaladinIndicatorDivinePurposeColor"] = "Divine Purpose is active"
 L["PaladinAudioDivinePurpose"] = "Divine Purpose"
 L["PaladinAudioCheckboxDivinePurpose"] = "Play audio cue when Divine Purpose procs"
 L["PaladinAudioCheckboxDivinePurposeTooltip"] = "Play an audio cue when a Divine Purpose proc occurs. This will only play once per proc."
+
+-- Druid Restoration Clearcasting Indicator Colors
+L["DruidRestorationBarTextVariable_clearcastingActive"] = "Is Clearcasting currently active? LOGIC VARIABLE ONLY!"
+L["DruidRestorationCheckboxClearcasting"] = "Clearcasting"
+L["DruidRestorationIndicatorClearcastingTooltip"] = "Changes to this color when you have a Clearcasting proc."
+L["DruidRestorationIndicatorClearcastingColor"] = "Clearcasting proc is active"


### PR DESCRIPTION
#738 

# Summary

Re-enables Clearcasting detection for Restoration and Feral Druid, migrating the legacy `colors.bar.clearcasting` setting into the Indicator Color system. Both specs now use `SPELL_ACTIVATION_OVERLAY_SHOW`/`HIDE` events (matching the pattern used by Paladin Divine Purpose and Evoker Essence Burst) rather than relying solely on aura tracking.

# Changes

## Restoration Druid
- Added `clearcastingActive` attribute to snapshot data
- Wired `SPELL_ACTIVATION_OVERLAY_SHOW`/`HIDE` events to set the attribute (spell ID 16870)
- Added `clearcasting` entry to `conditionMap` and `colors.shared.indicatorColors`
- Added `$clearcastingActive` bar text variable (logic-only)
- Migration moves existing `colors.bar.clearcasting` to the indicator system

## Feral Druid
- Added `clearcastingActive` attribute to snapshot data
- Extended overlay event handler for Feral (spell ID 135700)
- Registered `EnableEvents()` in Feral's `EventRegistration` branch
- Removed legacy `colors.bar.clearcasting` bar color block from `UpdateResourceBar`; replaced with `clearcasting` entry in the indicator `conditionMap`
- Added `$clearcastingActive` bar text variable (logic-only)
- Removed `clearcasting` from `colors.bar` defaults; added to `colors.shared.nodeOrder` and `indicatorColors`
- Added clearcasting row to `FeralConstructIndicatorColorsPanel`
- Migration moves existing `colors.bar.clearcasting` to the indicator system, inserting before `borderStealth` in priority order

**Feral threshold interaction**: When Clearcasting is active, threshold abilities with `isClearcasting = true` (Shred, Swipe) continue to show as "usable" — this existing logic was already driven by `buff.applications > 0` and remains unchanged.