### PR TITLE
Refactor shared lookup tables to use a centralized setup

### DIFF
--- a/ClassModules/Druid.lua
+++ b/ClassModules/Druid.lua
@@ -407,13 +407,36 @@ function TRB.Functions.Class:DisableEvents()
 	spellEventFrame:UnregisterEvent("SPELL_ACTIVATION_OVERLAY_HIDE")
 end
 
+---@param specId integer|nil
+---@return TRB.Data.SpecRegistryEntry|nil
+local function GetDruidSpecEntry(specId)
+	if specId == nil then
+		return nil
+	end
+	return TRB.Functions.Character:GetSpecRegistryEntryFromIds(11, specId)
+end
+
+---@param specId integer|nil
+---@return string|nil
+local function GetDruidSpecName(specId)
+	local entry = GetDruidSpecEntry(specId)
+	return entry and entry.specName or nil
+end
+
+---@param specId integer|nil
+---@return string|nil
+local function GetDruidCompositeKey(specId)
+	local entry = GetDruidSpecEntry(specId)
+	return entry and entry.compositeKey or nil
+end
+
 ---Returns which spec's settings should be used for the given form
 ---@param specId integer The current active spec ID
 ---@param formName string The current shapeshift form name
 ---@return integer specIdForSettings The spec ID whose settings should be used
 local function GetFormSpecForSettings(specId, formName)
 	-- Check if form switching is enabled for the active spec
-	local activeSpecName = ({ [1] = "balance", [2] = "feral", [3] = "guardian", [4] = "restoration" })[specId]
+	local activeSpecName = GetDruidSpecName(specId)
 	local settings = TRB.Data.settings.druid[activeSpecName]
 	if settings and settings.displayBar and settings.displayBar.enableFormSwitching == false then
 		return specId -- Return active spec, don't switch based on form
@@ -494,8 +517,8 @@ local function UpdateShapeshiftForm()
 		local oldDisplaySpecId = GetFormSpecForSettings(TRB.Data.character.specId, oldForm or "humanoid")
 		local newDisplaySpecId = GetFormSpecForSettings(TRB.Data.character.specId, TRB.Data.character.currentShapeshiftForm)
 		if oldDisplaySpecId ~= newDisplaySpecId then
-			local compositeKeys = { [1] = "druid_balance", [2] = "druid_feral", [3] = "druid_guardian", [4] = "druid_restoration" }
-			local newSettings = TRB.Data.specCache[compositeKeys[newDisplaySpecId]] and TRB.Data.specCache[compositeKeys[newDisplaySpecId]].settings
+			local newCompositeKey = GetDruidCompositeKey(newDisplaySpecId)
+			local newSettings = newCompositeKey and TRB.Data.specCache[newCompositeKey] and TRB.Data.specCache[newCompositeKey].settings
 			if newSettings then
 				Bar:ApplyBarGroupsLayout(newSettings, TRB.Frames.barGroups)
 				-- Clear thresholds so they will be recreated by ConstructPrimaryGeneric using the
@@ -1145,13 +1168,13 @@ local function RefreshLookupData_Unified()
 	
 	-- Determine which form's settings to use for coloring
 	local formSpecId = GetFormSpecForSettings(specId, currentForm)
-	local formSpecName = ({ [1] = "druid_balance", [2] = "druid_feral", [3] = "druid_guardian", [4] = "druid_restoration" })[formSpecId]
-	local sharedSettings = TRB.Data.specCache[formSpecName] and TRB.Data.specCache[formSpecName].settings
+	local formSpecName = GetDruidCompositeKey(formSpecId)
+	local sharedSettings = formSpecName and TRB.Data.specCache[formSpecName] and TRB.Data.specCache[formSpecName].settings
 	
 	if not sharedSettings then
 		-- Fallback to active spec settings
 		formSpecName = TRB.Data.character.compositeKey
-		sharedSettings = TRB.Data.specCache[formSpecName] and TRB.Data.specCache[formSpecName].settings
+		sharedSettings = formSpecName and TRB.Data.specCache[formSpecName] and TRB.Data.specCache[formSpecName].settings
 	end
 	
 	if not sharedSettings then
@@ -1576,8 +1599,11 @@ local function UpdateResourceBar()
 	local currentForm = TRB.Data.character.currentShapeshiftForm or "humanoid"
 	local activeSpecId = TRB.Data.character.specId
 	local displaySpecId = GetFormSpecForSettings(activeSpecId, currentForm)
-	local displaySpecName = ({ [1] = "balance", [2] = "feral", [3] = "guardian", [4] = "restoration" })[displaySpecId]
-	local displayCompositeKey = ({ [1] = "druid_balance", [2] = "druid_feral", [3] = "druid_guardian", [4] = "druid_restoration" })[displaySpecId]
+	local displaySpecName = GetDruidSpecName(displaySpecId)
+	local displayCompositeKey = GetDruidCompositeKey(displaySpecId)
+	if displaySpecName == nil or displayCompositeKey == nil then
+		return
+	end
 	
 	-- Determine which resource to display based on displaySpecId (respects enableFormSwitching setting)
 	local displayResource = snapshotData.attributes.resource -- default
@@ -1714,13 +1740,13 @@ local function UpdateResourceBar()
 		-- or when in cat form via form switching.
 		local showCp = false
 		local cpSettings = nil
-		local activeSpecName = ({ [1] = "balance", [2] = "feral", [3] = "guardian", [4] = "restoration" })[activeSpecId]
+		local activeSpecName = GetDruidSpecName(activeSpecId)
 		-- Visibility flags (displayBar.secondary.neverShow, displayBar.showComboPoints)
 		-- must be read from the specCache so that the active spec's "Use global settings"
 		-- toggle is honored. Reading from raw classSettings ignores the global merge and
 		-- shows incorrect visibility (e.g., Guardian useGlobal=on + global=Always but
 		-- Guardian's own raw setting=Never would incorrectly hide combo points).
-		local activeCacheKey = activeSpecName and ("druid_" .. activeSpecName)
+		local activeCacheKey = GetDruidCompositeKey(activeSpecId)
 		local activeSpecCache = activeCacheKey and TRB.Data.specCache and TRB.Data.specCache[activeCacheKey]
 		local activeVisSettings = activeSpecCache and activeSpecCache.settings
 		-- Color/dimension config (cpSettings) intentionally still uses raw spec settings;
@@ -3650,8 +3676,7 @@ function TRB.Functions.Class:GetActiveDisplayCompositeKey()
 		TRB.Data.character.specId,
 		TRB.Data.character.currentShapeshiftForm or "humanoid"
 	)
-	local compositeKeys = { [1] = "druid_balance", [2] = "druid_feral", [3] = "druid_guardian", [4] = "druid_restoration" }
-	return compositeKeys[displaySpecId] or TRB.Data.character.compositeKey
+	return GetDruidCompositeKey(displaySpecId) or TRB.Data.character.compositeKey
 end
 
 function TRB.Functions.Class:CheckCharacter()

--- a/ClassModules/Hunter.lua
+++ b/ClassModules/Hunter.lua
@@ -218,6 +218,20 @@ local function FillSpellData_Survival()
 	TRB.Classes.Hunter.SurvivalSpells.FillBarTextVariables(specCache.hunter_survival)
 end
 
+local function GetSurvivalTipOfTheSpearMaxStacks()
+	local spellsData = TRB.Data.spellsData
+	if spellsData == nil or spellsData.spells == nil or talents == nil then
+		return 0
+	end
+
+	local spells = spellsData.spells --[[@as TRB.Classes.Hunter.SurvivalSpells]]
+	if talents:IsTalentActive(spells.tipOfTheSpear) then
+		return spells.tipOfTheSpear.maxStacks or 0
+	end
+
+	return 0
+end
+
 local function CalculateAbilityResourceValue(resource, threshold)
 	local modifier = 1.0
 	if TRB.Data.character.specId == 2 then
@@ -256,14 +270,12 @@ local function ConstructResourceBar(settings)
 		return
 	end
 
-	-- Survival uses secondary bar (Tip of the Spear). maxResource2 must already be populated
-	-- by the snapshot pipeline (EventRegistration -> UpdateResourceValues) before this runs.
+	-- Survival uses secondary bar (Tip of the Spear). Seed the talent-gated node count
+	-- before layout so match-width calculations use the real rendered node count.
 	if barGroups and barGroups.secondary and TRB.Data.character.specId == 3 then
-		local maxStacks = TRB.Data.character.maxResource2
-		if maxStacks == nil or maxStacks == 0 then
-			maxStacks = barGroups.secondary.maxNodes or 3
-		end
+		local maxStacks = GetSurvivalTipOfTheSpearMaxStacks()
 		TRB.Data.character.maxResource2 = maxStacks
+		barGroups.secondary.lastRebuildNodeCount = maxStacks
 	end
 
 	-- Create thresholds on the BarNode (new system)
@@ -284,8 +296,12 @@ local function ConstructResourceBar(settings)
 	-- Survival uses secondary bar (Tip of the Spear); BM/MM do not.
 	if barGroups and barGroups.secondary then
 		if TRB.Data.character.specId == 3 then
-			local maxStacks = TRB.Data.character.maxResource2 or 3
-			barGroups.secondary:RebuildNodes(maxStacks, settings)
+			local maxStacks = TRB.Data.character.maxResource2 or 0
+			if maxStacks > 0 then
+				barGroups.secondary:RebuildNodes(maxStacks, settings)
+			else
+				barGroups.secondary:Hide()
+			end
 		else
 			barGroups.secondary:Hide()
 		end
@@ -1876,26 +1892,26 @@ function TRB.Functions.Class:CheckCharacter()
 		TRB.Data.character.compositeKey = "hunter_survival"
 
 		-- Tip of the Spear: talent-gated secondary resource
-		local spellsData = TRB.Data.spellsData
-		if spellsData and spellsData.spells and talents then
-			local spells = spellsData.spells --[[@as TRB.Classes.Hunter.SurvivalSpells]]
-			local maxComboPoints = 0
-			if talents:IsTalentActive(spells.tipOfTheSpear) then
-				maxComboPoints = spells.tipOfTheSpear.maxStacks
-			end
-			local barGroups = TRB.Frames.barGroups
-			local sharedSettings = TRB.Data.specCache[TRB.Data.character.compositeKey] and TRB.Data.specCache[TRB.Data.character.compositeKey].settings
-			if maxComboPoints ~= TRB.Data.character.maxResource2 then
-				TRB.Data.character.maxResource2 = maxComboPoints
-				if barGroups and barGroups.secondary and sharedSettings then
-					if maxComboPoints > 0 then
-						barGroups.secondary:Show()
-						Bar:ApplyBarGroupsLayout(sharedSettings, barGroups)
-						Bar:ApplyBarGroupsAppearance(sharedSettings, barGroups)
-					else
-						barGroups.secondary:Hide()
-					end
+		local maxComboPoints = GetSurvivalTipOfTheSpearMaxStacks()
+		local barGroups = TRB.Frames.barGroups
+		local sharedSettings = TRB.Data.specCache[TRB.Data.character.compositeKey] and TRB.Data.specCache[TRB.Data.character.compositeKey].settings
+		local maxComboPointsChanged = maxComboPoints ~= TRB.Data.character.maxResource2
+
+		if maxComboPointsChanged then
+			TRB.Data.character.maxResource2 = maxComboPoints
+			TRB.Functions.BarVisibility:MarkDirty()
+		end
+
+		if barGroups and barGroups.secondary and sharedSettings then
+			barGroups.secondary.lastRebuildNodeCount = maxComboPoints
+			if maxComboPoints > 0 then
+				barGroups.secondary:SetMaxNodes(maxComboPoints)
+				Bar:ApplySecondaryBarGroupLayout(sharedSettings, barGroups, maxComboPoints)
+				if maxComboPointsChanged then
+					Bar:ApplyBarGroupsAppearance(sharedSettings, barGroups)
 				end
+			else
+				barGroups.secondary:Hide()
 			end
 		end
 	end

--- a/ClassModules/Hunter.lua
+++ b/ClassModules/Hunter.lua
@@ -1907,6 +1907,8 @@ function TRB.Functions.Class:CheckCharacter()
 			if maxComboPoints > 0 then
 				barGroups.secondary:SetMaxNodes(maxComboPoints)
 				Bar:ApplySecondaryBarGroupLayout(sharedSettings, barGroups, maxComboPoints)
+				barGroups.secondary:Show()
+				barGroups.secondary:ShowNodes(maxComboPoints)
 				if maxComboPointsChanged then
 					Bar:ApplyBarGroupsAppearance(sharedSettings, barGroups)
 				end

--- a/Classes/Bar.lua
+++ b/Classes/Bar.lua
@@ -1493,25 +1493,7 @@ end
 ---@return table<string, TRB.Classes.BarTypeDefinition> # Map of key -> definition for this spec's custom bars
 function TRB.Classes.BarTypeRegistry:GetBarTypesForSpec(classId, specId)
 	local result = {}
-	
-	-- Get the class name from classId
-	local classNames = {
-		[1] = "Warrior",
-		[2] = "Paladin",
-		[3] = "Hunter",
-		[4] = "Rogue",
-		[5] = "Priest",
-		[6] = "DeathKnight",
-		[7] = "Shaman",
-		[8] = "Mage",
-		[9] = "Warlock",
-		[10] = "Monk",
-		[11] = "Druid",
-		[12] = "DemonHunter",
-		[13] = "Evoker"
-	}
-	
-	local className = classNames[classId]
+	local className = TRB.Functions.Character:GetClassModuleName(classId)
 	if not className then
 		return result
 	end

--- a/Functions/Bar.lua
+++ b/Functions/Bar.lua
@@ -2434,6 +2434,34 @@ function TRB.Functions.Bar:ResolveBarHeight(settings, barKey, visited)
 	return barSettings.height or settings.bar.height
 end
 
+---Maps a settings key to its runtime bar key.
+---@param settingKey string
+---@return string barKey
+function TRB.Functions.Bar:GetBarKeyFromSettingsKey(settingKey)
+	if settingKey == "bar" then
+		return "primary"
+	elseif settingKey == "comboPoints" then
+		return "secondary"
+	elseif settingKey == "healthBar" then
+		return "health"
+	end
+	return settingKey
+end
+
+---Maps a runtime bar key to its top-level settings key when one exists.
+---@param barKey string
+---@return string settingKey
+function TRB.Functions.Bar:GetSettingsKeyFromBarKey(barKey)
+	if barKey == "primary" then
+		return "bar"
+	elseif barKey == "secondary" then
+		return "comboPoints"
+	elseif barKey == "health" then
+		return "healthBar"
+	end
+	return barKey
+end
+
 ---Gets the visibility key for a bar key (maps bar keys to displayBar sub-keys).
 ---@param barKey string
 ---@return string

--- a/Functions/BarText.lua
+++ b/Functions/BarText.lua
@@ -40,28 +40,12 @@ local containerAnchorFirstNodeLabelByResourceType = {
 	WhirlwindCharges = L["WhirlwindCharge1"],
 }
 
-local barTextClassNamesById = {
-	[1] = "Warrior",
-	[2] = "Paladin",
-	[3] = "Hunter",
-	[4] = "Rogue",
-	[5] = "Priest",
-	[6] = "DeathKnight",
-	[7] = "Shaman",
-	[8] = "Mage",
-	[9] = "Warlock",
-	[10] = "Monk",
-	[11] = "Druid",
-	[12] = "DemonHunter",
-	[13] = "Evoker"
-}
-
 local function GetSpecBarGroupConfig(classId, specId)
 	if classId == nil or specId == nil then
 		return nil
 	end
 
-	local className = barTextClassNamesById[classId]
+	local className = TRB.Functions.Character:GetClassModuleName(classId)
 	if className == nil then
 		return nil
 	end

--- a/Functions/Character.lua
+++ b/Functions/Character.lua
@@ -634,6 +634,75 @@ function TRB.Functions.Character:DisableSpellRangeCheckUpdate()
 	TRB.Data.cache.values.range = {}
 end
 
+---@param className string?
+---@return string?
+local function NormalizeClassRegistryKey(className)
+	if type(className) ~= "string" then
+		return nil
+	end
+	return string.lower(string.gsub(className, "%s+", ""))
+end
+
+---Look up a classRegistry entry from numeric classId or an internal class name/token.
+---@param classIdOrName number|string
+---@return TRB.Data.ClassRegistryEntry|nil
+function TRB.Functions.Character:GetClassRegistryEntry(classIdOrName)
+	if type(classIdOrName) == "number" then
+		return TRB.Data.classRegistryByIds[classIdOrName]
+	elseif type(classIdOrName) == "string" then
+		local key = NormalizeClassRegistryKey(classIdOrName)
+		if key ~= nil and TRB.Data.classRegistry[key] ~= nil then
+			return TRB.Data.classRegistry[key]
+		end
+		local token = string.upper(string.gsub(classIdOrName, "%s+", ""))
+		return TRB.Data.classRegistryByTokens[token]
+	end
+	return nil
+end
+
+---Returns the addon module/options key for a class, e.g. "DeathKnight".
+---@param classIdOrName number|string
+---@return string|nil
+function TRB.Functions.Character:GetClassModuleName(classIdOrName)
+	local entry = self:GetClassRegistryEntry(classIdOrName)
+	return entry and entry.classModuleName or nil
+end
+
+---Returns the uppercase WoW class file token for a class, e.g. "DEATHKNIGHT".
+---@param classIdOrName number|string
+---@return string|nil
+function TRB.Functions.Character:GetClassToken(classIdOrName)
+	local entry = self:GetClassRegistryEntry(classIdOrName)
+	return entry and entry.classToken or nil
+end
+
+---Returns the numeric classId for an internal class name/token.
+---@param className string
+---@return integer|nil
+function TRB.Functions.Character:GetClassIdFromName(className)
+	local entry = self:GetClassRegistryEntry(className)
+	return entry and entry.classId or nil
+end
+
+---Returns class registry entries in WoW classId order.
+---@return TRB.Data.ClassRegistryEntry[]
+function TRB.Functions.Character:GetClassRegistryEntriesOrdered()
+	return TRB.Data.classRegistryOrder
+end
+
+---Returns spec registry entries in WoW classId/specId order.
+---@return TRB.Data.SpecRegistryEntry[]
+function TRB.Functions.Character:GetSpecRegistryEntriesOrdered()
+	return TRB.Data.specRegistryOrder
+end
+
+---Returns ordered spec registry entries for a class.
+---@param classIdOrName number|string
+---@return TRB.Data.SpecRegistryEntry[]
+function TRB.Functions.Character:GetSpecRegistryEntriesForClass(classIdOrName)
+	local classEntry = self:GetClassRegistryEntry(classIdOrName)
+	return classEntry and classEntry.specs or {}
+end
 
 ---Returns the class file name and specialization name for the given classId and specId.
 ---@param classId number|nil The numeric class ID (1-13). If nil, returns "Global".
@@ -642,20 +711,22 @@ end
 ---@return string className The class file name (e.g., "WARRIOR" or "warrior" if lowerCaseClass is true)
 ---@return string specName The specialization name in camelCase (e.g., "beastMastery"), or "" if not found
 function TRB.Functions.Character:GetClassAndSpecializationNames(classId, specId, lowerCaseClass)
+	local classEntry = classId ~= nil and self:GetClassRegistryEntry(classId) or nil
 	local className
 	if classId ~= nil then
-		className = select(2, GetClassInfo(classId))
+		className = classEntry and classEntry.classToken or select(2, GetClassInfo(classId))
 	else
 		className = "Global"
 	end
 
-	local specName = TRB.Functions.Character:GetSpecializationName(className, specId)
+	local specEntry = classId ~= nil and self:GetSpecRegistryEntryFromIds(classId, specId) or nil
+	local specName = specEntry and specEntry.specName or nil
 	if specName == nil then
 		specName = ""
 	end
 
 	if lowerCaseClass then
-		return string.lower(className), specName
+		return classEntry and classEntry.className or string.lower(className), specName
 	else
 		return className, specName
 	end
@@ -666,115 +737,13 @@ end
 ---@param specId number The numeric spec index (1-4) within the class
 ---@return string|nil specName The camelCase specialization name (e.g., "beastMastery"), or nil if not recognized
 function TRB.Functions.Character:GetSpecializationName(className, specId)
-    className = string.upper(className) -- Should be uppercase anyway from UnitClass() but let's be certain
-	if className == "DEATHKNIGHT" then
-        if specId == 1 then
-            return "blood"
-        elseif specId == 2 then
-            return "frost"
-        elseif specId == 3 then
-            return "unholy"
-        end
-    elseif className == "DEMONHUNTER" then
-        if specId == 1 then
-            return "havoc"
-        elseif specId == 2 then
-            return "vengeance"
-		elseif specId == 3 then
-			return "devourer"
-        end
-    elseif className == "DRUID" then
-        if specId == 1 then
-            return "balance"
-        elseif specId == 2 then
-            return "feral"
-        elseif specId == 3 then
-            return "guardian"
-        elseif specId == 4 then
-            return "restoration"
-        end
-    elseif className == "HUNTER" then
-        if specId == 1 then
-            return "beastMastery"
-        elseif specId == 2 then
-            return "marksmanship"
-        elseif specId == 3 then
-            return "survival"
-        end
-    elseif className == "EVOKER" then
-        if specId == 1 then
-            return "devastation"
-        elseif specId == 2 then
-            return "preservation"
-        elseif specId == 3 then
-            return "augmentation"
-        end
-    elseif className == "MAGE" then
-        if specId == 1 then
-            return "arcane"
-        elseif specId == 2 then
-            return "fire"
-        elseif specId == 3 then
-            return "frost"
-        end
-    elseif className == "MONK" then
-        if specId == 1 then
-            return "brewmaster"
-        elseif specId == 2 then
-            return "mistweaver"
-        elseif specId == 3 then
-            return "windwalker"
-        end
-    elseif className == "PALADIN" then
-        if specId == 1 then
-            return "holy"
-        elseif specId == 2 then
-            return "protection"
-        elseif specId == 3 then
-            return "retribution"
-        end
-    elseif className == "PRIEST" then
-        if specId == 1 then
-            return "discipline"
-        elseif specId == 2 then
-            return "holy"
-        elseif specId == 3 then
-            return "shadow"
-        end
-    elseif className == "ROGUE" then
-        if specId == 1 then
-            return "assassination"
-        elseif specId == 2 then
-            return "outlaw"
-        elseif specId == 3 then
-            return "subtlety"
-        end
-    elseif className == "SHAMAN" then
-        if specId == 1 then
-            return "elemental"
-        elseif specId == 2 then
-            return "enhancement"
-        elseif specId == 3 then
-            return "restoration"
-        end
-    elseif className == "WARLOCK" then
-        if specId == 1 then
-            return "affliction"
-        elseif specId == 2 then
-            return "demonology"
-        elseif specId == 3 then
-            return "destruction"
-        end
-    elseif className == "WARRIOR" then
-        if specId == 1 then
-            return "arms"
-        elseif specId == 2 then
-            return "fury"
-        elseif specId == 3 then
-            return "protection"
-        end
-    end
-    return nil
+	local classEntry = self:GetClassRegistryEntry(className)
+	if classEntry == nil then
+		return nil
+	end
+
+	local specEntry = self:GetSpecRegistryEntryFromIds(classEntry.classId, specId)
+	return specEntry and specEntry.specName or nil
 end
 
 ---Build a composite key from a className and specName.

--- a/Functions/IO.lua
+++ b/Functions/IO.lua
@@ -7,6 +7,211 @@ TRB.Data = TRB.Data or {}
 local EXPORT_STRING_PREFIX = "!TRB!"
 local EXPORT_STRING_PREFIX2 = "!TRBv2!"
 
+local SECONDARY_BAR_EXPORT_SPECS = {
+	[1] = { [2] = true },
+	[2] = { [1] = true, [2] = true, [3] = true },
+	[3] = { [3] = true },
+	[4] = { [1] = true, [2] = true, [3] = true },
+	[5] = { [1] = true },
+	[6] = { [1] = true, [2] = true, [3] = true },
+	[7] = { [2] = true },
+	[8] = { [1] = true, [3] = true },
+	[9] = { [1] = true, [2] = true, [3] = true },
+	[10] = { [3] = true },
+	[11] = { [2] = true },
+	[12] = { [2] = true, [3] = true },
+	[13] = { [1] = true, [2] = true, [3] = true },
+}
+
+local CUSTOM_BAR_EXPORT_SPECS = {
+	[1] = {
+		[2] = { "whirlwind" },
+		[3] = { "defensives" },
+	},
+	[5] = {
+		[1] = { "utility" },
+		[2] = { "holyWords", "lightweaver", "utility" },
+		[3] = { "mana", "utility" },
+	},
+	[6] = {
+		[1] = { "boneShield" },
+	},
+	[7] = {
+		[1] = { "mana" },
+	},
+	[10] = {
+		[1] = { "stagger" },
+	},
+	[11] = {
+		[1] = { "mana" },
+	},
+	[13] = {
+		[3] = { "ebonMight" },
+	},
+}
+
+local CORE_TEXTURE_KEYS = {
+	"background",
+	"backgroundName",
+	"border",
+	"borderName",
+	"resourceBar",
+	"resourceBarName",
+	"textureLock",
+	"healthBackground",
+	"healthBackgroundName",
+	"healthBorder",
+	"healthBorderName",
+	"healthBar",
+	"healthBarName",
+	"absorbBar",
+	"absorbBarName",
+	"incomingHealBar",
+	"incomingHealBarName",
+	"castingBar",
+	"castingBarName",
+}
+
+local DRUID_DISPLAY_BAR_FLAG_KEYS = {
+	"enableFormSwitching",
+	"showComboPoints",
+}
+
+local function CopyKey(destination, source, key)
+	if destination ~= nil and source ~= nil and source[key] ~= nil then
+		destination[key] = source[key]
+	end
+end
+
+local function CopyKeys(destination, source, keys)
+	if destination == nil or source == nil then
+		return
+	end
+
+	for _, key in ipairs(keys) do
+		CopyKey(destination, source, key)
+	end
+end
+
+local function CopyTexturePrefix(destination, source, prefix)
+	CopyKeys(destination, source, {
+		prefix .. "Bar",
+		prefix .. "BarName",
+		prefix .. "Border",
+		prefix .. "BorderName",
+		prefix .. "Background",
+		prefix .. "BackgroundName",
+	})
+end
+
+local function CopyDruidDisplayBarFlags(configuration, settings, classId)
+	if classId ~= 11 then
+		return
+	end
+
+	CopyKeys(configuration.displayBar, settings.displayBar, DRUID_DISPLAY_BAR_FLAG_KEYS)
+end
+
+local function GetSpecBarGroupConfiguration(classId, specId)
+	local className = TRB.Functions.Character:GetClassModuleName(classId)
+	if className == nil then
+		return nil
+	end
+
+	local classModule = TRB.Classes and TRB.Classes[className]
+	if classModule == nil or classModule.BarGroupsFactory == nil or classModule.BarGroupsFactory.GetSpecConfiguration == nil then
+		return nil
+	end
+
+	return classModule.BarGroupsFactory:GetSpecConfiguration(specId)
+end
+
+local function ShouldExportSecondaryBar(classId, specId, settings)
+	local hasSecondarySettings = settings.comboPoints ~= nil or (settings.colors ~= nil and settings.colors.comboPoints ~= nil)
+	if not hasSecondarySettings then
+		return false
+	end
+
+	if SECONDARY_BAR_EXPORT_SPECS[classId] ~= nil and SECONDARY_BAR_EXPORT_SPECS[classId][specId] == true then
+		return true
+	end
+
+	local specConfiguration = GetSpecBarGroupConfiguration(classId, specId)
+	return specConfiguration ~= nil and specConfiguration.secondary ~= nil
+end
+
+local function AddCustomBarKey(allowedBars, barKey)
+	if barKey ~= nil then
+		allowedBars[barKey] = true
+	end
+end
+
+local function GetAllowedCustomBarKeys(classId, specId)
+	local allowedBars = {}
+	local registry = TRB.Classes and TRB.Classes.BarTypeRegistry and TRB.Classes.BarTypeRegistry:GetInstance()
+
+	if registry ~= nil then
+		local registryBars = registry:GetBarTypesForSpec(classId, specId)
+		for barKey in pairs(registryBars) do
+			AddCustomBarKey(allowedBars, barKey)
+		end
+	end
+
+	local classBars = CUSTOM_BAR_EXPORT_SPECS[classId]
+	local specBars = classBars and classBars[specId]
+	if specBars ~= nil then
+		for _, barKey in ipairs(specBars) do
+			AddCustomBarKey(allowedBars, barKey)
+		end
+	end
+
+	return allowedBars
+end
+
+local function CopySecondaryBarConfiguration(configuration, settings)
+	configuration.comboPoints = settings.comboPoints
+	configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
+
+	CopyKey(configuration.displayBar, settings.displayBar, "secondary")
+	CopyTexturePrefix(configuration.textures, settings.textures, "comboPoints")
+	CopyKeys(configuration.textures, settings.textures, {
+		"comboPointsCastingBar",
+		"comboPointsCastingBarName",
+	})
+end
+
+local function CopyCustomBarConfiguration(configuration, settings, barKey)
+	local registry = TRB.Classes and TRB.Classes.BarTypeRegistry and TRB.Classes.BarTypeRegistry:GetInstance()
+	local barTypeDef = registry and registry:Get(barKey)
+	local barSettings = settings.bars and settings.bars[barKey]
+
+	if barSettings ~= nil then
+		configuration.bars = configuration.bars or {}
+		configuration.bars[barKey] = barSettings
+
+		local visibilityKey = barTypeDef and barTypeDef.visibilityKey or barKey
+		CopyKey(configuration.displayBar, settings.displayBar, visibilityKey)
+		CopyTexturePrefix(configuration.textures, settings.textures, barKey)
+
+		if barKey == "mana" then
+			CopyTexturePrefix(configuration.textures, settings.textures, "manaBar")
+		end
+	end
+
+	local barColors = settings.colors and settings.colors.bars and settings.colors.bars[barKey]
+	if barColors ~= nil then
+		configuration.colors.bars = configuration.colors.bars or {}
+		configuration.colors.bars[barKey] = barColors
+	end
+end
+
+local function CopyCustomBarConfigurations(configuration, settings, classId, specId)
+	local allowedBars = GetAllowedCustomBarKeys(classId, specId)
+	for barKey in pairs(allowedBars) do
+		CopyCustomBarConfiguration(configuration, settings, barKey)
+	end
+end
+
 ---Extracts selected configuration sections (bar display, thresholds, font/text, audio/tracking, bar text) from a single spec's settings table into an export-ready table, including class/spec-specific fields like combo points, mana bar, or stagger bar.
 ---@param classId integer # WoW class ID (1=Warrior, 2=Paladin, ..., 13=Evoker)
 ---@param specId integer # Specialization index within the class (1-based)
@@ -26,263 +231,23 @@ local function ExportConfigurationSections(classId, specId, settings, includeBar
 	if includeBarDisplay then
 		configuration.bar = settings.bar
 		configuration.healthBar = settings.healthBar
-		configuration.displayBar = settings.displayBar
-		configuration.textures = settings.textures or {}
+		configuration.displayBar = {}
+		configuration.textures = {}
 		configuration.colors.bar = settings.colors and settings.colors.bar
 		configuration.colors.shared = settings.colors and settings.colors.shared
 		configuration.colors.healthBar = settings.colors and settings.colors.healthBar
 		configuration.overcap = settings.overcap
 		configuration.endOf = settings.endOf
 
-		if classId == 1 then -- Warrior
-			if specId == 1 then -- Arms
-			elseif specId == 2 then -- Fury
-				configuration.comboPoints = settings.comboPoints
-				configuration.colors.bars = configuration.colors.bars or {}
-				configuration.colors.bars.whirlwind = settings.colors and settings.colors.bars and settings.colors.bars.whirlwind
-			elseif specId == 3 then -- Protection
-				-- Export defensives bar settings
-				configuration.bars = configuration.bars or {}
-				configuration.bars.defensives = settings.bars and settings.bars.defensives
-				configuration.colors.bars = configuration.colors.bars or {}
-				configuration.colors.bars.defensives = settings.colors and settings.colors.bars and settings.colors.bars.defensives
-				-- Export flat texture keys
-				configuration.textures.defensivesBar = settings.textures and settings.textures.defensivesBar
-				configuration.textures.defensivesBarName = settings.textures and settings.textures.defensivesBarName
-				configuration.textures.defensivesBorder = settings.textures and settings.textures.defensivesBorder
-				configuration.textures.defensivesBorderName = settings.textures and settings.textures.defensivesBorderName
-				configuration.textures.defensivesBackground = settings.textures and settings.textures.defensivesBackground
-				configuration.textures.defensivesBackgroundName = settings.textures and settings.textures.defensivesBackgroundName
-			end
-		elseif classId == 2 then -- Paladin
-			if specId == 1 then -- Holy
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			elseif specId == 2 then -- Protection
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			elseif specId == 3 then -- Retribution
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			end
-		elseif classId == 3 then -- Hunters
-			if specId == 1 then -- Beast Mastery
-			elseif specId == 2 then -- Marksmanship
-			elseif specId == 3 then -- Survival
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			end
-		elseif classId == 4 then -- Rogue
-			if specId == 1 then -- Assassination
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			elseif specId == 2 then -- Outlaw
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			elseif specId == 3 then -- Subtlety
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			end 
-		elseif classId == 5 then -- Priests
-			if specId == 1 then -- Discipline
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-				-- Export utility bar settings
-				configuration.bars = configuration.bars or {}
-				configuration.bars.utility = settings.bars and settings.bars.utility
-				configuration.colors.bars = configuration.colors.bars or {}
-				configuration.colors.bars.utility = settings.colors and settings.colors.bars and settings.colors.bars.utility
-				configuration.textures.utilityBar = settings.textures and settings.textures.utilityBar
-				configuration.textures.utilityBarName = settings.textures and settings.textures.utilityBarName
-				configuration.textures.utilityBorder = settings.textures and settings.textures.utilityBorder
-				configuration.textures.utilityBorderName = settings.textures and settings.textures.utilityBorderName
-				configuration.textures.utilityBackground = settings.textures and settings.textures.utilityBackground
-				configuration.textures.utilityBackgroundName = settings.textures and settings.textures.utilityBackgroundName
-			elseif specId == 2 then -- Holy
-				-- Export Holy Words bar settings
-				configuration.bars = configuration.bars or {}
-				configuration.bars.holyWords = settings.bars and settings.bars.holyWords
-				configuration.colors.bars = configuration.colors.bars or {}
-				configuration.colors.bars.holyWords = settings.colors and settings.colors.bars and settings.colors.bars.holyWords
-				configuration.textures.holyWordsBar = settings.textures and settings.textures.holyWordsBar
-				configuration.textures.holyWordsBarName = settings.textures and settings.textures.holyWordsBarName
-				configuration.textures.holyWordsBorder = settings.textures and settings.textures.holyWordsBorder
-				configuration.textures.holyWordsBorderName = settings.textures and settings.textures.holyWordsBorderName
-				configuration.textures.holyWordsBackground = settings.textures and settings.textures.holyWordsBackground
-				configuration.textures.holyWordsBackgroundName = settings.textures and settings.textures.holyWordsBackgroundName
-				-- Export Lightweaver bar settings
-				configuration.bars.lightweaver = settings.bars and settings.bars.lightweaver
-				configuration.colors.bars.lightweaver = settings.colors and settings.colors.bars and settings.colors.bars.lightweaver
-				configuration.textures.lightweaverBar = settings.textures and settings.textures.lightweaverBar
-				configuration.textures.lightweaverBarName = settings.textures and settings.textures.lightweaverBarName
-				configuration.textures.lightweaverBorder = settings.textures and settings.textures.lightweaverBorder
-				configuration.textures.lightweaverBorderName = settings.textures and settings.textures.lightweaverBorderName
-				configuration.textures.lightweaverBackground = settings.textures and settings.textures.lightweaverBackground
-				configuration.textures.lightweaverBackgroundName = settings.textures and settings.textures.lightweaverBackgroundName
-				-- Export utility bar settings
-				configuration.bars.utility = settings.bars and settings.bars.utility
-				configuration.colors.bars.utility = settings.colors and settings.colors.bars and settings.colors.bars.utility
-				configuration.textures.utilityBar = settings.textures and settings.textures.utilityBar
-				configuration.textures.utilityBarName = settings.textures and settings.textures.utilityBarName
-				configuration.textures.utilityBorder = settings.textures and settings.textures.utilityBorder
-				configuration.textures.utilityBorderName = settings.textures and settings.textures.utilityBorderName
-				configuration.textures.utilityBackground = settings.textures and settings.textures.utilityBackground
-				configuration.textures.utilityBackgroundName = settings.textures and settings.textures.utilityBackgroundName
-			elseif specId == 3 then -- Shadow
-				-- Export mana bar settings
-				configuration.bars = configuration.bars or {}
-				configuration.bars.mana = settings.bars and settings.bars.mana
-				configuration.colors.bars = configuration.colors.bars or {}
-				configuration.colors.bars.mana = settings.colors and settings.colors.bars and settings.colors.bars.mana
-				-- Export flat texture keys
-				configuration.textures.manaBar = settings.textures and settings.textures.manaBar
-				configuration.textures.manaBarName = settings.textures and settings.textures.manaBarName
-				configuration.textures.manaBorder = settings.textures and settings.textures.manaBorder
-				configuration.textures.manaBorderName = settings.textures and settings.textures.manaBorderName
-				configuration.textures.manaBackground = settings.textures and settings.textures.manaBackground
-				configuration.textures.manaBackgroundName = settings.textures and settings.textures.manaBackgroundName
-				-- Export utility bar settings
-				configuration.bars.utility = settings.bars and settings.bars.utility
-				configuration.colors.bars.utility = settings.colors and settings.colors.bars and settings.colors.bars.utility
-				configuration.textures.utilityBar = settings.textures and settings.textures.utilityBar
-				configuration.textures.utilityBarName = settings.textures and settings.textures.utilityBarName
-				configuration.textures.utilityBorder = settings.textures and settings.textures.utilityBorder
-				configuration.textures.utilityBorderName = settings.textures and settings.textures.utilityBorderName
-				configuration.textures.utilityBackground = settings.textures and settings.textures.utilityBackground
-				configuration.textures.utilityBackgroundName = settings.textures and settings.textures.utilityBackgroundName
-			end
-		elseif classId == 6 then -- Death Knight
-			if specId == 1 then -- Blood
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-				-- Bone Shield bar
-				configuration.bars = configuration.bars or {}
-				configuration.bars.boneShield = settings.bars and settings.bars.boneShield
-				configuration.colors.bars = configuration.colors.bars or {}
-				configuration.colors.bars.boneShield = settings.colors and settings.colors.bars and settings.colors.bars.boneShield
-				configuration.textures.boneShieldBar = settings.textures and settings.textures.boneShieldBar
-				configuration.textures.boneShieldBarName = settings.textures and settings.textures.boneShieldBarName
-				configuration.textures.boneShieldBorder = settings.textures and settings.textures.boneShieldBorder
-				configuration.textures.boneShieldBorderName = settings.textures and settings.textures.boneShieldBorderName
-				configuration.textures.boneShieldBackground = settings.textures and settings.textures.boneShieldBackground
-				configuration.textures.boneShieldBackgroundName = settings.textures and settings.textures.boneShieldBackgroundName
-			elseif specId == 2 then -- Frost
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			elseif specId == 3 then -- Unholy
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			end
-		elseif classId == 7 then -- Shaman
-			if specId == 1 then -- Elemental
-				-- Export mana bar settings
-				configuration.bars = configuration.bars or {}
-				configuration.bars.mana = settings.bars and settings.bars.mana
-				configuration.colors.bars = configuration.colors.bars or {}
-				configuration.colors.bars.mana = settings.colors and settings.colors.bars and settings.colors.bars.mana
-				-- Export flat texture keys
-				configuration.textures.manaBar = settings.textures and settings.textures.manaBar
-				configuration.textures.manaBarName = settings.textures and settings.textures.manaBarName
-				configuration.textures.manaBorder = settings.textures and settings.textures.manaBorder
-				configuration.textures.manaBorderName = settings.textures and settings.textures.manaBorderName
-				configuration.textures.manaBackground = settings.textures and settings.textures.manaBackground
-				configuration.textures.manaBackgroundName = settings.textures and settings.textures.manaBackgroundName
-			elseif specId == 2 then -- Enhancement
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			elseif specId == 3 then -- Restoration
-			end
-		elseif classId == 8 then -- Mage
-			if specId == 1 then -- Arcane
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			elseif specId == 2 then -- Fire
-			elseif specId == 3 then -- Frost
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			end
-		elseif classId == 9 then -- Warlock
-			if specId == 1 then -- Affliction
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			elseif specId == 2 then -- Demonology
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			elseif specId == 3 then -- Destruction
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			end
-		elseif classId == 10 then -- Monk
-			if specId == 1 then -- Brewmaster
-				-- Export stagger bar settings
-				configuration.bars = configuration.bars or {}
-				configuration.bars.stagger = settings.bars and settings.bars.stagger
-				configuration.colors.bars = configuration.colors.bars or {}
-				configuration.colors.bars.stagger = settings.colors and settings.colors.bars and settings.colors.bars.stagger
-				-- Export flat texture keys (same pattern as manaBar)
-				configuration.textures.staggerBar = settings.textures and settings.textures.staggerBar
-				configuration.textures.staggerBarName = settings.textures and settings.textures.staggerBarName
-				configuration.textures.staggerBorder = settings.textures and settings.textures.staggerBorder
-				configuration.textures.staggerBorderName = settings.textures and settings.textures.staggerBorderName
-				configuration.textures.staggerBackground = settings.textures and settings.textures.staggerBackground
-				configuration.textures.staggerBackgroundName = settings.textures and settings.textures.staggerBackgroundName
-			elseif specId == 2 then -- Mistweaver
-			elseif specId == 3 then -- Windwalker
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			end
-		elseif classId == 11 then -- Druids
-			if specId == 1 then -- Balance
-				-- Export mana bar settings
-				configuration.bars = configuration.bars or {}
-				configuration.bars.mana = settings.bars and settings.bars.mana
-				configuration.colors.bars = configuration.colors.bars or {}
-				configuration.colors.bars.mana = settings.colors and settings.colors.bars and settings.colors.bars.mana
-				-- Export flat texture keys
-				configuration.textures.manaBar = settings.textures and settings.textures.manaBar
-				configuration.textures.manaBarName = settings.textures and settings.textures.manaBarName
-				configuration.textures.manaBorder = settings.textures and settings.textures.manaBorder
-				configuration.textures.manaBorderName = settings.textures and settings.textures.manaBorderName
-				configuration.textures.manaBackground = settings.textures and settings.textures.manaBackground
-				configuration.textures.manaBackgroundName = settings.textures and settings.textures.manaBackgroundName
-			elseif specId == 2 then -- Feral
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			elseif specId == 3 then -- Guardian
-			elseif specId == 4 then -- Restoration
-			end
-		elseif classId == 12 then -- Demon Hunter
-			if specId == 1 then -- Havoc
-			elseif specId == 2 then -- Vengeance
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			elseif specId == 3 then -- Devourer
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			end
-		elseif classId == 13 then -- Evoker
-			if specId == 1 then -- Devastation
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			elseif specId == 2 then -- Preservation
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-			elseif specId == 3 then -- Augmentation
-				configuration.colors.comboPoints = settings.colors and settings.colors.comboPoints
-				configuration.comboPoints = settings.comboPoints
-				-- Export Ebon Might bar settings
-				configuration.bars = configuration.bars or {}
-				configuration.bars.ebonMight = settings.bars and settings.bars.ebonMight
-				configuration.colors.bars = configuration.colors.bars or {}
-				configuration.colors.bars.ebonMight = settings.colors and settings.colors.bars and settings.colors.bars.ebonMight
-				configuration.textures.ebonMightBar = settings.textures and settings.textures.ebonMightBar
-				configuration.textures.ebonMightBarName = settings.textures and settings.textures.ebonMightBarName
-				configuration.textures.ebonMightBorder = settings.textures and settings.textures.ebonMightBorder
-				configuration.textures.ebonMightBorderName = settings.textures and settings.textures.ebonMightBorderName
-				configuration.textures.ebonMightBackground = settings.textures and settings.textures.ebonMightBackground
-				configuration.textures.ebonMightBackgroundName = settings.textures and settings.textures.ebonMightBackgroundName
-			end
+		CopyKeys(configuration.displayBar, settings.displayBar, { "primary", "health" })
+		CopyDruidDisplayBarFlags(configuration, settings, classId)
+		CopyKeys(configuration.textures, settings.textures, CORE_TEXTURE_KEYS)
+
+		if ShouldExportSecondaryBar(classId, specId, settings) then
+			CopySecondaryBarConfiguration(configuration, settings)
 		end
+
+		CopyCustomBarConfigurations(configuration, settings, classId, specId)
 	end
 
 	if includeThresholds then
@@ -295,143 +260,14 @@ local function ExportConfigurationSections(classId, specId, settings, includeBar
 		configuration.precision = settings.precision
 		configuration.displayText.default = settings.displayText and settings.displayText.default
 
-		if classId == 1 then -- Warrior
-			if specId == 1 then -- Arms
-			elseif specId == 2 then -- Fury
-			elseif specId == 3 then -- Protection
-			end
-		elseif classId == 2 then -- Paladins
-			if specId == 1 then -- Holy
-			elseif specId == 2 then -- Protection
-			elseif specId == 3 then -- Retribution
-			end
-		elseif classId == 3 then -- Hunters
-			if specId == 1 then -- Beast Mastery
-			elseif specId == 2 then -- Marksmanship
-			elseif specId == 3 then -- Survival
-			end
-		elseif classId == 4 then -- Rogue
-			if specId == 1 then -- Assassination
-			elseif specId == 2 then -- Outlaw
-			elseif specId == 3 then -- Subtlety
-			end 
-		elseif classId == 5 then -- Priests
-			if specId == 1 then -- Discipline
-			elseif specId == 2 then -- Holy
-			elseif specId == 3 then -- Shadow
-				configuration.hasteApproachingThreshold = settings.hasteApproachingThreshold
-				configuration.hasteThreshold = settings.hasteThreshold
-			end
-		elseif classId == 6 then -- Death Knight
-			if specId == 1 then -- Blood
-			elseif specId == 2 then -- Frost
-			elseif specId == 3 then -- Unholy
-			end
-		elseif classId == 7 then -- Shaman
-			if specId == 1 then -- Elemental
-			elseif specId == 2 then -- Enhancement
-			elseif specId == 3 then -- Restoration
-			end
-		elseif classId == 8 then -- Mage
-			if specId == 1 then -- Arcane
-			elseif specId == 2 then -- Fire
-			elseif specId == 3 then -- Frost
-			end
-		elseif classId == 9 then -- Warlock
-			if specId == 1 then -- Affliction
-			end
-		elseif classId == 10 then -- Monk
-			if specId == 1 then -- Brewmaster
-			elseif specId == 2 then -- Mistweaver
-			elseif specId == 3 then -- Windwalker
-			end
-		elseif classId == 11 then -- Druids
-			if specId == 1 then -- Balance
-			elseif specId == 2 then -- Feral
-			elseif specId == 3 then -- Guardian
-			elseif specId == 4 then -- Restoration
-			end
-		elseif classId == 12 then -- Demon Hunter
-			if specId == 1 then -- Havoc
-			elseif specId == 2 then -- Vengeance
-			elseif specId == 3 then -- Devourer
-			end
-		elseif classId == 13 then -- Evoker
-			if specId == 1 then -- Devastation
-			elseif specId == 2 then -- Preservation
-			elseif specId == 3 then -- Augmentation
-			end
+		if classId == 5 and specId == 3 then -- Shadow Priest
+			configuration.hasteApproachingThreshold = settings.hasteApproachingThreshold
+			configuration.hasteThreshold = settings.hasteThreshold
 		end
 	end
 
 	if includeAudioAndTracking then
 		configuration.audio = settings.audio
-
-		if classId == 1 then -- Warrior
-			if specId == 1 then -- Arms
-			elseif specId == 2 then -- Fury
-			elseif specId == 3 then -- Protection
-			end
-		elseif classId == 2 then -- Paladin
-			if specId == 1 then -- Holy
-			elseif specId == 2 then -- Protection
-			elseif specId == 3 then -- Retribution
-			end
-		elseif classId == 3 then -- Hunters
-			if specId == 1 then -- Beast Mastery
-			elseif specId == 2 then -- Marksmanship
-			elseif specId == 3 then -- Survival
-			end
-		elseif classId == 4 then -- Rogues
-			if specId == 1 then -- Assassination
-			elseif specId == 2 then -- Outlaw
-			elseif specId == 3 then -- Subtlety
-			end
-		elseif classId == 5 then -- Priests
-			if specId == 1 then -- Discipline
-			elseif specId == 2 then -- Holy
-			elseif specId == 3 then -- Shadow
-			end
-		elseif classId == 6 then -- Death Knight
-			if specId == 1 then -- Blood
-			elseif specId == 2 then -- Frost
-			elseif specId == 3 then -- Unholy
-			end
-		elseif classId == 7 then -- Shaman
-			if specId == 1 then -- Elemental
-			elseif specId == 2 then -- Enhancement
-			elseif specId == 3 then -- Restoration
-			end
-		elseif classId == 8 then -- Mage
-			if specId == 1 then -- Arcane
-			elseif specId == 2 then -- Fire
-			elseif specId == 3 then -- Frost
-			end
-		elseif classId == 9 then -- Warlock
-			if specId == 1 then -- Affliction
-			end
-		elseif classId == 10 then -- Monk
-			if specId == 1 then -- Brewmaster
-			elseif specId == 2 then -- Mistweaver
-			elseif specId == 3 then -- Windwalker
-			end
-		elseif classId == 11 then -- Druid
-			if specId == 1 then -- Balance
-			elseif specId == 2 then -- Feral
-			elseif specId == 3 then -- Guardian
-			elseif specId == 4 then -- Restoration
-			end
-		elseif classId == 12 then -- Demon Hunter
-			if specId == 1 then -- Havoc
-			elseif specId == 2 then -- Vengeance
-			elseif specId == 3 then -- Devourer
-			end
-		elseif classId == 13 then -- Evoker
-			if specId == 1 then -- Devastation
-			elseif specId == 2 then -- Preservation
-			elseif specId == 3 then -- Augmentation
-			end
-		end
 	end
 
 	if includeBarText then
@@ -481,296 +317,37 @@ local function ExportGetConfiguration(classId, specId, includeBarDisplay, includ
 
 	local configuration = {}
 
-	if classId ~= nil then -- One class
-		if classId == 1 and settings.warrior ~= nil then -- Warrior
-			configuration.warrior = {}
+	local function ExportClassEntry(entry)
+		if entry == nil then
+			return
+		end
 
-			if (specId == 1 or specId == nil) and TRB.Functions.Table:Length(settings.warrior.arms) > 0 then -- Arms
-				configuration.warrior.arms = ExportConfigurationSections(1, 1, settings.warrior.arms, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
+		local classSettings = settings[entry.className]
+		if type(classSettings) ~= "table" then
+			return
+		end
 
-			if (specId == 2 or specId == nil) and TRB.Functions.Table:Length(settings.warrior.fury) > 0 then -- Fury
-				configuration.warrior.fury = ExportConfigurationSections(1, 2, settings.warrior.fury, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 3 or specId == nil) and TRB.Functions.Table:Length(settings.warrior.protection) > 0 then -- Protection
-				configuration.warrior.protection = ExportConfigurationSections(1, 3, settings.warrior.protection, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-		elseif classId == 2 and settings.paladin ~= nil then -- Paladin
-			configuration.paladin = {}
-			
-			if (specId == 1 or specId == nil) and TRB.Functions.Table:Length(settings.paladin.holy) > 0 then -- Holy
-				configuration.paladin.holy = ExportConfigurationSections(2, 1, settings.paladin.holy, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-			if (specId == 2 or specId == nil) and TRB.Functions.Table:Length(settings.paladin.protection) > 0 then -- Protection
-				configuration.paladin.protection = ExportConfigurationSections(2, 2, settings.paladin.protection, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-			if (specId == 3 or specId == nil) and TRB.Functions.Table:Length(settings.paladin.retribution) > 0 then -- Retribution
-				configuration.paladin.retribution = ExportConfigurationSections(2, 3, settings.paladin.retribution, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-		elseif classId == 3 and settings.hunter ~= nil then -- Hunter
-			configuration.hunter = {}
-
-			if (specId == 1 or specId == nil) and TRB.Functions.Table:Length(settings.hunter.beastMastery) > 0 then -- Beast Mastery
-				configuration.hunter.beastMastery = ExportConfigurationSections(3, 1, settings.hunter.beastMastery, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 2 or specId == nil) and TRB.Functions.Table:Length(settings.hunter.marksmanship) > 0 then -- Marksmanship
-				configuration.hunter.marksmanship = ExportConfigurationSections(3, 2, settings.hunter.marksmanship, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 3 or specId == nil) and TRB.Functions.Table:Length(settings.hunter.survival) > 0 then -- Survival
-				configuration.hunter.survival = ExportConfigurationSections(3, 3, settings.hunter.survival, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-		elseif classId == 4 and settings.rogue ~= nil then -- Rogue
-			configuration.rogue = {}
-
-			if (specId == 1 or specId == nil) and TRB.Functions.Table:Length(settings.rogue.assassination) > 0 then -- Assassination
-				configuration.rogue.assassination = ExportConfigurationSections(4, 1, settings.rogue.assassination, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 2 or specId == nil) and TRB.Functions.Table:Length(settings.rogue.outlaw) > 0 then -- Outlaw
-				configuration.rogue.outlaw = ExportConfigurationSections(4, 2, settings.rogue.outlaw, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 3 or specId == nil) and TRB.Functions.Table:Length(settings.rogue.subtlety) > 0 then -- Subtlety
-				configuration.rogue.subtlety = ExportConfigurationSections(4, 3, settings.rogue.subtlety, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-		elseif classId == 5 and settings.priest ~= nil then -- Priest
-			configuration.priest = {}
-			if (specId == 1 or specId == nil) and TRB.Functions.Table:Length(settings.priest.discipline) > 0 then -- Discipline
-				configuration.priest.discipline = ExportConfigurationSections(5, 1, settings.priest.discipline, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 2 or specId == nil) and TRB.Functions.Table:Length(settings.priest.holy) > 0 then -- Holy
-				configuration.priest.holy = ExportConfigurationSections(5, 2, settings.priest.holy, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 3 or specId == nil) and TRB.Functions.Table:Length(settings.priest.shadow) > 0 then -- Shadow
-				configuration.priest.shadow = ExportConfigurationSections(5, 3, settings.priest.shadow, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-		elseif classId == 6 and settings.deathknight ~= nil then -- Death Knight
-			configuration.deathknight = {}
-			if (specId == 1 or specId == nil) and TRB.Functions.Table:Length(settings.deathknight.blood) > 0 then -- Blood
-				configuration.deathknight.blood = ExportConfigurationSections(6, 1, settings.deathknight.blood, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 2 or specId == nil) and TRB.Functions.Table:Length(settings.deathknight.frost) > 0 then -- Frost
-				configuration.deathknight.frost = ExportConfigurationSections(6, 2, settings.deathknight.frost, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 3 or specId == nil) and TRB.Functions.Table:Length(settings.deathknight.unholy) > 0 then -- Unholy
-				configuration.deathknight.unholy = ExportConfigurationSections(6, 3, settings.deathknight.unholy, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-		elseif classId == 7 and settings.shaman ~= nil then -- Shaman
-			configuration.shaman = {}
-
-			if (specId == 1 or specId == nil) and TRB.Functions.Table:Length(settings.shaman.elemental) > 0 then -- Elemental
-				configuration.shaman.elemental = ExportConfigurationSections(7, 1, settings.shaman.elemental, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-			
-			if (specId == 2 or specId == nil) and TRB.Functions.Table:Length(settings.shaman.enhancement) > 0 then -- Enhancement
-				configuration.shaman.enhancement = ExportConfigurationSections(7, 2, settings.shaman.enhancement, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 3 or specId == nil) and TRB.Functions.Table:Length(settings.shaman.restoration) > 0 then -- Restoration
-				configuration.shaman.restoration = ExportConfigurationSections(7, 3, settings.shaman.restoration, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-		elseif classId == 8 and settings.mage ~= nil then -- Mage
-			configuration.mage = {}
-			if (specId == 1 or specId == nil) and TRB.Functions.Table:Length(settings.mage.arcane) > 0 then -- Arcane
-				configuration.mage.arcane = ExportConfigurationSections(8, 1, settings.mage.arcane, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 2 or specId == nil) and TRB.Functions.Table:Length(settings.mage.fire) > 0 then -- Fire
-				configuration.mage.fire = ExportConfigurationSections(8, 2, settings.mage.fire, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 3 or specId == nil) and TRB.Functions.Table:Length(settings.mage.frost) > 0 then -- Frost
-				configuration.mage.frost = ExportConfigurationSections(8, 3, settings.mage.frost, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-		elseif classId == 9 and settings.warlock ~= nil then
-			configuration.warlock = {}
-			
-			if (specId == 1 or specId == nil) and TRB.Functions.Table:Length(settings.warlock.affliction) > 0 then -- Affliction
-				configuration.warlock.affliction = ExportConfigurationSections(9, 1, settings.warlock.affliction, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 2 or specId == nil) and TRB.Functions.Table:Length(settings.warlock.demonology) > 0 then -- Demonology
-				configuration.warlock.demonology = ExportConfigurationSections(9, 2, settings.warlock.demonology, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 3 or specId == nil) and TRB.Functions.Table:Length(settings.warlock.destruction) > 0 then -- Destruction
-				configuration.warlock.destruction = ExportConfigurationSections(9, 3, settings.warlock.destruction, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-		elseif classId == 10 and settings.monk ~= nil then -- Monk
-			configuration.monk = {}
-
-			if (specId == 1 or specId == nil) and TRB.Functions.Table:Length(settings.monk.brewmaster) > 0 then -- Brewmaster
-				configuration.monk.brewmaster = ExportConfigurationSections(10, 1, settings.monk.brewmaster, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 2 or specId == nil) and TRB.Functions.Table:Length(settings.monk.mistweaver) > 0 then -- Mistweaver
-				configuration.monk.mistweaver = ExportConfigurationSections(10, 2, settings.monk.mistweaver, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 3 or specId == nil) and TRB.Functions.Table:Length(settings.monk.windwalker) > 0 then -- Windwalker
-				configuration.monk.windwalker = ExportConfigurationSections(10, 3, settings.monk.windwalker, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-		elseif classId == 11 and settings.druid ~= nil then -- Druid
-			configuration.druid = {}
-			
-			if (specId == 1 or specId == nil) and TRB.Functions.Table:Length(settings.druid.balance) > 0 then -- Balance
-				configuration.druid.balance = ExportConfigurationSections(11, 1, settings.druid.balance, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-			
-			if (specId == 2 or specId == nil) and TRB.Functions.Table:Length(settings.druid.feral) > 0 then -- Feral
-				configuration.druid.feral = ExportConfigurationSections(11, 2, settings.druid.feral, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 3 or specId == nil) and TRB.Functions.Table:Length(settings.druid.guardian) > 0 then -- Guardian
-				configuration.druid.guardian = ExportConfigurationSections(11, 3, settings.druid.guardian, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 4 or specId == nil) and TRB.Functions.Table:Length(settings.druid.restoration) > 0 then -- Restoration
-				configuration.druid.restoration = ExportConfigurationSections(11, 4, settings.druid.restoration, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-		elseif classId == 12 and settings.demonhunter ~= nil then -- Demon Hunter
-			configuration.demonhunter = {}
-			
-			if (specId == 1 or specId == nil) and TRB.Functions.Table:Length(settings.demonhunter.havoc) > 0 then -- Havoc
-				configuration.demonhunter.havoc = ExportConfigurationSections(12, 1, settings.demonhunter.havoc, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 2 or specId == nil) and TRB.Functions.Table:Length(settings.demonhunter.vengeance) > 0 then -- Vengeance
-				configuration.demonhunter.vengeance = ExportConfigurationSections(12, 2, settings.demonhunter.vengeance, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 3 or specId == nil) and TRB.Functions.Table:Length(settings.demonhunter.devourer) > 0 then -- Devourer
-				configuration.demonhunter.devourer = ExportConfigurationSections(12, 3, settings.demonhunter.devourer, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-		elseif classId == 13 and settings.evoker ~= nil then -- Evoker
-			configuration.evoker = {}
-			
-			if (specId == 1 or specId == nil) and TRB.Functions.Table:Length(settings.evoker.devastation) > 0 then -- Devastation
-				configuration.evoker.devastation = ExportConfigurationSections(13, 1, settings.evoker.devastation, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-
-			if (specId == 2 or specId == nil) and TRB.Functions.Table:Length(settings.evoker.preservation) > 0 then -- Preservation
-				configuration.evoker.preservation = ExportConfigurationSections(13, 2, settings.evoker.preservation, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
-			end
-			
-			if (specId == 3 or specId == nil) and TRB.Functions.Table:Length(settings.evoker.augmentation) > 0 then -- Augmentation
-				configuration.evoker.augmentation = ExportConfigurationSections(13, 1, settings.evoker.augmentation, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
+		local classConfiguration = {}
+		for _, specEntry in ipairs(entry.specs) do
+			if specId == nil or specId == specEntry.specId then
+				local specSettings = classSettings[specEntry.specName]
+				if type(specSettings) == "table" and TRB.Functions.Table:Length(specSettings) > 0 then
+					classConfiguration[specEntry.specName] = ExportConfigurationSections(specEntry.classId, specEntry.specId, specSettings, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText)
+				end
 			end
 		end
+
+		if next(classConfiguration) ~= nil then
+			configuration[entry.className] = classConfiguration
+		end
+	end
+
+	if classId ~= nil then
+		ExportClassEntry(TRB.Functions.Character:GetClassRegistryEntry(classId))
 	elseif classId == nil and specId == nil then -- Everything
-		-- Instead of just dumping the whole table, let's clean it up
-
-		-- Warrior
-		-- Arms
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(1, 1, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Fury
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(1, 2, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Protection
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(1, 3, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-
-		-- Paladin
-		-- Holy
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(2, 1, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Protection
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(2, 2, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Retribution
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(2, 3, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-
-		-- Hunter
-		-- Beast Mastery
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(3, 1, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Marksmanship
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(3, 2, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Survival
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(3, 3, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-
-		-- Rogue
-		-- Assassination
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(4, 1, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Outlaw
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(4, 2, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Subtlety
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(4, 3, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-
-		-- Priest
-		-- Discipline
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(5, 1, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Holy
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(5, 2, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Shadow
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(5, 3, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-
-		-- Death Knight
-		-- Blood
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(6, 1, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Frost
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(6, 2, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Unholy
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(6, 3, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-
-		-- Shaman
-		-- Elemental
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(7, 1, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Enhancement
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(7, 2, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Restoration
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(7, 3, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-
-		-- Mage
-		-- Arcane
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(8, 1, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Fire
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(8, 2, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Frost
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(8, 3, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Warlock
-		-- Affliction
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(9, 1, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Demonology
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(9, 2, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Destruction
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(9, 3, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-
-		-- Monk
-		-- Brewmaster
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(10, 1, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Mistweaver
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(10, 2, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Windwalker
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(10, 3, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		
-		-- Druid
-		-- Balance
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(11, 1, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Feral
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(11, 2, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Guardian
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(11, 3, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Restoration
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(11, 4, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-
-		-- Demon Hunter
-		-- Havoc
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(12, 1, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Vengeance
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(12, 2, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Devourer
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(12, 3, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		
-		-- Evoker
-		-- Devastation
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(13, 1, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Preservation
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(13, 2, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
-		-- Augmentation
-		configuration = TRB.Functions.Table:Merge(configuration, ExportGetConfiguration(13, 3, includeBarDisplay, includeThresholds, includeFontAndText, includeAudioAndTracking, includeBarText))
+		for _, entry in ipairs(TRB.Functions.Character:GetClassRegistryEntriesOrdered()) do
+			ExportClassEntry(entry)
+		end
 	end
 
 	if includeCore then
@@ -1022,52 +599,17 @@ Twintop_API.ImportConfiguration = HandleImport
 -- actions. They do not modify the behaviour of the legacy `HandleExport` /
 -- `HandleImport` pipeline used by the Import/Export options screen.
 
--- Ordered list of (classId, className, [specId] = specName). Used to convert
--- between the two representations of a class/spec identity, and to enumerate
--- the valid slots inside an imported profile body.
----@type { classId: integer, className: string, specs: table<integer, string> }[]
-local CLASS_SPEC_TABLE = {
-	{ classId = 1,  className = "warrior",     specs = { [1] = "arms",         [2] = "fury",         [3] = "protection" } },
-	{ classId = 2,  className = "paladin",     specs = { [1] = "holy",         [2] = "protection",   [3] = "retribution" } },
-	{ classId = 3,  className = "hunter",      specs = { [1] = "beastMastery", [2] = "marksmanship", [3] = "survival" } },
-	{ classId = 4,  className = "rogue",       specs = { [1] = "assassination",[2] = "outlaw",       [3] = "subtlety" } },
-	{ classId = 5,  className = "priest",      specs = { [1] = "discipline",   [2] = "holy",         [3] = "shadow" } },
-	{ classId = 6,  className = "deathknight", specs = { [1] = "blood",        [2] = "frost",        [3] = "unholy" } },
-	{ classId = 7,  className = "shaman",      specs = { [1] = "elemental",    [2] = "enhancement",  [3] = "restoration" } },
-	{ classId = 8,  className = "mage",        specs = { [1] = "arcane",       [2] = "fire",         [3] = "frost" } },
-	{ classId = 9,  className = "warlock",     specs = { [1] = "affliction",   [2] = "demonology",   [3] = "destruction" } },
-	{ classId = 10, className = "monk",        specs = { [1] = "brewmaster",   [2] = "mistweaver",   [3] = "windwalker" } },
-	{ classId = 11, className = "druid",       specs = { [1] = "balance",      [2] = "feral",        [3] = "guardian",    [4] = "restoration" } },
-	{ classId = 12, className = "demonhunter", specs = { [1] = "havoc",        [2] = "vengeance",    [3] = "devourer" } },
-	{ classId = 13, className = "evoker",      specs = { [1] = "devastation",  [2] = "preservation", [3] = "augmentation" } },
-}
-
--- Derived lookups.
-local classEntryById = {}
-local classIdByName = {}
-local specNameByClassIdAndSpecId = {}
-local specIdByClassNameAndSpecName = {}
-for _, entry in ipairs(CLASS_SPEC_TABLE) do
-	classEntryById[entry.classId] = entry
-	classIdByName[entry.className] = entry.classId
-	specNameByClassIdAndSpecId[entry.classId] = entry.specs
-	specIdByClassNameAndSpecName[entry.className] = {}
-	for specId, specName in pairs(entry.specs) do
-		specIdByClassNameAndSpecName[entry.className][specName] = specId
-	end
-end
-
 ---Resolves `(classId, specId)` to `(className, specName)`.
 ---@param classId integer
 ---@param specId integer
 ---@return string? className
 ---@return string? specName
 function TRB.Functions.IO:GetClassSpecNamesById(classId, specId)
-	local entry = classEntryById[classId]
+	local entry = TRB.Functions.Character:GetSpecRegistryEntryFromIds(classId, specId)
 	if entry == nil then
 		return nil, nil
 	end
-	return entry.className, entry.specs[specId]
+	return entry.className, entry.specName
 end
 
 ---Resolves `(className, specName)` to `(classId, specId)`.
@@ -1076,15 +618,16 @@ end
 ---@return integer? classId
 ---@return integer? specId
 function TRB.Functions.IO:GetClassSpecIdsByName(className, specName)
-	local classId = classIdByName[className]
-	if classId == nil then
+	local classEntry = TRB.Functions.Character:GetClassRegistryEntry(className)
+	if classEntry == nil then
 		return nil, nil
 	end
-	local specs = specIdByClassNameAndSpecName[className]
-	if specs == nil then
-		return classId, nil
+	for _, specEntry in ipairs(classEntry.specs) do
+		if specEntry.specName == specName then
+			return classEntry.classId, specEntry.specId
+		end
 	end
-	return classId, specs[specName]
+	return classEntry.classId, nil
 end
 
 ---Decodes an export string into a Lua table. Strips the `!TRBv2!` or legacy
@@ -1193,14 +736,16 @@ function TRB.Functions.IO:BuildClassProfileExportConfiguration(profileName, clas
 		return nil
 	end
 
-	local entry = classEntryById[classId]
+	local entry = TRB.Functions.Character:GetClassRegistryEntry(classId)
 	if entry == nil or type(specPieces) ~= "table" then
 		return nil
 	end
 
 	local classConfig = {}
 	local hasAnySpec = false
-	for specId, specName in pairs(entry.specs) do
+	for _, specEntry in ipairs(entry.specs) do
+		local specId = specEntry.specId
+		local specName = specEntry.specName
 		local specPiece = specPieces[specName]
 		if type(specPiece) == "table" then
 			classConfig[specName] = ExportConfigurationSections(classId, specId, specPiece, true, true, true, true, true)
@@ -1240,8 +785,7 @@ end
 ---@return table?
 local function ResolveLiveOrStoredSpecPiece(profileName, className, specName)
 	local character = TRB.Data.character
-	local classId = classIdByName[className]
-	local specId = specIdByClassNameAndSpecName[className] and specIdByClassNameAndSpecName[className][specName]
+	local classId, specId = TRB.Functions.IO:GetClassSpecIdsByName(className, specName)
 	local useLive = character ~= nil
 		and character.classId == classId
 		and character.specId == specId
@@ -1334,14 +878,15 @@ end
 ---@return string? exportString # Encoded export string, or nil on error
 ---@return integer? errorCode # -1 invalid args, -2 no class data available
 function TRB.Functions.IO:ExportClassProfile(profileName, classId, includeCore)
-	local entry = classEntryById[classId]
+	local entry = TRB.Functions.Character:GetClassRegistryEntry(classId)
 	if type(profileName) ~= "string" or profileName == "" or entry == nil then
 		return nil, -1
 	end
 
 	local specPieces = {}
 	local hasAnySpec = false
-	for _, specName in pairs(entry.specs) do
+	for _, specEntry in ipairs(entry.specs) do
+		local specName = specEntry.specName
 		local specPiece = ResolveLiveOrStoredSpecPiece(profileName, entry.className, specName)
 		if specPiece ~= nil then
 			specPieces[specName] = specPiece
@@ -1436,8 +981,10 @@ function TRB.Functions.IO:ExportFullProfile(profileName)
 
 	-- All spec pieces
 	local hasAnySpec = false
-	for _, entry in ipairs(CLASS_SPEC_TABLE) do
-		for specId, specName in pairs(entry.specs) do
+	for _, entry in ipairs(TRB.Functions.Character:GetClassRegistryEntriesOrdered()) do
+		for _, specEntry in ipairs(entry.specs) do
+			local specId = specEntry.specId
+			local specName = specEntry.specName
 			local specPiece = ResolveLiveOrStoredSpecPiece(profileName, entry.className, specName)
 			if specPiece ~= nil then
 				profileBody[entry.className] = profileBody[entry.className] or {}
@@ -1490,10 +1037,12 @@ function TRB.Functions.IO:ExportProfileSelection(profileName, selection)
 		end
 	end
 
-	for _, entry in ipairs(CLASS_SPEC_TABLE) do
+	for _, entry in ipairs(TRB.Functions.Character:GetClassRegistryEntriesOrdered()) do
 		local specSel = selection[entry.className]
 		if type(specSel) == "table" then
-			for specId, specName in pairs(entry.specs) do
+			for _, specEntry in ipairs(entry.specs) do
+				local specId = specEntry.specId
+				local specName = specEntry.specName
 				if specSel[specName] then
 					local specPiece = ResolveLiveOrStoredSpecPiece(profileName, entry.className, specName)
 					if specPiece ~= nil then
@@ -1573,10 +1122,11 @@ function TRB.Functions.IO:ParseProfileImport(input)
 
 	local validSpecs = {}
 	local hasCore = type(profileBody.core) == "table" and next(profileBody.core) ~= nil
-	for _, entry in ipairs(CLASS_SPEC_TABLE) do
+	for _, entry in ipairs(TRB.Functions.Character:GetClassRegistryEntriesOrdered()) do
 		local classTable = profileBody[entry.className]
 		if type(classTable) == "table" then
-			for _, specName in pairs(entry.specs) do
+			for _, specEntry in ipairs(entry.specs) do
+				local specName = specEntry.specName
 				local piece = classTable[specName]
 				if type(piece) == "table" and next(piece) ~= nil then
 					validSpecs[#validSpecs + 1] = { className = entry.className, specName = specName }

--- a/Init.lua
+++ b/Init.lua
@@ -213,8 +213,34 @@ TRB.Data.specCache = {}
 ---@field public classId number
 ---@field public specId number
 ---@field public className string   -- all-lowercase, e.g. "deathknight"
+---@field public classToken string  -- uppercase WoW class file token, e.g. "DEATHKNIGHT"
+---@field public classModuleName string -- PascalCase addon module key, e.g. "DeathKnight"
 ---@field public specName string    -- camelCase, e.g. "beastMastery"
+---@field public specNameLower string -- all-lowercase convenience form, e.g. "beastmastery"
+---@field public specNameUpper string -- uppercase convenience form, e.g. "BEASTMASTERY"
 ---@field public compositeKey string -- "className_specName", e.g. "deathknight_frost"
+
+---@class TRB.Data.ClassRegistryEntry
+---@field public classId number
+---@field public className string   -- all-lowercase settings key, e.g. "deathknight"
+---@field public classToken string  -- uppercase WoW class file token, e.g. "DEATHKNIGHT"
+---@field public classModuleName string -- PascalCase addon module/options key, e.g. "DeathKnight"
+---@field public specs TRB.Data.SpecRegistryEntry[]
+
+---@type TRB.Data.ClassRegistryEntry[]
+TRB.Data.classRegistryOrder = {}
+
+---@type table<string, TRB.Data.ClassRegistryEntry>
+TRB.Data.classRegistry = {}
+
+---@type table<number, TRB.Data.ClassRegistryEntry>
+TRB.Data.classRegistryByIds = {}
+
+---@type table<string, TRB.Data.ClassRegistryEntry>
+TRB.Data.classRegistryByTokens = {}
+
+---@type TRB.Data.SpecRegistryEntry[]
+TRB.Data.specRegistryOrder = {}
 
 ---@type table<string, TRB.Data.SpecRegistryEntry>
 TRB.Data.specRegistry = {}
@@ -223,87 +249,85 @@ TRB.Data.specRegistry = {}
 TRB.Data.specRegistryByIds = {}
 
 do
-	local function reg(classId, specId, className, specName)
-		local compositeKey = className .. "_" .. specName
-		local entry = {
+	local function regClass(classId, className, classToken, classModuleName, specs)
+		local classEntry = {
 			classId = classId,
-			specId = specId,
 			className = className,
-			specName = specName,
-			compositeKey = compositeKey,
+			classToken = classToken,
+			classModuleName = classModuleName,
+			specs = {},
 		}
-		TRB.Data.specRegistry[compositeKey] = entry
+
+		TRB.Data.classRegistry[className] = classEntry
+		TRB.Data.classRegistryByIds[classId] = classEntry
+		TRB.Data.classRegistryByTokens[classToken] = classEntry
+		table.insert(TRB.Data.classRegistryOrder, classEntry)
+
 		if not TRB.Data.specRegistryByIds[classId] then
 			TRB.Data.specRegistryByIds[classId] = {}
 		end
-		TRB.Data.specRegistryByIds[classId][specId] = entry
+
+		for _, spec in ipairs(specs) do
+			local specId = spec[1]
+			local specName = spec[2]
+			local compositeKey = className .. "_" .. specName
+			local entry = {
+				classId = classId,
+				specId = specId,
+				className = className,
+				classToken = classToken,
+				classModuleName = classModuleName,
+				specName = specName,
+				specNameLower = string.lower(specName),
+				specNameUpper = string.upper(specName),
+				compositeKey = compositeKey,
+			}
+			TRB.Data.specRegistry[compositeKey] = entry
+			TRB.Data.specRegistryByIds[classId][specId] = entry
+			table.insert(classEntry.specs, entry)
+			table.insert(TRB.Data.specRegistryOrder, entry)
+		end
 	end
 
-	-- Death Knight (classId 6)
-	reg(6, 1, "deathknight", "blood")
-	reg(6, 2, "deathknight", "frost")
-	reg(6, 3, "deathknight", "unholy")
-
-	-- Demon Hunter (classId 12)
-	reg(12, 1, "demonhunter", "havoc")
-	reg(12, 2, "demonhunter", "vengeance")
-	reg(12, 3, "demonhunter", "devourer")
-
-	-- Druid (classId 11)
-	reg(11, 1, "druid", "balance")
-	reg(11, 2, "druid", "feral")
-	reg(11, 3, "druid", "guardian")
-	reg(11, 4, "druid", "restoration")
-
-	-- Evoker (classId 13)
-	reg(13, 1, "evoker", "devastation")
-	reg(13, 2, "evoker", "preservation")
-	reg(13, 3, "evoker", "augmentation")
-
-	-- Hunter (classId 3)
-	reg(3, 1, "hunter", "beastMastery")
-	reg(3, 2, "hunter", "marksmanship")
-	reg(3, 3, "hunter", "survival")
-
-	-- Mage (classId 8)
-	reg(8, 1, "mage", "arcane")
-	reg(8, 2, "mage", "fire")
-	reg(8, 3, "mage", "frost")
-
-	-- Monk (classId 10)
-	reg(10, 1, "monk", "brewmaster")
-	reg(10, 2, "monk", "mistweaver")
-	reg(10, 3, "monk", "windwalker")
-
-	-- Paladin (classId 2)
-	reg(2, 1, "paladin", "holy")
-	reg(2, 2, "paladin", "protection")
-	reg(2, 3, "paladin", "retribution")
-
-	-- Priest (classId 5)
-	reg(5, 1, "priest", "discipline")
-	reg(5, 2, "priest", "holy")
-	reg(5, 3, "priest", "shadow")
-
-	-- Rogue (classId 4)
-	reg(4, 1, "rogue", "assassination")
-	reg(4, 2, "rogue", "outlaw")
-	reg(4, 3, "rogue", "subtlety")
-
-	-- Shaman (classId 7)
-	reg(7, 1, "shaman", "elemental")
-	reg(7, 2, "shaman", "enhancement")
-	reg(7, 3, "shaman", "restoration")
-
-	-- Warlock (classId 9)
-	reg(9, 1, "warlock", "affliction")
-	reg(9, 2, "warlock", "demonology")
-	reg(9, 3, "warlock", "destruction")
-
-	-- Warrior (classId 1)
-	reg(1, 1, "warrior", "arms")
-	reg(1, 2, "warrior", "fury")
-	reg(1, 3, "warrior", "protection")
+	regClass(1, "warrior", "WARRIOR", "Warrior", {
+		{ 1, "arms" }, { 2, "fury" }, { 3, "protection" }
+	})
+	regClass(2, "paladin", "PALADIN", "Paladin", {
+		{ 1, "holy" }, { 2, "protection" }, { 3, "retribution" }
+	})
+	regClass(3, "hunter", "HUNTER", "Hunter", {
+		{ 1, "beastMastery" }, { 2, "marksmanship" }, { 3, "survival" }
+	})
+	regClass(4, "rogue", "ROGUE", "Rogue", {
+		{ 1, "assassination" }, { 2, "outlaw" }, { 3, "subtlety" }
+	})
+	regClass(5, "priest", "PRIEST", "Priest", {
+		{ 1, "discipline" }, { 2, "holy" }, { 3, "shadow" }
+	})
+	regClass(6, "deathknight", "DEATHKNIGHT", "DeathKnight", {
+		{ 1, "blood" }, { 2, "frost" }, { 3, "unholy" }
+	})
+	regClass(7, "shaman", "SHAMAN", "Shaman", {
+		{ 1, "elemental" }, { 2, "enhancement" }, { 3, "restoration" }
+	})
+	regClass(8, "mage", "MAGE", "Mage", {
+		{ 1, "arcane" }, { 2, "fire" }, { 3, "frost" }
+	})
+	regClass(9, "warlock", "WARLOCK", "Warlock", {
+		{ 1, "affliction" }, { 2, "demonology" }, { 3, "destruction" }
+	})
+	regClass(10, "monk", "MONK", "Monk", {
+		{ 1, "brewmaster" }, { 2, "mistweaver" }, { 3, "windwalker" }
+	})
+	regClass(11, "druid", "DRUID", "Druid", {
+		{ 1, "balance" }, { 2, "feral" }, { 3, "guardian" }, { 4, "restoration" }
+	})
+	regClass(12, "demonhunter", "DEMONHUNTER", "DemonHunter", {
+		{ 1, "havoc" }, { 2, "vengeance" }, { 3, "devourer" }
+	})
+	regClass(13, "evoker", "EVOKER", "Evoker", {
+		{ 1, "devastation" }, { 2, "preservation" }, { 3, "augmentation" }
+	})
 end
 
 TRB.Data.character = {

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -642,65 +642,56 @@ local function ConstructGlobalOptionsPanel()
 	TRB.Frames.interfaceSettingsFrameContainer = interfaceSettingsFrame
 end
 
--- ─────────────────────────────────────────────────────────────────────
--- Alphabetically-ordered class/spec table for the profile manager grid.
--- classToken is the uppercase token used with GetClassColor().
--- ─────────────────────────────────────────────────────────────────────
-local PROFILE_CLASSES_ALPHA = {
-	{classId=6,  className="deathknight", token="DEATHKNIGHT", locKey="DeathKnight",
-	 specs={{specId=1,specName="blood",       locKey="DeathKnightBlood"},
-	        {specId=2,specName="frost",       locKey="DeathKnightFrost"},
-	        {specId=3,specName="unholy",      locKey="DeathKnightUnholy"}}},
-	{classId=12, className="demonhunter",  token="DEMONHUNTER",  locKey="DemonHunter",
-	 specs={{specId=1,specName="havoc",       locKey="DemonHunterHavoc"},
-	        {specId=2,specName="vengeance",   locKey="DemonHunterVengeance"},
-	        {specId=3,specName="devourer",    locKey="DemonHunterDevourer"}}},
-	{classId=11, className="druid",        token="DRUID",        locKey="Druid",
-	 specs={{specId=1,specName="balance",     locKey="DruidBalance"},
-	        {specId=2,specName="feral",       locKey="DruidFeral"},
-	        {specId=3,specName="guardian",    locKey="DruidGuardian"},
-	        {specId=4,specName="restoration", locKey="DruidRestoration"}}},
-	{classId=13, className="evoker",       token="EVOKER",       locKey="Evoker",
-	 specs={{specId=1,specName="devastation",  locKey="EvokerDevastation"},
-	        {specId=2,specName="preservation", locKey="EvokerPreservation"},
-	        {specId=3,specName="augmentation", locKey="EvokerAugmentation"}}},
-	{classId=3,  className="hunter",       token="HUNTER",       locKey="Hunter",
-	 specs={{specId=1,specName="beastMastery", locKey="HunterBeastMastery"},
-	        {specId=2,specName="marksmanship", locKey="HunterMarksmanship"},
-	        {specId=3,specName="survival",     locKey="HunterSurvival"}}},
-	{classId=8,  className="mage",         token="MAGE",         locKey="Mage",
-	 specs={{specId=1,specName="arcane",      locKey="MageArcane"},
-	        {specId=2,specName="fire",        locKey="MageFire"},
-	        {specId=3,specName="frost",       locKey="MageFrost"}}},
-	{classId=10, className="monk",         token="MONK",         locKey="Monk",
-	 specs={{specId=1,specName="brewmaster",  locKey="MonkBrewmaster"},
-	        {specId=2,specName="mistweaver",  locKey="MonkMistweaver"},
-	        {specId=3,specName="windwalker",  locKey="MonkWindwalker"}}},
-	{classId=2,  className="paladin",      token="PALADIN",      locKey="Paladin",
-	 specs={{specId=1,specName="holy",        locKey="PaladinHoly"},
-	        {specId=2,specName="protection",  locKey="PaladinProtection"},
-	        {specId=3,specName="retribution", locKey="PaladinRetribution"}}},
-	{classId=5,  className="priest",       token="PRIEST",       locKey="Priest",
-	 specs={{specId=1,specName="discipline",  locKey="PriestDiscipline"},
-	        {specId=2,specName="holy",        locKey="PriestHoly"},
-	        {specId=3,specName="shadow",      locKey="PriestShadow"}}},
-	{classId=4,  className="rogue",        token="ROGUE",        locKey="Rogue",
-	 specs={{specId=1,specName="assassination",locKey="RogueAssassination"},
-	        {specId=2,specName="outlaw",      locKey="RogueOutlaw"},
-	        {specId=3,specName="subtlety",    locKey="RogueSubtlety"}}},
-	{classId=7,  className="shaman",       token="SHAMAN",       locKey="Shaman",
-	 specs={{specId=1,specName="elemental",   locKey="ShamanElemental"},
-	        {specId=2,specName="enhancement", locKey="ShamanEnhancement"},
-	        {specId=3,specName="restoration", locKey="ShamanRestoration"}}},
-	{classId=9,  className="warlock",      token="WARLOCK",      locKey="Warlock",
-	 specs={{specId=1,specName="affliction",  locKey="WarlockAffliction"},
-	        {specId=2,specName="demonology",  locKey="WarlockDemonology"},
-	        {specId=3,specName="destruction", locKey="WarlockDestruction"}}},
-	{classId=1,  className="warrior",      token="WARRIOR",      locKey="Warrior",
-	 specs={{specId=1,specName="arms",        locKey="WarriorArms"},
-	        {specId=2,specName="fury",        locKey="WarriorFury"},
-	        {specId=3,specName="protection",  locKey="WarriorProtection"}}},
+-- Localized labels for the profile/nav catalogs. Identity comes from
+-- TRB.Data.specRegistry; this table only keeps literal localization lookups.
+local PROFILE_LABELS_BY_CLASS = {
+	warrior = { classLabel = L["Warrior"], specs = { arms = { label = L["WarriorArms"], fullLabel = L["WarriorArmsFull"] }, fury = { label = L["WarriorFury"], fullLabel = L["WarriorFuryFull"] }, protection = { label = L["WarriorProtection"], fullLabel = L["WarriorProtectionFull"] } } },
+	paladin = { classLabel = L["Paladin"], specs = { holy = { label = L["PaladinHoly"], fullLabel = L["PaladinHolyFull"] }, protection = { label = L["PaladinProtection"], fullLabel = L["PaladinProtectionFull"] }, retribution = { label = L["PaladinRetribution"], fullLabel = L["PaladinRetributionFull"] } } },
+	hunter = { classLabel = L["Hunter"], specs = { beastMastery = { label = L["HunterBeastMastery"], fullLabel = L["HunterBeastMasteryFull"] }, marksmanship = { label = L["HunterMarksmanship"], fullLabel = L["HunterMarksmanshipFull"] }, survival = { label = L["HunterSurvival"], fullLabel = L["HunterSurvivalFull"] } } },
+	rogue = { classLabel = L["Rogue"], specs = { assassination = { label = L["RogueAssassination"], fullLabel = L["RogueAssassinationFull"] }, outlaw = { label = L["RogueOutlaw"], fullLabel = L["RogueOutlawFull"] }, subtlety = { label = L["RogueSubtlety"], fullLabel = L["RogueSubtletyFull"] } } },
+	priest = { classLabel = L["Priest"], specs = { discipline = { label = L["PriestDiscipline"], fullLabel = L["PriestDisciplineFull"] }, holy = { label = L["PriestHoly"], fullLabel = L["PriestHolyFull"] }, shadow = { label = L["PriestShadow"], fullLabel = L["PriestShadowFull"] } } },
+	deathknight = { classLabel = L["DeathKnight"], specs = { blood = { label = L["DeathKnightBlood"], fullLabel = L["DeathKnightBloodFull"] }, frost = { label = L["DeathKnightFrost"], fullLabel = L["DeathKnightFrostFull"] }, unholy = { label = L["DeathKnightUnholy"], fullLabel = L["DeathKnightUnholyFull"] } } },
+	shaman = { classLabel = L["Shaman"], specs = { elemental = { label = L["ShamanElemental"], fullLabel = L["ShamanElementalFull"] }, enhancement = { label = L["ShamanEnhancement"], fullLabel = L["ShamanEnhancementFull"] }, restoration = { label = L["ShamanRestoration"], fullLabel = L["ShamanRestorationFull"] } } },
+	mage = { classLabel = L["Mage"], specs = { arcane = { label = L["MageArcane"], fullLabel = L["MageArcaneFull"] }, fire = { label = L["MageFire"], fullLabel = L["MageFireFull"] }, frost = { label = L["MageFrost"], fullLabel = L["MageFrostFull"] } } },
+	warlock = { classLabel = L["Warlock"], specs = { affliction = { label = L["WarlockAffliction"], fullLabel = L["WarlockAfflictionFull"] }, demonology = { label = L["WarlockDemonology"], fullLabel = L["WarlockDemonologyFull"] }, destruction = { label = L["WarlockDestruction"], fullLabel = L["WarlockDestructionFull"] } } },
+	monk = { classLabel = L["Monk"], specs = { brewmaster = { label = L["MonkBrewmaster"], fullLabel = L["MonkBrewmasterFull"] }, mistweaver = { label = L["MonkMistweaver"], fullLabel = L["MonkMistweaverFull"] }, windwalker = { label = L["MonkWindwalker"], fullLabel = L["MonkWindwalkerFull"] } } },
+	druid = { classLabel = L["Druid"], specs = { balance = { label = L["DruidBalance"], fullLabel = L["DruidBalanceFull"] }, feral = { label = L["DruidFeral"], fullLabel = L["DruidFeralFull"] }, guardian = { label = L["DruidGuardian"], fullLabel = L["DruidGuardianFull"] }, restoration = { label = L["DruidRestoration"], fullLabel = L["DruidRestorationFull"] } } },
+	demonhunter = { classLabel = L["DemonHunter"], specs = { havoc = { label = L["DemonHunterHavoc"], fullLabel = L["DemonHunterHavocFull"] }, vengeance = { label = L["DemonHunterVengeance"], fullLabel = L["DemonHunterVengeanceFull"] }, devourer = { label = L["DemonHunterDevourer"], fullLabel = L["DemonHunterDevourerFull"] } } },
+	evoker = { classLabel = L["Evoker"], specs = { devastation = { label = L["EvokerDevastation"], fullLabel = L["EvokerDevastationFull"] }, preservation = { label = L["EvokerPreservation"], fullLabel = L["EvokerPreservationFull"] }, augmentation = { label = L["EvokerAugmentation"], fullLabel = L["EvokerAugmentationFull"] } } },
 }
+
+local function BuildProfileClassCatalog()
+	local catalog = {}
+	for _, classEntry in ipairs(TRB.Functions.Character:GetClassRegistryEntriesOrdered()) do
+		local classLabels = PROFILE_LABELS_BY_CLASS[classEntry.className]
+		if classLabels ~= nil then
+			local classDef = {
+				classId = classEntry.classId,
+				className = classEntry.className,
+				token = classEntry.classToken,
+				classLabel = classLabels.classLabel,
+				specs = {},
+			}
+			for _, specEntry in ipairs(classEntry.specs) do
+				local specLabels = classLabels.specs[specEntry.specName]
+				if specLabels ~= nil then
+					table.insert(classDef.specs, {
+						specId = specEntry.specId,
+						specName = specEntry.specName,
+						compositeKey = specEntry.compositeKey,
+						specLabel = specLabels.label,
+						specFullLabel = specLabels.fullLabel,
+					})
+				end
+			end
+			table.insert(catalog, classDef)
+		end
+	end
+	table.sort(catalog, function(a, b) return a.classLabel < b.classLabel end)
+	return catalog
+end
+
+local PROFILE_CLASSES_ALPHA = BuildProfileClassCatalog()
 
 -- Row and layout constants for the profile manager grid.
 local IE_HEADER_H  = 22  -- column-header row height
@@ -1057,7 +1048,7 @@ local function ConstructImportExportPanel()
 		end
 		frame:SetScript("OnEnter", function(self)
 			GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
-			GameTooltip:SetText(tooltipText, nil, nil, nil, nil, true)
+			GameTooltip:SetText(tooltipText, 1, 1, 1, nil, true)
 			GameTooltip:Show()
 		end)
 		frame:SetScript("OnLeave", function() GameTooltip:Hide() end)
@@ -1182,7 +1173,7 @@ local function ConstructImportExportPanel()
 		if classDef == nil then return 0 end
 		local className  = classDef.className
 		local classToken = classDef.token
-		local classLabel = L[classDef.locKey]
+		local classLabel = classDef.classLabel
 
 		local _, _, _, classColorHex = GetClassColor(classToken)
 		local colStr = classColorHex and ("|c" .. classColorHex) or "|cffffffff"
@@ -1224,7 +1215,7 @@ local function ConstructImportExportPanel()
 			local sDelBtn = BuildDeleteButton(specRow, SPEC_DEL_X, -2)
 			local sExpBtn = BuildExportButton(specRow, SPEC_EXP_X, -2)
 			local sCb = BuildCheckbox(specRow, SPEC_CB_X, -2)
-			local specLabel = L[spec.locKey]
+			local specLabel = spec.specLabel
 			SetButtonTooltip(sDelBtn, string.format(L["ProfileManagerDeleteSpecTooltipFormat"], specLabel, classLabel))
 			SetButtonTooltip(sExpBtn, string.format(L["ProfileManagerExportSpecTooltipFormat"], specLabel, classLabel))
 			SetButtonTooltip(sCb, string.format(L["ProfileManagerSelectSpecTooltipFormat"], specLabel, classLabel))
@@ -1236,7 +1227,7 @@ local function ConstructImportExportPanel()
 				end
 			end
 			local sLbl = BuildLabel(specRow, SPEC_LBL_X, -2,
-				IE_COL_W - SPEC_LBL_X - 4, L[spec.locKey])
+				IE_COL_W - SPEC_LBL_X - 4, specLabel)
 
 			local key = className .. "_" .. spec.specName
 			specRowData[key] = {
@@ -1842,7 +1833,7 @@ local function ConstructProfileDefaultsPanel()
 	-- Per-class section with one row per spec, ordered alphabetically by class name.
 	for _, classDef in ipairs(PROFILE_CLASSES_ALPHA) do
 		controls["classHeader_" .. classDef.className] = BuildProfileDefaultsClassHeader(
-			parent, yCoord, classDef.token, classDef.className, L[classDef.locKey])
+			parent, yCoord, classDef.token, classDef.className, classDef.classLabel)
 		yCoord = yCoord - 28
 
 		controls.dropDowns[classDef.className] = controls.dropDowns[classDef.className] or {}
@@ -1853,7 +1844,7 @@ local function ConstructProfileDefaultsPanel()
 				specIconId = iconId
 			end
 			controls.dropDowns[classDef.className][specDef.specName], yCoord = BuildProfileDefaultRow(
-				parent, yCoord, L[specDef.locKey .. "Full"],
+				parent, yCoord, specDef.specFullLabel,
 				"spec", classDef.className, specDef.specName,
 				specIconId, false)
 		end
@@ -2033,97 +2024,27 @@ end
 --- Exposed on TRB.Data so other modules (OptionsUi copy menus, etc.) can reuse it
 --- instead of duplicating class/spec metadata.
 ---@type {classKey: string, classLabel: string, specs: {compositeKey: string, specLabel: string}[]}[]
-TRB.Data.allClassSpecs = {
-	{ classKey = "warrior", classLabel = L["Warrior"], specs = {
-		{ compositeKey = "warrior_arms", specLabel = L["WarriorArmsFull"] },
-		{ compositeKey = "warrior_fury", specLabel = L["WarriorFuryFull"] },
-		{ compositeKey = "warrior_protection", specLabel = L["WarriorProtectionFull"] },
-	}},
-	{ classKey = "paladin", classLabel = L["Paladin"], specs = {
-		{ compositeKey = "paladin_holy", specLabel = L["PaladinHolyFull"] },
-		{ compositeKey = "paladin_protection", specLabel = L["PaladinProtectionFull"] },
-		{ compositeKey = "paladin_retribution", specLabel = L["PaladinRetributionFull"] },
-	}},
-	{ classKey = "hunter", classLabel = L["Hunter"], specs = {
-		{ compositeKey = "hunter_beastMastery", specLabel = L["HunterBeastMasteryFull"] },
-		{ compositeKey = "hunter_marksmanship", specLabel = L["HunterMarksmanshipFull"] },
-		{ compositeKey = "hunter_survival", specLabel = L["HunterSurvivalFull"] },
-	}},
-	{ classKey = "rogue", classLabel = L["Rogue"], specs = {
-		{ compositeKey = "rogue_assassination", specLabel = L["RogueAssassinationFull"] },
-		{ compositeKey = "rogue_outlaw", specLabel = L["RogueOutlawFull"] },
-		{ compositeKey = "rogue_subtlety", specLabel = L["RogueSubtletyFull"] },
-	}},
-	{ classKey = "priest", classLabel = L["Priest"], specs = {
-		{ compositeKey = "priest_discipline", specLabel = L["PriestDisciplineFull"] },
-		{ compositeKey = "priest_holy", specLabel = L["PriestHolyFull"] },
-		{ compositeKey = "priest_shadow", specLabel = L["PriestShadowFull"] },
-	}},
-	{ classKey = "deathknight", classLabel = L["DeathKnight"], specs = {
-		{ compositeKey = "deathknight_blood", specLabel = L["DeathKnightBloodFull"] },
-		{ compositeKey = "deathknight_frost", specLabel = L["DeathKnightFrostFull"] },
-		{ compositeKey = "deathknight_unholy", specLabel = L["DeathKnightUnholyFull"] },
-	}},
-	{ classKey = "shaman", classLabel = L["Shaman"], specs = {
-		{ compositeKey = "shaman_elemental", specLabel = L["ShamanElementalFull"] },
-		{ compositeKey = "shaman_enhancement", specLabel = L["ShamanEnhancementFull"] },
-		{ compositeKey = "shaman_restoration", specLabel = L["ShamanRestorationFull"] },
-	}},
-	{ classKey = "mage", classLabel = L["Mage"], specs = {
-		{ compositeKey = "mage_arcane", specLabel = L["MageArcaneFull"] },
-		{ compositeKey = "mage_fire", specLabel = L["MageFireFull"] },
-		{ compositeKey = "mage_frost", specLabel = L["MageFrostFull"] },
-	}},
-	{ classKey = "warlock", classLabel = L["Warlock"], specs = {
-		{ compositeKey = "warlock_affliction", specLabel = L["WarlockAfflictionFull"] },
-		{ compositeKey = "warlock_demonology", specLabel = L["WarlockDemonologyFull"] },
-		{ compositeKey = "warlock_destruction", specLabel = L["WarlockDestructionFull"] },
-	}},
-	{ classKey = "monk", classLabel = L["Monk"], specs = {
-		{ compositeKey = "monk_brewmaster", specLabel = L["MonkBrewmasterFull"] },
-		{ compositeKey = "monk_mistweaver", specLabel = L["MonkMistweaverFull"] },
-		{ compositeKey = "monk_windwalker", specLabel = L["MonkWindwalkerFull"] },
-	}},
-	{ classKey = "druid", classLabel = L["Druid"], specs = {
-		{ compositeKey = "druid_balance", specLabel = L["DruidBalanceFull"] },
-		{ compositeKey = "druid_feral", specLabel = L["DruidFeralFull"] },
-		{ compositeKey = "druid_guardian", specLabel = L["DruidGuardianFull"] },
-		{ compositeKey = "druid_restoration", specLabel = L["DruidRestorationFull"] },
-	}},
-	{ classKey = "demonhunter", classLabel = L["DemonHunter"], specs = {
-		{ compositeKey = "demonhunter_havoc", specLabel = L["DemonHunterHavocFull"] },
-		{ compositeKey = "demonhunter_vengeance", specLabel = L["DemonHunterVengeanceFull"] },
-		{ compositeKey = "demonhunter_devourer", specLabel = L["DemonHunterDevourerFull"] },
-	}},
-	{ classKey = "evoker", classLabel = L["Evoker"], specs = {
-		{ compositeKey = "evoker_devastation", specLabel = L["EvokerDevastationFull"] },
-		{ compositeKey = "evoker_preservation", specLabel = L["EvokerPreservationFull"] },
-		{ compositeKey = "evoker_augmentation", specLabel = L["EvokerAugmentationFull"] },
-	}},
-}
-
---- Mapping from lowercase className to PascalCase options module key (e.g., TRB.Options.DeathKnight)
-local CLASS_OPTIONS_MODULE = {
-	deathknight = "DeathKnight",
-	demonhunter = "DemonHunter",
-	druid = "Druid",
-	evoker = "Evoker",
-	hunter = "Hunter",
-	mage = "Mage",
-	monk = "Monk",
-	paladin = "Paladin",
-	priest = "Priest",
-	rogue = "Rogue",
-	shaman = "Shaman",
-	warlock = "Warlock",
-	warrior = "Warrior",
-}
+TRB.Data.allClassSpecs = {}
+for _, classDef in ipairs(PROFILE_CLASSES_ALPHA) do
+	local specs = {}
+	for _, specDef in ipairs(classDef.specs) do
+		table.insert(specs, {
+			compositeKey = specDef.compositeKey,
+			specLabel = specDef.specFullLabel,
+		})
+	end
+	table.insert(TRB.Data.allClassSpecs, {
+		classKey = classDef.className,
+		classLabel = classDef.classLabel,
+		specs = specs,
+	})
+end
 
 ---Lazily build all options panels for a class.
 ---Ensures specCache entries and settings exist, then calls the class's ConstructOptionsPanel.
 ---@param classKey string # Lowercase class key (e.g., "warrior")
 function TRB.Options:BuildClassPanels(classKey)
-	local moduleKey = CLASS_OPTIONS_MODULE[classKey]
+	local moduleKey = TRB.Functions.Character:GetClassModuleName(classKey)
 	if not moduleKey or not TRB.Options[moduleKey] or not TRB.Options[moduleKey].ConstructOptionsPanel then
 		return
 	end

--- a/Options/OptionsUi.lua
+++ b/Options/OptionsUi.lua
@@ -95,19 +95,6 @@ local function GetAnchorPointDisplayName(point)
 	return anchorPointDisplayNames[point or "TOP"] or point or "TOP"
 end
 
----Maps a settings key (used by GenerateAncillaryBarDimensionsOptions) to its bar key
----(used by GetAvailableAnchorTargets, ValidateAnchorTree, etc.).
----@param settingKey string
----@return string barKey
-local function SettingKeyToBarKey(settingKey)
-	local map = {
-		bar = "primary",
-		comboPoints = "secondary",
-		healthBar = "health",
-	}
-	return map[settingKey] or settingKey
-end
-
 ---Applies sensible defaults when changing anchor target type (screen â†” bar).
 ---When transitioning between screen and bar anchoring, the existing offset/point values
 ---are meaningless for the new context, so reset them to useful defaults.
@@ -235,54 +222,21 @@ local function SwapSliderBounds(widthSlider, heightSlider)
 	heightSlider.MaxLabel:SetText(tostring(wMax))
 end
 
--- Mapping of all class names to their spec names for bulk global toggle iteration
-local allClassSpecs = {
-	deathknight = { "blood", "frost", "unholy" },
-	demonhunter = { "havoc", "vengeance", "devourer" },
-	druid = { "balance", "feral", "guardian", "restoration" },
-	evoker = { "devastation", "preservation", "augmentation" },
-	hunter = { "beastMastery", "marksmanship", "survival" },
-	mage = { "arcane", "fire", "frost" },
-	monk = { "brewmaster", "mistweaver", "windwalker" },
-	paladin = { "holy", "protection", "retribution" },
-	priest = { "discipline", "holy", "shadow" },
-	rogue = { "assassination", "outlaw", "subtlety" },
-	shaman = { "elemental", "enhancement", "restoration" },
-	warlock = { "affliction", "demonology", "destruction" },
-	warrior = { "arms", "fury", "protection" }
-}
-
--- Mapping from settings key to checkbox frame suffix
-local settingKeyToCheckboxSuffix = {
-	bar = "barDimensions",
-	comboPoints = "comboPoints",
-	healthBar = "healthBar",
-	healthBarColors = "healthBarColors",
-	textures = "textures",
-	displayBar = "displayBar",
-	thresholdIcons = "thresholdIcons",
-	thresholdColors = "thresholdColors",
-	displayText = "displayText",
-	textColors = "textColors",
-	precision = "precision",
-	globalBarText = "globalBarText"
-}
-
--- Mapping from lowercase class name to classId for frame name resolution
-local classNameToId = {
-	deathknight = 6,
-	demonhunter = 12,
-	druid = 11,
-	evoker = 13,
-	hunter = 3,
-	mage = 8,
-	monk = 10,
-	paladin = 2,
-	priest = 5,
-	rogue = 4,
-	shaman = 7,
-	warlock = 9,
-	warrior = 1
+-- Per-section global settings registry. These keys mirror the per-spec
+-- "Use Global" flags and the copy menu sections that operate on them.
+local globalSettingDefinitions = {
+	bar             = { checkboxSuffix = "barDimensions",   tabKey = "resourceBar",     sectionLabel = L["CopyMenuSection_bar"],             paths = { {"bar"} } },
+	comboPoints     = { checkboxSuffix = "comboPoints",     tabKey = "comboPointsBar",  sectionLabel = L["CopyMenuSection_comboPoints"],     paths = { {"comboPoints"} } },
+	healthBar       = { checkboxSuffix = "healthBar",       tabKey = "healthBar",       sectionLabel = L["CopyMenuSection_healthBar"],       paths = { {"healthBar"} } },
+	healthBarColors = { checkboxSuffix = "healthBarColors", tabKey = "healthBar",       sectionLabel = L["CopyMenuSection_healthBarColors"], paths = { {"colors", "healthBar"} } },
+	textures        = { checkboxSuffix = "textures",        tabKey = "barTextures",     sectionLabel = L["CopyMenuSection_textures"],        paths = { {"textures"} } },
+	displayBar      = { checkboxSuffix = "displayBar",      tabKey = "barVisibility",   sectionLabel = L["CopyMenuSection_displayBar"],      paths = { {"displayBar"} }, shapeSensitive = true },
+	thresholdIcons  = { checkboxSuffix = "thresholdIcons",  tabKey = "thresholds",      sectionLabel = L["CopyMenuSection_thresholdIcons"],  paths = { {"thresholds", "properties"}, {"thresholds", "icons"} }, shapeSensitive = true },
+	thresholdColors = { checkboxSuffix = "thresholdColors", tabKey = "thresholds",      sectionLabel = L["CopyMenuSection_thresholdColors"], paths = { {"colors", "threshold"} }, shapeSensitive = true },
+	displayText     = { checkboxSuffix = "displayText",     tabKey = "fontText",        sectionLabel = L["CopyMenuSection_displayText"],     paths = { {"displayText", "default"} } },
+	textColors      = { checkboxSuffix = "textColors",      tabKey = "fontText",        sectionLabel = L["CopyMenuSection_textColors"],      paths = { {"colors", "text"} } },
+	precision       = { checkboxSuffix = "precision",       tabKey = "fontText",        sectionLabel = L["CopyMenuSection_precision"],       paths = { {"precision"} } },
+	globalBarText   = { checkboxSuffix = "globalBarText",   tabKey = "barText",         sectionLabel = L["CopyMenuSection_globalBarText"],   paths = { {"displayText", "barText"} }, shapeSensitive = true },
 }
 
 ---Sets a checkbox to tristate visual mode
@@ -338,16 +292,14 @@ local function GetAllSpecsGlobalState(settingKey)
 	local allTrue = true
 	local allFalse = true
 
-	for className, specs in pairs(allClassSpecs) do
-		if global[className] then
-			for _, specName in ipairs(specs) do
-				if global[className][specName] and global[className][specName][settingKey] ~= nil then
-					if global[className][specName][settingKey] then
-						allFalse = false
-					else
-						allTrue = false
-					end
-				end
+	for _, entry in ipairs(TRB.Functions.Character:GetSpecRegistryEntriesOrdered()) do
+		local className = entry.className
+		local specName = entry.specName
+		if global[className] and global[className][specName] and global[className][specName][settingKey] ~= nil then
+			if global[className][specName][settingKey] then
+				allFalse = false
+			else
+				allTrue = false
 			end
 		end
 	end
@@ -366,43 +318,33 @@ end
 ---@param value boolean # The value to set
 local function SetAllSpecsGlobalSetting(settingKey, value)
 	local global = TRB.Data.settings.core.global
-	local checkboxSuffix = settingKeyToCheckboxSuffix[settingKey]
+	local settingDef = globalSettingDefinitions[settingKey]
+	local checkboxSuffix = settingDef and settingDef.checkboxSuffix
 
 	-- Update settings for all class/specs
-	for className, specs in pairs(allClassSpecs) do
-		if global[className] then
-			for _, specName in ipairs(specs) do
-				if global[className][specName] and global[className][specName][settingKey] ~= nil then
-					global[className][specName][settingKey] = value
-				end
-			end
+	for _, entry in ipairs(TRB.Functions.Character:GetSpecRegistryEntriesOrdered()) do
+		local className = entry.className
+		local specName = entry.specName
+		if global[className] and global[className][specName] and global[className][specName][settingKey] ~= nil then
+			global[className][specName][settingKey] = value
 		end
 	end
 
 	-- Update all existing per-spec checkboxes in the UI across ALL classes
 	if checkboxSuffix then
-		for className, specs in pairs(allClassSpecs) do
-			local classId = classNameToId[className]
-			if classId then
-				local capitalizedClassName, _ = TRB.Functions.Character:GetClassAndSpecializationNames(classId, nil)
-				for _, specName in ipairs(specs) do
-					local frameName = "TwintopResourceBar_" .. capitalizedClassName .. "_" .. specName .. "_useGlobal_" .. checkboxSuffix
-					local checkbox = _G[frameName]
-					if checkbox then
-						checkbox:SetChecked(value)
-					end
-				end
+		for _, entry in ipairs(TRB.Functions.Character:GetSpecRegistryEntriesOrdered()) do
+			local frameName = "TwintopResourceBar_" .. entry.classToken .. "_" .. entry.specName .. "_useGlobal_" .. checkboxSuffix
+			local checkbox = _G[frameName]
+			if checkbox then
+				checkbox:SetChecked(value)
 			end
 		end
 	end
 
 	-- Refresh caches for all specs that have been initialized (specCache exists)
-	for className, specs in pairs(allClassSpecs) do
-		for _, specName in ipairs(specs) do
-			local compositeKey = TRB.Functions.Character:GetCompositeKey(className, specName)
-			if TRB.Data.specCache[compositeKey] then
-				TRB.Functions.Character:FillSpecializationCacheSettings(className, specName)
-			end
+	for _, entry in ipairs(TRB.Functions.Character:GetSpecRegistryEntriesOrdered()) do
+		if TRB.Data.specCache[entry.compositeKey] then
+			TRB.Functions.Character:FillSpecializationCacheSettings(entry.className, entry.specName)
 		end
 	end
 
@@ -508,23 +450,6 @@ function TRB.Functions.OptionsUi:RefreshBulkGlobalToggleCheckbox(settingKey)
 	end
 end
 
----Mapping from per-spec global setting keys to the corresponding Global Options tab key.
----Used by BuildUseGlobalShortcutLink to navigate to the correct tab.
-local globalSettingKeyToTabKey = {
-	bar = "resourceBar",
-	comboPoints = "comboPointsBar",
-	healthBar = "healthBar",
-	healthBarColors = "healthBar",
-	textures = "barTextures",
-	displayBar = "barVisibility",
-	thresholdIcons = "thresholds",
-	thresholdColors = "thresholds",
-	displayText = "fontText",
-	textColors = "fontText",
-	precision = "fontText",
-	globalBarText = "barText",
-}
-
 ---Creates a teal hyperlink-style text button anchored to the right of a "Use global settings" checkbox.
 ---Clicking the link navigates to the Global Options panel and selects the corresponding tab.
 ---@param checkbox CheckButton The "Use global settings" checkbox to attach the link to
@@ -615,37 +540,6 @@ local function GetSortedClassSpecs()
 	table.sort(sorted, function(a, b) return a.classLabel < b.classLabel end)
 	return sorted
 end
-
--- Per-section copy registry. `paths` is a list of dotted key-paths (as arrays)
--- that should be deep-copied between source and destination pieces. The
--- subtree shape mirrors what FillSpecializationCacheSettings reads for each
--- "Use Global" flag - the same fields that the global toggle would substitute
--- if it were checked.
-local globalSettingKeyCopyDef = {
-	bar             = { sectionLabel = L["CopyMenuSection_bar"],             paths = { {"bar"} } },
-	comboPoints     = { sectionLabel = L["CopyMenuSection_comboPoints"],     paths = { {"comboPoints"} } },
-	healthBar       = { sectionLabel = L["CopyMenuSection_healthBar"],       paths = { {"healthBar"} } },
-	healthBarColors = { sectionLabel = L["CopyMenuSection_healthBarColors"], paths = { {"colors", "healthBar"} } },
-	textures        = { sectionLabel = L["CopyMenuSection_textures"],        paths = { {"textures"} } },
-	displayBar      = { sectionLabel = L["CopyMenuSection_displayBar"],      paths = { {"displayBar"} } },
-	thresholdIcons  = { sectionLabel = L["CopyMenuSection_thresholdIcons"],  paths = { {"thresholds", "properties"}, {"thresholds", "icons"} } },
-	thresholdColors = { sectionLabel = L["CopyMenuSection_thresholdColors"], paths = { {"colors", "threshold"} } },
-	displayText     = { sectionLabel = L["CopyMenuSection_displayText"],     paths = { {"displayText", "default"} } },
-	textColors      = { sectionLabel = L["CopyMenuSection_textColors"],      paths = { {"colors", "text"} } },
-	precision       = { sectionLabel = L["CopyMenuSection_precision"],       paths = { {"precision"} } },
-	globalBarText   = { sectionLabel = L["CopyMenuSection_globalBarText"],   paths = { {"displayText", "barText"} } },
-}
-
--- Sections whose subtree shape differs between specs (e.g. bar text entries
--- reference spec-specific variables, threshold dictionaries reference
--- spec-specific spell IDs). Cross-class copies for these sections show an
--- additional warning in the confirmation popup.
-local globalSettingKeyShapeSensitive = {
-	displayBar    = true,
-	globalBarText = true,
-	thresholdIcons = true,
-	thresholdColors = true,
-}
 
 -- Returns the readable source piece for the given (scope, profile, class, spec).
 -- When profileName matches the resolved active profile (or is nil), the LIVE
@@ -753,12 +647,9 @@ local function RefreshAfterLiveCopy(destScope, destClassName, destSpecName)
 	local profiles = TRB.Functions.Profiles
 	if destScope == "core" then
 		-- Re-resolve every initialized spec because any of them may pull from core.
-		for className, specs in pairs(allClassSpecs) do
-			for _, specName in ipairs(specs) do
-				local compositeKey = TRB.Functions.Character:GetCompositeKey(className, specName)
-				if TRB.Data.specCache[compositeKey] then
-					TRB.Functions.Character:FillSpecializationCacheSettings(className, specName)
-				end
+		for _, entry in ipairs(TRB.Functions.Character:GetSpecRegistryEntriesOrdered()) do
+			if TRB.Data.specCache[entry.compositeKey] then
+				TRB.Functions.Character:FillSpecializationCacheSettings(entry.className, entry.specName)
 			end
 		end
 		profiles:WriteThrough("core")
@@ -829,7 +720,7 @@ local function EnsureCopyConfigPopupsRegistered()
 		if data == nil or data.settingKey == nil then
 			return
 		end
-		local def = globalSettingKeyCopyDef[data.settingKey]
+		local def = globalSettingDefinitions[data.settingKey]
 		if def == nil then
 			return
 		end
@@ -893,12 +784,13 @@ end
 local function PromptCopyConfirm(data)
 	EnsureCopyConfigPopupsRegistered()
 
-	local def = globalSettingKeyCopyDef[data.settingKey]
+	local def = globalSettingDefinitions[data.settingKey]
 	local sectionLabel = (def and def.sectionLabel) or data.settingKey
 	local srcLabel = FormatCopyTarget(data.srcScope, data.srcProfileName, data.srcClassName, data.srcSpecName)
 	local dstLabel = FormatCopyTarget(data.dstScope, data.dstProfileName, data.dstClassName, data.dstSpecName)
 
-	local crossClass = globalSettingKeyShapeSensitive[data.settingKey]
+	local crossClass = globalSettingDefinitions[data.settingKey]
+		and globalSettingDefinitions[data.settingKey].shapeSensitive
 		and data.srcScope == "spec" and data.dstScope == "spec"
 		and data.srcClassName ~= nil and data.dstClassName ~= nil
 		and data.srcClassName ~= data.dstClassName
@@ -1083,7 +975,7 @@ local function ShowUseGlobalCopyMenu(owner, classId, specId, settingKey)
 		return
 	end
 	local profiles = TRB.Functions.Profiles
-	local def = globalSettingKeyCopyDef[settingKey]
+	local def = globalSettingDefinitions[settingKey]
 	local sectionLabel = (def and def.sectionLabel) or settingKey
 	local excludeKey = className .. ":" .. specName
 	local currentCoreProfileName = profiles:ResolveCoreProfileName() or profiles.DEFAULT_NAME
@@ -1165,9 +1057,9 @@ end
 ---@param checkbox CheckButton The "Use Global" checkbox to attach the button to
 ---@param classId integer The class ID of the destination spec
 ---@param specId integer The spec ID of the destination spec
----@param settingKey string A key from globalSettingKeyCopyDef
+---@param settingKey string A key from globalSettingDefinitions
 function TRB.Functions.OptionsUi:BuildUseGlobalCopyButton(checkbox, classId, specId, settingKey)
-	if checkbox == nil or globalSettingKeyCopyDef[settingKey] == nil then
+	if checkbox == nil or globalSettingDefinitions[settingKey] == nil then
 		return nil
 	end
 	-- Bar Text section is intentionally excluded from the Copy menu.
@@ -1198,7 +1090,7 @@ end
 -- to `owner`. Source/destination semantics are inverted relative to the
 -- per-spec menu: pick one or push/pull from one spec at a time.
 local function ShowBulkGlobalCopyMenu(owner, settingKey)
-	local def = globalSettingKeyCopyDef[settingKey]
+	local def = globalSettingDefinitions[settingKey]
 	local sectionLabel = (def and def.sectionLabel) or settingKey
 
 	MenuUtil.CreateContextMenu(owner, function(_, rootDescription)
@@ -1250,9 +1142,9 @@ end
 
 -- Builds a "Copy..." button next to a Global-panel bulk-toggle checkbox.
 ---@param bulkCheckbox CheckButton The bulk-toggle checkbox to attach the button to
----@param settingKey string A key from globalSettingKeyCopyDef
+---@param settingKey string A key from globalSettingDefinitions
 function TRB.Functions.OptionsUi:BuildGlobalBulkCopyButton(bulkCheckbox, settingKey)
-	if bulkCheckbox == nil or globalSettingKeyCopyDef[settingKey] == nil then
+	if bulkCheckbox == nil or globalSettingDefinitions[settingKey] == nil then
 		return nil
 	end
 	-- Bar Text section is intentionally excluded from the Copy menu.
@@ -2368,33 +2260,13 @@ end
 -- Profile management dropdown (Phase 2B + 2C)
 -- ============================================================================
 
--- Maps the lowercase `className` used throughout the addon (e.g. "deathknight")
--- to the capitalized key under `TRB.Options` (e.g. "DeathKnight") that exposes
--- each class module's `LoadDefaultSettings` factory. Needed to resolve the
--- baseline-settings piece for a spec when the user picks "Use Baseline".
-local profileClassNameCapitalized = {
-	deathknight = "DeathKnight",
-	demonhunter = "DemonHunter",
-	druid = "Druid",
-	evoker = "Evoker",
-	hunter = "Hunter",
-	mage = "Mage",
-	monk = "Monk",
-	paladin = "Paladin",
-	priest = "Priest",
-	rogue = "Rogue",
-	shaman = "Shaman",
-	warlock = "Warlock",
-	warrior = "Warrior",
-}
-
 ---Returns a deep-copied spec piece from the class's LoadDefaultSettings, so
 ---"Use Baseline" gets a fresh default table not shared with runtime state.
 ---@param className string # lowercase
 ---@param specName string
 ---@return table?
 local function GetBaselineSpecPiece(className, specName)
-	local capitalized = profileClassNameCapitalized[className]
+	local capitalized = TRB.Functions.Character:GetClassModuleName(className)
 	if capitalized == nil then
 		return nil
 	end
@@ -5641,8 +5513,9 @@ function TRB.Functions.OptionsUi:GenerateAncillaryBarDimensionsOptions(parent, c
 		f:SetPoint("TOPLEFT", oUi.xCoord+oUi.xPadding, yCoord)
 		getglobal(f:GetName() .. 'Text'):SetText(L["CheckboxUseGlobal"])
 		getglobal(f:GetName() .. 'Text'):SetTextColor(GetUseGlobalSettingsColor())
-		if globalSettingKeyToTabKey[globalSettingKey] then
-			TRB.Functions.OptionsUi:BuildUseGlobalShortcutLink(f, globalSettingKeyToTabKey[globalSettingKey])
+		local globalSettingDef = globalSettingDefinitions[globalSettingKey]
+		if globalSettingDef and globalSettingDef.tabKey then
+			TRB.Functions.OptionsUi:BuildUseGlobalShortcutLink(f, globalSettingDef.tabKey)
 		end
 		f.tooltip = globalTooltip or L["CheckboxUseGlobalTooltip_ComboPoints"]
 		f:SetChecked(TRB.Data.settings.core.global[lowerClassName][specName][globalSettingKey])
@@ -5852,7 +5725,7 @@ function TRB.Functions.OptionsUi:GenerateAncillaryBarDimensionsOptions(parent, c
 	-- Anchor To dropdown + Match Width checkbox
 	yCoord = yCoord - 40
 
-	local thisBarKey = SettingKeyToBarKey(settingKey)
+	local thisBarKey = TRB.Functions.Bar:GetBarKeyFromSettingsKey(settingKey)
 	local anchorPoints = TRB.Data.constants.anchorPoints
 
 	-- Forward-declare dropdown variables referenced in callbacks


### PR DESCRIPTION
# Summary

Consolidates class/spec metadata into a shared registry while preserving the different casing forms used across settings, WoW tokens, class modules, and localization paths. This reduces duplicated bespoke mapping tables and gives shared systems a single source of truth for class/spec lookup.

Also restores per-spec import/export whitelist behavior so optional secondary/custom bar settings are exported only for specs that actually support them, instead of leaking stale saved-variable sections.

# Fixes

Fixes Survival Hunter Tip of the Spear secondary bar behavior on spec swap by initializing the talent-gated node count before layout, rebuilding/hiding the secondary bar when the count changes, and marking bar visibility dirty so match-width and combat visibility stay correct.

# Validation

- Checked the Hunter change with workspace diagnostics.
- Ran whitespace validation on the touched Hunter/IO changes.
- Audited other secondary-resource specs for the same spec-swap/layout timing issue and identified targeted in-game regression cases.