### PR TITLE
Add always hide visibility options

### DIFF
--- a/ClassModules/Options/DeathKnightOptions.lua
+++ b/ClassModules/Options/DeathKnightOptions.lua
@@ -278,10 +278,10 @@ local function BloodLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			boneShield = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			boneShield = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",
@@ -501,9 +501,9 @@ local function FrostLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",
@@ -702,9 +702,9 @@ local function UnholyLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",

--- a/ClassModules/Options/DemonHunterOptions.lua
+++ b/ClassModules/Options/DemonHunterOptions.lua
@@ -102,9 +102,9 @@ local function HavocLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		endOf = {
 			metamorphosis = TRB.Functions.Settings:DefaultEndOfSettings("gcd", 2, 3.0)
@@ -307,9 +307,9 @@ local function VengeanceLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		endOf = {
 			metamorphosis = TRB.Functions.Settings:DefaultEndOfSettings("gcd", 2, 3.0)
@@ -550,9 +550,9 @@ local function DevourerLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		endOf = {
 			metamorphosis = TRB.Functions.Settings:DefaultEndOfSettings("gcd", 2, 3.0)

--- a/ClassModules/Options/DruidOptions.lua
+++ b/ClassModules/Options/DruidOptions.lua
@@ -328,10 +328,10 @@ local function BalanceLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			mana = { neverShow = true, alwaysShow = false, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			mana = { neverShow = true, alwaysShow = false, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 			enableFormSwitching = true,
 			showComboPoints = false
 		},
@@ -780,9 +780,9 @@ local function FeralLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 			enableFormSwitching = true,
 			showComboPoints = true
 		},
@@ -1074,9 +1074,9 @@ local function GuardianLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 			enableFormSwitching = true,
 			showComboPoints = false
 		},
@@ -1250,9 +1250,9 @@ local function RestorationLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 			enableFormSwitching = true,
 			showComboPoints = false
 		},

--- a/ClassModules/Options/EvokerOptions.lua
+++ b/ClassModules/Options/EvokerOptions.lua
@@ -226,9 +226,9 @@ local function DevastationLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		endOf = {
 			dragonrage = TRB.Functions.Settings:DefaultEndOfSettings("gcd", 2, 3.0)
@@ -436,9 +436,9 @@ local function PreservationLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		comboPoints = TRB.Functions.Settings:DefaultComboPointsDimensions(classic),
@@ -678,10 +678,10 @@ local function AugmentationLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			ebonMight = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			ebonMight = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		comboPoints = TRB.Functions.Settings:DefaultComboPointsDimensions(classic),

--- a/ClassModules/Options/HunterOptions.lua
+++ b/ClassModules/Options/HunterOptions.lua
@@ -84,9 +84,9 @@ local function BeastMasteryLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		endOf = {
 			bestialWrath = TRB.Functions.Settings:DefaultEndOfSettings("gcd", 2, 3.0),
@@ -309,9 +309,9 @@ local function MarksmanshipLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		endOf = {
 			trueshot = TRB.Functions.Settings:DefaultEndOfSettings("gcd", 2, 3.0),
@@ -515,9 +515,9 @@ local function SurvivalLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		endOf = {
 			takedown = TRB.Functions.Settings:DefaultEndOfSettings("gcd", 2, 3.0),

--- a/ClassModules/Options/MageOptions.lua
+++ b/ClassModules/Options/MageOptions.lua
@@ -40,9 +40,9 @@ local function ArcaneLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		comboPoints = TRB.Functions.Settings:DefaultComboPointsDimensions(classic),
@@ -188,9 +188,9 @@ local function FireLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		healthBar = TRB.Functions.Settings:DefaultHealthDimensions(classic),
@@ -292,9 +292,9 @@ local function FrostLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		comboPoints = TRB.Functions.Settings:DefaultComboPointsDimensions(classic),

--- a/ClassModules/Options/MonkOptions.lua
+++ b/ClassModules/Options/MonkOptions.lua
@@ -157,9 +157,9 @@ local function BrewmasterLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			stagger = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			stagger = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		endOf = {
 			invokeNiuzao = TRB.Functions.Settings:DefaultEndOfSettings("gcd", 2, 3.0)
@@ -357,9 +357,9 @@ local function MistweaverLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		healthBar = TRB.Functions.Settings:DefaultHealthDimensions(classic),
@@ -536,9 +536,9 @@ local function WindwalkerLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",

--- a/ClassModules/Options/PaladinOptions.lua
+++ b/ClassModules/Options/PaladinOptions.lua
@@ -40,9 +40,9 @@ local function HolyLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		comboPoints = TRB.Functions.Settings:DefaultComboPointsDimensions(classic),
@@ -239,9 +239,9 @@ local function ProtectionLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		comboPoints = TRB.Functions.Settings:DefaultComboPointsDimensions(classic),
@@ -431,9 +431,9 @@ local function RetributionLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		comboPoints = TRB.Functions.Settings:DefaultComboPointsDimensions(classic),

--- a/ClassModules/Options/PriestOptions.lua
+++ b/ClassModules/Options/PriestOptions.lua
@@ -232,10 +232,10 @@ local function DisciplineLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			utility = { neverShow = true, alwaysShow = false, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			utility = { neverShow = true, alwaysShow = false, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		comboPoints = TRB.Functions.Settings:DefaultComboPointsDimensions(classic),
@@ -647,12 +647,12 @@ local function HolyLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			holyWords = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			lightweaver = { neverShow = true, alwaysShow = false, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			utility = { neverShow = true, alwaysShow = false, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			holyWords = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			lightweaver = { neverShow = true, alwaysShow = false, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			utility = { neverShow = true, alwaysShow = false, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		healthBar = TRB.Functions.Settings:DefaultHealthDimensions(classic),
@@ -1013,11 +1013,11 @@ local function ShadowLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			mana = { neverShow = true, alwaysShow = false, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			utility = { neverShow = true, alwaysShow = false, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			mana = { neverShow = true, alwaysShow = false, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			utility = { neverShow = true, alwaysShow = false, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",

--- a/ClassModules/Options/RogueOptions.lua
+++ b/ClassModules/Options/RogueOptions.lua
@@ -119,9 +119,9 @@ local function AssassinationLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",
@@ -419,9 +419,9 @@ local function OutlawLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",
@@ -736,9 +736,9 @@ local function SubtletyLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",

--- a/ClassModules/Options/ShamanOptions.lua
+++ b/ClassModules/Options/ShamanOptions.lua
@@ -75,10 +75,10 @@ local function ElementalLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			mana = { neverShow = true, alwaysShow = false, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			mana = { neverShow = true, alwaysShow = false, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		endOf = {
 			ascendance = TRB.Functions.Settings:DefaultEndOfSettings("gcd", 2, 3.0)
@@ -282,9 +282,9 @@ local function EnhancementLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		healthBar = TRB.Functions.Settings:DefaultHealthDimensions(classic),
@@ -482,9 +482,9 @@ local function RestorationLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		healthBar = TRB.Functions.Settings:DefaultHealthDimensions(classic),

--- a/ClassModules/Options/WarlockOptions.lua
+++ b/ClassModules/Options/WarlockOptions.lua
@@ -36,9 +36,9 @@ local function AfflictionLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		healthBar = TRB.Functions.Settings:DefaultHealthDimensions(classic),
@@ -193,9 +193,9 @@ local function DemonologyLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		healthBar = TRB.Functions.Settings:DefaultHealthDimensions(classic),
@@ -351,9 +351,9 @@ local function DestructionLoadDefaultSettings(includeBarText, classic)
 			mana = 1
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		bar = TRB.Functions.Settings:DefaultBarDimensions(classic),
 		healthBar = TRB.Functions.Settings:DefaultHealthDimensions(classic),

--- a/ClassModules/Options/WarriorOptions.lua
+++ b/ClassModules/Options/WarriorOptions.lua
@@ -96,9 +96,9 @@ local function ArmsLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",
@@ -407,9 +407,9 @@ local function FuryLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",
@@ -716,10 +716,10 @@ local function ProtectionLoadDefaultSettings(includeBarText, classic)
 			enabled = false
 		},
 		displayBar = {
-			primary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			secondary = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			health = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
-			defensives = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			primary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			secondary = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			health = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
+			defensives = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 },
 		},
 		overcap = {
 			mode = "relative",

--- a/Classes/BarVisibility.lua
+++ b/Classes/BarVisibility.lua
@@ -3,15 +3,18 @@ TRB.Classes = TRB.Classes or {}
 TRB.Functions = TRB.Functions or {}
 
 ---@class TRB.Classes.BarVisibilityContext
----@field force boolean # Whether to force-hide all bars (e.g., spec switch, pet battle)
+---@field force boolean # Whether to force-hide all bars (e.g., spec switch or render transition)
 ---@field specSupported boolean # Whether the current spec is enabled in addon settings
 ---@field inCombat boolean # Whether the player is currently in combat
 ---@field inVehicle boolean # Whether the player is currently in a vehicle
+---@field inPetBattle boolean # Whether the player is currently in a pet battle
+---@field onTaxi boolean # Whether the player is currently on a flight path
 ---@field hasTarget boolean # Whether the player has a target selected
 ---@field targetIsFriendly boolean # Whether the current target is friendly
 ---@field targetIsEnemy boolean # Whether the current target is unfriendly
 ---@field isMountedAny boolean # Whether the player is currently mounted (any mount)
 ---@field isMountedGround boolean # Whether the player is mounted and on the ground (not flying, any mount type)
+---@field isMountedFlying boolean # Whether the player is on a non-skyriding mount and actively flying
 ---@field isSkyriding boolean # Whether the player is actively skyriding (mounted, canGlide, and flying)
 ---@field isSteadyFlight boolean # Whether the player is on a non-skyriding mount and actively flying
 ---@field inGroup boolean # Whether the player is in a group (party or raid)
@@ -37,11 +40,14 @@ function TRB.Classes.BarVisibilityContext:New(params)
 	self.specSupported = params.specSupported or false
 	self.inCombat = params.inCombat or false
 	self.inVehicle = params.inVehicle or false
+	self.inPetBattle = params.inPetBattle or false
+	self.onTaxi = params.onTaxi or false
 	self.hasTarget = params.hasTarget or false
 	self.targetIsFriendly = params.targetIsFriendly or false
 	self.targetIsEnemy = params.targetIsEnemy or false
 	self.isMountedAny = params.isMountedAny or false
 	self.isMountedGround = params.isMountedGround or false
+	self.isMountedFlying = params.isMountedFlying or false
 	self.isSkyriding = params.isSkyriding or false
 	self.isSteadyFlight = params.isSteadyFlight or false
 	self.inGroup = params.inGroup or false
@@ -76,6 +82,11 @@ function TRB.Classes.BarVisibilityContext:NewFromGameState(force, settings)
 	local isMountedGround = isMountedAny and not isFlying
 	local isSkyriding = isMountedAny and canSkyriding and isFlying
 	local isSteadyFlight = isMountedAny and not canSkyriding and isFlying
+	local isMountedFlying = isSteadyFlight
+	local onTaxi = TRB.Data.character.onTaxi
+	if onTaxi == nil then
+		onTaxi = UnitOnTaxi("player") or false
+	end
 
 	-- Instance type: cached on ZONE_CHANGED_NEW_AREA
 	local instanceType = TRB.Data.character.instanceType or "none"
@@ -99,11 +110,14 @@ function TRB.Classes.BarVisibilityContext:NewFromGameState(force, settings)
 		specSupported = TRB.Data.specSupported or false,
 		inCombat = TRB.Data.character.inCombat or false,
 		inVehicle = TRB.Data.character.inVehicle or false,
+		inPetBattle = TRB.Data.character.inPetBattle or false,
+		onTaxi = onTaxi or false,
 		hasTarget = hasTarget,
 		targetIsFriendly = targetIsFriendly,
 		targetIsEnemy = targetIsEnemy,
 		isMountedAny = isMountedAny,
 		isMountedGround = isMountedGround,
+		isMountedFlying = isMountedFlying,
 		isSkyriding = isSkyriding,
 		isSteadyFlight = isSteadyFlight,
 		inGroup = IsInGroup() or false,
@@ -126,6 +140,7 @@ end
 ---@field showNodesCount number|nil # If set, calls :ShowNodes(n) when showing the bar
 ---@field setMaxNodes number|nil # If set, calls :SetMaxNodes(n) before showing the bar
 ---@field boolShowCached boolean|nil # Cached result of ShouldShowBar from last dirty evaluation; used by Phase 3 to skip curve when boolean conditions already satisfied
+---@field forceHideCached boolean|nil # Cached result of hard-hide/force/unsupported evaluation from last dirty evaluation
 ---@field thresholdEligibleCached boolean|nil # Cached threshold eligibility from last dirty evaluation; false when force/neverShow/unsupported prevent curve evaluation
 TRB.Classes.BarVisibilityEntry = {}
 TRB.Classes.BarVisibilityEntry.__index = TRB.Classes.BarVisibilityEntry
@@ -163,7 +178,7 @@ TRB.Functions.BarVisibility.hasResourceCurve = false
 ---Marks visibility state as dirty, forcing the next ProcessBars call to re-evaluate.
 ---Call this whenever any input to visibility evaluation changes:
 ---  inCombat, inVehicle, inPetBattle, onTaxi, specSupported,
----  isMountedAny, isMountedGround, isSkyriding, hasTarget, inGroup, inRaid,
+---  isMountedAny, isMountedGround, isMountedFlying, isSkyriding, hasTarget, inGroup, inRaid,
 ---  inInstance, inDungeon, inRaidInstance, inBattleground, inArena, isPvpFlagged, isWarMode,
 ---  per-bar visibility settings, talent gates, maxResource2.
 function TRB.Functions.BarVisibility:MarkDirty()
@@ -188,6 +203,45 @@ function TRB.Functions.BarVisibility:MarkClean()
 	self.lastAppliedToken = self.dirtyToken
 end
 
+---Evaluates whether a bar has any configured hard-hide condition active.
+---@param context TRB.Classes.BarVisibilityContext # The shared environment snapshot
+---@param entry TRB.Classes.BarVisibilityEntry # The bar entry to evaluate
+---@return boolean # true if a hard-hide condition is currently active
+function TRB.Functions.BarVisibility:ShouldForceHideBar(context, entry)
+	if entry.visibilitySettings == nil then
+		return false
+	end
+
+	local conditions = entry.visibilitySettings.hideConditions
+	if conditions == nil then
+		return false
+	end
+
+	if conditions.isMountedAny == true and context.isMountedAny then
+		return true
+	end
+	if conditions.isMountedGround == true and context.isMountedGround then
+		return true
+	end
+	if conditions.isMountedFlying == true and context.isMountedFlying then
+		return true
+	end
+	if conditions.isSkyriding == true and context.isSkyriding then
+		return true
+	end
+	if conditions.inVehicle == true and context.inVehicle then
+		return true
+	end
+	if conditions.inPetBattle == true and context.inPetBattle then
+		return true
+	end
+	if conditions.onTaxi == true and context.onTaxi then
+		return true
+	end
+
+	return false
+end
+
 ---Evaluates whether a single bar should be shown. Pure function, no side effects.
 ---@param context TRB.Classes.BarVisibilityContext # The shared environment snapshot
 ---@param entry TRB.Classes.BarVisibilityEntry # The bar entry to evaluate
@@ -210,6 +264,11 @@ function TRB.Functions.BarVisibility:ShouldShowBar(context, entry)
 
 	-- "Never Show" override
 	if entry.visibilitySettings.neverShow then
+		return false
+	end
+
+	-- Per-bar hard-hide conditions override Always Show and threshold visibility.
+	if self:ShouldForceHideBar(context, entry) then
 		return false
 	end
 
@@ -465,20 +524,29 @@ function TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData,
 			-- Phase 1: Evaluate conditions and compute target alpha (only when dirty)
 			if conditionsChanged then
 				local boolShow = self:ShouldShowBar(context, entry)
+				local forceHide = context.force
+					or not context.specSupported
+					or not entry.enabled
+					or visSettings == nil
+					or (visSettings and visSettings.neverShow == true)
+					or self:ShouldForceHideBar(context, entry)
 				-- Cache boolShow and thresholdEligible so Phase 3 can:
 				--  (a) skip the curve when boolean conditions already satisfy the OR,
 				--  (b) skip the curve when force/neverShow/unsupported make it ineligible.
 				entry.boolShowCached = boolShow
+				entry.forceHideCached = forceHide
 				local thresholdEligible = entry.enabled
 					and visSettings ~= nil
-					and not context.force
-					and context.specSupported
-					and not visSettings.neverShow
+					and not forceHide
 				entry.thresholdEligibleCached = thresholdEligible
 				local targetAlpha, fadeDuration
 				local fadeDelay = 0
 
-				if hasCurve and boolShow then
+				if forceHide then
+					targetAlpha = 0
+					fadeDuration = 0
+					fadeDelay = 0
+				elseif hasCurve and boolShow then
 					-- Boolean conditions already satisfied (OR short-circuit).
 					-- Show at active alpha; the curve is not needed this tick.
 					targetAlpha = (visSettings and visSettings.activeAlpha or 100) / 100
@@ -582,6 +650,7 @@ function TRB.Functions.BarVisibility:ProcessBars(context, entries, snapshotData,
 				local isPermanentlyHidden = not entry.enabled
 					or entry.visibilitySettings == nil
 					or entry.visibilitySettings.neverShow == true
+					or entry.forceHideCached == true
 				if isPermanentlyHidden then
 					entry.barGroup.containerFrame:SetHeight(0.001)
 					entry.barGroup.containerFrame:SetWidth(0.001)
@@ -676,7 +745,7 @@ end
 ---@return TRB.Classes.BarVisibilityEntry[]
 function TRB.Functions.BarVisibility:BuildEditModeEntries(barGroups, displayBar, maxResource2)
 	local entries = {}
-	local alwaysVis = { neverShow = false, alwaysShow = true, conditions = {} }
+	local alwaysVis = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = {} }
 
 	-- Primary always shows in Edit Mode
 	if barGroups.primary then

--- a/Classes/Settings.lua
+++ b/Classes/Settings.lua
@@ -309,10 +309,21 @@ TRB.Classes.Settings = TRB.Classes.Settings or {}
 ---@field public isPvpFlagged boolean? # Show when the player is PVP flagged
 ---@field public isWarMode boolean? # Show when War Mode is enabled
 
+---@class trbBarVisibilityHideConditions
+---@field public isMountedAny boolean? # Hide when the player is mounted (any mount)
+---@field public isMountedGround boolean? # Hide when the player is on a ground mount (mounted + not flying)
+---@field public isMountedFlying boolean? # Hide when the player is on a flying mount (non-skyriding, flying)
+---@field public isSteadyFlight boolean? # DEPRECATED: migrated to isMountedFlying
+---@field public isSkyriding boolean? # Hide when the player is skyriding
+---@field public inVehicle boolean? # Hide when the player is in a vehicle
+---@field public inPetBattle boolean? # Hide when the player is in a pet battle
+---@field public onTaxi boolean? # Hide when the player is on a flight path
+
 ---@class trbBarVisibilitySetting
 ---@field public neverShow boolean # When true, the bar is unconditionally hidden regardless of conditions
 ---@field public alwaysShow boolean # When true, the bar is unconditionally shown (overrides conditions but not neverShow). Independent of individual conditions.
 ---@field public conditions trbBarVisibilityConditions # OR-combined conditions evaluated when alwaysShow is false
+---@field public hideConditions trbBarVisibilityHideConditions # OR-combined hard-hide conditions that override alwaysShow, normal show conditions, and threshold visibility
 ---@field public smooth boolean
 ---@field public activeAlpha number # Opacity (0–100) when visibility conditions are met. Default 100.
 ---@field public inactiveAlpha number # Opacity (0–100) when visibility conditions are NOT met. 0 = fully hidden. Default 0.

--- a/Functions/Bar.lua
+++ b/Functions/Bar.lua
@@ -432,14 +432,10 @@ function TRB.Functions.Bar:EndRenderTransition(reason)
 	SetBarGroupsAlpha(1)
 end
 
----Evaluates bar visibility and shows or hides the resource bar based on combat state, pet battles, taxi, Edit Mode, and spec support
+---Evaluates bar visibility and shows or hides the resource bar based on combat state, configured hide conditions, Edit Mode, and spec support
 ---@param force boolean? When true, forces the bar to hide regardless of other conditions
 function TRB.Functions.Bar:HideResourceBar(force)
 	force = force or false
-	
-	if TRB.Data.character.inPetBattle or TRB.Data.character.onTaxi then
-		force = true
-	end
 
 	-- If spec is not supported (disabled), hide all bars immediately and skip all other logic
 	if not TRB.Data.specSupported then

--- a/Functions/Character.lua
+++ b/Functions/Character.lua
@@ -817,6 +817,8 @@ end
 function TRB.Functions.Character:CheckCharacter()
 	TRB.Data.character.isPvp = TRB.Functions.Talent:ArePvpTalentsActive()
 	TRB.Data.character.isMounted = IsMounted()
+	TRB.Data.character.onTaxi = UnitOnTaxi("player") or false
+	TRB.Data.character.inPetBattle = C_PetBattles.IsInBattle() or false
 
 	-- Phase 2 visibility state
 	local _, canGlide = C_PlayerInfo.GetGlidingInfo()
@@ -985,6 +987,7 @@ function TRB.Functions.Character:LoadFromSpecializationCache(cache)
 	TRB.Data.character.inCombat = InCombatLockdown()
 	TRB.Data.character.inVehicle = UnitInVehicle("player") or false
 	TRB.Data.character.inPetBattle = C_PetBattles.IsInBattle() or false
+	TRB.Data.character.onTaxi = UnitOnTaxi("player") or false
 	TRB.Data.spellsData = cache.spellsData
 	TRB.Data.talents = cache.talents
 	TRB.Data.barTextVariables.icons = cache.barTextVariables.icons

--- a/Functions/News.lua
+++ b/Functions/News.lua
@@ -12,10 +12,15 @@ local content = [====[
 
 ---
 
-# 12.0.5.9-release (2026-05-21)
+# 12.0.5.9-release (2026-05-24)
 ## General
 
+- [#529](#529) Add new visibility overrides to always hide a bar when certain conditions are met, regardless of other visibility settings.
 - Fix an issue where specialization level bar text was not being rotated into the correct orientation when the bar's orientation was changed between horizontal and vertical. Shared/Global bar text remains unchanged when bar orientation changes occur.
+
+### Localization
+
+- [#756](#756) Updated translations for Simplified Chinese (zhCN) by M.O.S.S! Thank you so much for your help!
 
 ---
 

--- a/Functions/Settings.lua
+++ b/Functions/Settings.lua
@@ -3,6 +3,20 @@ local L = TRB.Localization
 
 TRB.Functions.Settings = {}
 
+---Creates a new independent copy of the default hard-hide visibility conditions.
+---@return trbBarVisibilityHideConditions
+function TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions()
+	return {
+		isMountedAny = false,
+		isMountedGround = false,
+		isMountedFlying = false,
+		isSkyriding = false,
+		inVehicle = true,
+		inPetBattle = true,
+		onTaxi = true,
+	}
+end
+
 ---Creates a new independent copy of NewSpecGlobalDefaults()
 ---@return TRB.Classes.Settings.SpecializationGlobalEnabled
 local function NewSpecGlobalDefaults()
@@ -83,6 +97,7 @@ function TRB.Functions.Settings:LoadDefaultSettings(classic)
 					neverShow = false,
 					alwaysShow = true,
 					conditions = {},
+					hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(),
 					smooth = true,
 					activeAlpha = 100,
 					inactiveAlpha = 0,
@@ -96,6 +111,7 @@ function TRB.Functions.Settings:LoadDefaultSettings(classic)
 					neverShow = false,
 					alwaysShow = true,
 					conditions = {},
+					hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(),
 					smooth = false,
 					activeAlpha = 100,
 					inactiveAlpha = 0,
@@ -109,6 +125,7 @@ function TRB.Functions.Settings:LoadDefaultSettings(classic)
 					neverShow = false,
 					alwaysShow = true,
 					conditions = {},
+					hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(),
 					smooth = true,
 					activeAlpha = 100,
 					inactiveAlpha = 0,
@@ -122,6 +139,7 @@ function TRB.Functions.Settings:LoadDefaultSettings(classic)
 					neverShow = true,
 					alwaysShow = false,
 					conditions = {},
+					hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(),
 					smooth = true,
 					activeAlpha = 100,
 					inactiveAlpha = 0,
@@ -2188,6 +2206,7 @@ function TRB.Functions.Settings:PortForwardSettings(settings)
 									inactiveAlpha = gs.inactiveAlpha,
 									fadeDuration = gs.fadeDuration,
 									fadeDelay = gs.fadeDelay,
+									hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(),
 								}
 								-- Deep copy conditions table if present
 								if gs.conditions then
@@ -2198,6 +2217,11 @@ function TRB.Functions.Settings:PortForwardSettings(settings)
 								else
 									visSource.conditions = {}
 								end
+								if gs.hideConditions then
+									for ck, cv in pairs(gs.hideConditions) do
+										visSource.hideConditions[ck] = cv
+									end
+								end
 							elseif specSettings.displayBar.secondary then
 								visSource = specSettings.displayBar.secondary
 							end
@@ -2206,7 +2230,7 @@ function TRB.Functions.Settings:PortForwardSettings(settings)
 								specSettings.displayBar.holyWords = visSource
 								specSettings.displayBar.secondary = nil
 							else
-								specSettings.displayBar.holyWords = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 }
+								specSettings.displayBar.holyWords = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 }
 							end
 						end
 
@@ -2283,7 +2307,7 @@ function TRB.Functions.Settings:PortForwardSettings(settings)
 							specSettings.displayBar = {}
 						end
 						if not specSettings.displayBar.boneShield then
-							specSettings.displayBar.boneShield = { neverShow = false, alwaysShow = true, conditions = {}, smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 }
+							specSettings.displayBar.boneShield = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = false, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 }
 						end
 
 						if specSettings.displayText and specSettings.displayText.barText then
@@ -2401,10 +2425,16 @@ function TRB.Functions.Settings:PortForwardSettings(settings)
 									fadeDuration = gs.fadeDuration,
 									fadeDelay = gs.fadeDelay,
 									conditions = {},
+									hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(),
 								}
 								if gs.conditions then
 									for ck, cv in pairs(gs.conditions) do
 										visSource.conditions[ck] = cv
+									end
+								end
+								if gs.hideConditions then
+									for ck, cv in pairs(gs.hideConditions) do
+										visSource.hideConditions[ck] = cv
 									end
 								end
 							elseif specSettings.displayBar.secondary then
@@ -2415,7 +2445,7 @@ function TRB.Functions.Settings:PortForwardSettings(settings)
 							if visSource then
 								specSettings.displayBar.ebonMight = visSource
 							else
-								specSettings.displayBar.ebonMight = { neverShow = false, alwaysShow = true, conditions = {}, smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 }
+								specSettings.displayBar.ebonMight = { neverShow = false, alwaysShow = true, conditions = {}, hideConditions = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions(), smooth = true, activeAlpha = 100, inactiveAlpha = 0, fadeDuration = 0, fadeDelay = 0 }
 							end
 						end
 
@@ -5202,6 +5232,51 @@ function TRB.Functions.Settings:PortForwardSettings(settings)
 				for specName, specSettings in pairs(TwintopInsanityBarSettings[className]) do
 					if specSettings and type(specSettings) == "table" and specSettings.displayBar then
 						MigrateResourceConditionSettings(specSettings.displayBar)
+					end
+				end
+			end
+		end
+	end
+
+	-- Backfill per-bar hard-hide conditions. These replace the old global pet battle
+	-- and taxi force-hide path, and default to enabled for all bars.
+	do
+		---@param displayBar table? # The displayBar settings table to migrate in-place
+		local function MigrateHideConditionSettings(displayBar)
+			if displayBar == nil then
+				return
+			end
+			for _, entry in pairs(displayBar) do
+				if type(entry) == "table" and entry.conditions ~= nil then
+					local defaults = TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions()
+					if entry.hideConditions == nil then
+						entry.hideConditions = defaults
+					else
+						---@type table<string, boolean>
+						local hideConditions = entry.hideConditions
+						if hideConditions.isSteadyFlight ~= nil and hideConditions.isMountedFlying == nil then
+							hideConditions.isMountedFlying = hideConditions.isSteadyFlight
+							hideConditions.isSteadyFlight = nil
+						end
+						for key, value in pairs(defaults) do
+							if hideConditions[key] == nil then
+								hideConditions[key] = value
+							end
+						end
+					end
+				end
+			end
+		end
+
+		if TwintopInsanityBarSettings and TwintopInsanityBarSettings.core and TwintopInsanityBarSettings.core.displayBar then
+			MigrateHideConditionSettings(TwintopInsanityBarSettings.core.displayBar)
+		end
+
+		for _, className in ipairs(classes) do
+			if TwintopInsanityBarSettings and TwintopInsanityBarSettings[className] then
+				for specName, specSettings in pairs(TwintopInsanityBarSettings[className]) do
+					if specSettings and type(specSettings) == "table" and specSettings.displayBar then
+						MigrateHideConditionSettings(specSettings.displayBar)
 					end
 				end
 			end

--- a/Functions/Settings.lua
+++ b/Functions/Settings.lua
@@ -11,7 +11,7 @@ function TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions()
 		isMountedGround = false,
 		isMountedFlying = false,
 		isSkyriding = false,
-		inVehicle = true,
+		inVehicle = false,
 		inPetBattle = true,
 		onTaxi = true,
 	}

--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -2809,3 +2809,22 @@ L["MatchAnchorHeightTooltip"] = "When enabled, this bar's height will match the 
 -- Threshold Icon Position Labels
 L["ThresholdIconPositionAboveLeft"] = "Above/Left"
 L["ThresholdIconPositionBelowRight"] = "Below/Right"
+
+-- Bar Visibility Hard Hide Conditions
+L["ShowBarVisibilityShowHeader"] = "Show Options"
+L["ShowBarVisibilityConditionInPetBattle"] = "In Pet Battle"
+L["ShowBarVisibilityConditionOnTaxi"] = "On a Flight Path"
+L["BarVisibilitySummaryShowHide"] = "%s / Hide: %s"
+
+-- Bar Visibility Column Headers
+L["ShowBarVisibilityShowColumnHeader"] = "Show Bar When"
+L["ShowBarVisibilityForceHideColumnHeader"] = "Always Hide Bar When"
+
+-- Bar Visibility Split Table Columns
+L["BarVisibilityTableHeaderShow"] = "Show"
+L["BarVisibilityTableHeaderAlwaysHide"] = "Always Hide"
+L["BarVisibilityTableShowNeverShown"] = "Never"
+
+-- Bar Visibility Dropdown Tooltips
+L["ShowBarVisibilityShowDropdownTooltip"] = "Controls when this bar is allowed to show. Always Show and Never Show override the selected show conditions; resource and health thresholds only apply when neither override is selected."
+L["ShowBarVisibilityForceHideDropdownTooltip"] = "Controls conditions that always force this bar to hide. These options take precedence over Show Bar When, Always Show, opacity, and resource or health threshold settings."

--- a/Options/OptionsUi.lua
+++ b/Options/OptionsUi.lua
@@ -8353,6 +8353,27 @@ function TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, 
 		},
 	}
 
+	local hideConditionKeys = { "isMountedAny", "isMountedGround", "isMountedFlying", "isSkyriding", "inVehicle", "inPetBattle", "onTaxi" }
+	local hideConditionLabels = {
+		isMountedAny = L["ShowBarVisibilityConditionIsMountedAny"],
+		isMountedGround = L["ShowBarVisibilityConditionIsMountedGround"],
+		isMountedFlying = L["ShowBarVisibilityConditionIsSteadyFlight"],
+		isSkyriding = L["ShowBarVisibilityConditionIsSkyriding"],
+		inVehicle = L["ShowBarVisibilityConditionInVehicle"],
+		inPetBattle = L["ShowBarVisibilityConditionInPetBattle"],
+		onTaxi = L["ShowBarVisibilityConditionOnTaxi"],
+	}
+	local hideConditionGroups = {
+		{
+			title = L["ShowBarVisibilityGroupGeneral"],
+			keys = { "inVehicle", "inPetBattle", "onTaxi" },
+		},
+		{
+			title = L["ShowBarVisibilityGroupMounting"],
+			keys = { "isMountedAny", "isMountedGround", "isSkyriding", "isMountedFlying" },
+		},
+	}
+
 	-- Labels for resource/health threshold condition types (used in dropdown and summary)
 	-- Ordered array so dropdown items render in a deterministic, logical order.
 	local thresholdTypes = {
@@ -8362,10 +8383,23 @@ function TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, 
 		{ key = "healthValue",     label = L["BarVisibilityThresholdHealthValue"] },
 	}
 
-	---Builds a localized summary string describing a bar visibility entry's conditions.
-	---@param entry table The visibility settings entry (with neverShow, alwaysShow, conditions, etc.)
+	---Builds a compact summary from a set of boolean conditions.
+	---@param selectedLabels string[] The selected condition labels
 	---@return string displayName The summary display text
-	local function GetVisibilityDisplayName(entry)
+	local function GetConditionDisplayName(selectedLabels)
+		if #selectedLabels == 0 then
+			return string.format(L["ShowBarVisibilitySelectedCount"], 0)
+		end
+		if #selectedLabels == 1 then
+			return selectedLabels[1]
+		end
+		return string.format(L["ShowBarVisibilitySelectedCount"], #selectedLabels)
+	end
+
+	---Builds a localized summary string describing the show side of a visibility entry.
+	---@param entry table The visibility settings entry
+	---@return string displayName The show summary display text
+	local function GetShowVisibilityDisplayName(entry)
 		if entry.neverShow then
 			return L["ShowBarVisibilityNever"]
 		end
@@ -8379,10 +8413,10 @@ function TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, 
 			if entry.visibility == "combat" then return L["ShowBarVisibilityCombat"] end
 			return L["ShowBarVisibilityAlways"]
 		end
-		local parts = {}
+		local selectedLabels = {}
 		for _, key in ipairs(conditionKeys) do
 			if conditions[key] then
-				table.insert(parts, conditionLabels[key])
+				table.insert(selectedLabels, conditionLabels[key])
 			end
 		end
 		-- Include resource/health threshold as an additional condition in the summary
@@ -8390,37 +8424,120 @@ function TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, 
 		if ct ~= nil and ct ~= "none" then
 			for _, tt in ipairs(thresholdTypes) do
 				if tt.key == ct then
-					table.insert(parts, tt.label)
+					table.insert(selectedLabels, tt.label)
 					break
 				end
 			end
 		end
-		if #parts == 0 then
-			return string.format(L["ShowBarVisibilitySelectedCount"], 0)
-		end
-		if #parts == 1 then
-			return parts[1]
-		end
-		return string.format(L["ShowBarVisibilitySelectedCount"], #parts)
+		return GetConditionDisplayName(selectedLabels)
 	end
 
-	-- Override a dropdown's SetText so the framework's auto-concatenated
-	-- checkbox labels are always replaced with our custom summary text.
-	-- The hook is installed once; call UpdateDropdownDisplayText() to change
-	-- the function that provides the display string and force a refresh.
-	local dropdownOriginalSetText = nil
-	local dropdownGetTextFunc = nil
+	---Counts selected options in the show-condition dropdown.
+	---@param entry table The visibility settings entry
+	---@return number selectedCount The number of selected show options
+	local function GetShowVisibilitySelectedCount(entry)
+		if entry.neverShow or entry.alwaysShow then
+			return 1
+		end
+
+		local conditions = entry.conditions
+		if conditions == nil then
+			return 1
+		end
+
+		local selectedCount = 0
+		for _, key in ipairs(conditionKeys) do
+			if conditions[key] then
+				selectedCount = selectedCount + 1
+			end
+		end
+
+		local ct = entry.resourceConditionType
+		if ct ~= nil and ct ~= "none" then
+			selectedCount = selectedCount + 1
+		end
+
+		return selectedCount
+	end
+
+	---Counts selected options in the hard-hide dropdown.
+	---@param entry table The visibility settings entry
+	---@return number selectedCount The number of selected hide options
+	local function GetHideVisibilitySelectedCount(entry)
+		local selectedCount = 0
+		local hideConditions = entry.hideConditions
+		if hideConditions ~= nil then
+			for _, key in ipairs(hideConditionKeys) do
+				if hideConditions[key] == true then
+					selectedCount = selectedCount + 1
+				end
+			end
+		end
+		return selectedCount
+	end
+
+	---Builds a count display string using the standard "X Selected" format.
+	---@param selectedCount number The number of selected options
+	---@return string displayName The count display text
+	local function GetSelectedCountDisplayName(selectedCount)
+		return string.format(L["ShowBarVisibilitySelectedCount"], selectedCount)
+	end
+
+	---Builds the compact show summary used in the visibility table.
+	---@param entry table The visibility settings entry
+	---@return string displayName The table display text
+	local function GetShowVisibilityTableDisplayName(entry)
+		if entry.neverShow then
+			return L["BarVisibilityTableShowNeverShown"]
+		end
+		if entry.alwaysShow then
+			return L["ShowBarVisibilityAlways"]
+		end
+		return GetSelectedCountDisplayName(GetShowVisibilitySelectedCount(entry))
+	end
+
+	---Builds the compact hard-hide summary used in the visibility table.
+	---@param entry table The visibility settings entry
+	---@return string displayName The table display text
+	local function GetHideVisibilityTableDisplayName(entry)
+		return GetSelectedCountDisplayName(GetHideVisibilitySelectedCount(entry))
+	end
+
+	---Builds a localized summary string describing the hard-hide side of a visibility entry.
+	---@param entry table The visibility settings entry
+	---@return string displayName The hide summary display text
+	---@return number selectedCount The number of selected hide conditions
+	local function GetHideVisibilityDisplayName(entry)
+		local selectedLabels = {}
+		local hideConditions = entry.hideConditions
+		if hideConditions ~= nil then
+			for _, key in ipairs(hideConditionKeys) do
+				if hideConditions[key] == true then
+					table.insert(selectedLabels, hideConditionLabels[key])
+				end
+			end
+		end
+		return GetConditionDisplayName(selectedLabels), GetHideVisibilitySelectedCount(entry)
+	end
+
+	local dropdownOriginalSetText = setmetatable({}, { __mode = "k" })
+	local dropdownGetTextFunc = setmetatable({}, { __mode = "k" })
 
 	---Installs a SetText hook on a dropdown so its display text is always replaced with a custom summary.
 	---@param dropdown DropdownButton The dropdown button to hook
 	local function InstallDropdownDisplayTextHook(dropdown)
-		if dropdownOriginalSetText == nil then
-			dropdownOriginalSetText = dropdown.SetText
+		if dropdownOriginalSetText[dropdown] == nil then
+			dropdownOriginalSetText[dropdown] = dropdown.SetText
 			dropdown.SetText = function(self, text)
-				if dropdownGetTextFunc then
-					dropdownOriginalSetText(self, dropdownGetTextFunc())
+				local originalSetText = dropdownOriginalSetText[self]
+				local getTextFunc = dropdownGetTextFunc[self]
+				if originalSetText == nil then
+					return
+				end
+				if getTextFunc then
+					originalSetText(self, getTextFunc())
 				else
-					dropdownOriginalSetText(self, text)
+					originalSetText(self, text)
 				end
 			end
 		end
@@ -8430,11 +8547,25 @@ function TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, 
 	---@param dropdown DropdownButton The dropdown button to update
 	---@param getTextFunc fun(): string A function that returns the current display text
 	local function UpdateDropdownDisplayText(dropdown, getTextFunc)
-		dropdownGetTextFunc = getTextFunc
+		dropdownGetTextFunc[dropdown] = getTextFunc
 		-- Force an immediate visual refresh via the original SetText
-		if dropdownOriginalSetText then
-			dropdownOriginalSetText(dropdown, getTextFunc())
+		if dropdownOriginalSetText[dropdown] then
+			dropdownOriginalSetText[dropdown](dropdown, getTextFunc())
 		end
+	end
+
+	---Adds a hover tooltip to a dropdown button.
+	---@param dropdown DropdownButton The dropdown button to attach a tooltip to
+	---@param tooltipText string The localized tooltip text
+	local function SetDropdownTooltip(dropdown, tooltipText)
+		dropdown:SetScript("OnEnter", function(self)
+			GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+			GameTooltip:SetText(tooltipText, 1, 1, 1, 1, true)
+			GameTooltip:Show()
+		end)
+		dropdown:SetScript("OnLeave", function()
+			GameTooltip:Hide()
+		end)
 	end
 
 	---Refreshes the spec/global cache and re-evaluates bar visibility after visibility settings change.
@@ -8508,14 +8639,17 @@ function TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, 
 		end
 	end
 
-	---Populates a dropdown menu with visibility condition checkboxes grouped by category.
+	---Populates the show-condition dropdown menu.
 	---@param rootDescription table The root menu description to add items to
 	---@param entry table The visibility settings entry to read/write conditions on
 	---@param onChange function Callback invoked after any condition is toggled
-	local function BuildVisibilityDropdownItems(rootDescription, entry, onChange)
-		rootDescription:SetScrollMode(400)
+	local function BuildShowVisibilityDropdownItems(rootDescription, entry, onChange)
+		if rootDescription.SetScrollMode then
+			rootDescription:SetScrollMode(400)
+		end
 
-		-- Always Show checkbox (standalone toggle, like Never Show)
+		entry.conditions = entry.conditions or {}
+
 		rootDescription:CreateCheckbox(
 			L["ShowBarVisibilityAlwaysShow"],
 			function() return entry.alwaysShow == true end,
@@ -8530,7 +8664,6 @@ function TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, 
 			end
 		)
 
-		-- Never Show checkbox
 		rootDescription:CreateCheckbox(
 			L["ShowBarVisibilityNeverShow"],
 			function() return entry.neverShow or false end,
@@ -8543,22 +8676,24 @@ function TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, 
 			end
 		)
 
-		-- Grouped condition sections
 		for _, group in ipairs(conditionGroups) do
+			local groupTitle = group.title
+			local groupKeys = group.keys
 			rootDescription:CreateDivider()
-			rootDescription:CreateTitle(group.title)
-			for _, key in ipairs(group.keys) do
+			rootDescription:CreateTitle(groupTitle)
+			for _, key in ipairs(groupKeys) do
+				local capturedKey = key
 				local checkbox = rootDescription:CreateCheckbox(
-					conditionLabels[key],
+					conditionLabels[capturedKey],
 					function()
-						return entry.conditions and entry.conditions[key] or false
+						return entry.conditions and entry.conditions[capturedKey] or false
 					end,
 					function()
 						entry.conditions = entry.conditions or {}
-						if entry.conditions[key] then
-							entry.conditions[key] = nil
+						if entry.conditions[capturedKey] then
+							entry.conditions[capturedKey] = nil
 						else
-							entry.conditions[key] = true
+							entry.conditions[capturedKey] = true
 						end
 						onChange()
 					end
@@ -8567,13 +8702,13 @@ function TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, 
 			end
 		end
 
-		-- Resource / Health Threshold section (mutually exclusive checkboxes)
 		rootDescription:CreateDivider()
 		rootDescription:CreateTitle(L["BarVisibilityThresholdHeader"])
 		for _, tt in ipairs(thresholdTypes) do
 			local capturedKey = tt.key
+			local capturedLabel = tt.label
 			local checkbox = rootDescription:CreateCheckbox(
-				tt.label,
+				capturedLabel,
 				function() return entry.resourceConditionType == capturedKey end,
 				function()
 					if entry.resourceConditionType == capturedKey then
@@ -8585,6 +8720,41 @@ function TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, 
 				end
 			)
 			checkbox:SetEnabled(function() return not entry.neverShow and not entry.alwaysShow end)
+		end
+	end
+
+	---Populates the hard-hide dropdown menu.
+	---@param rootDescription table The root menu description to add items to
+	---@param entry table The visibility settings entry to read/write hide conditions on
+	---@param onChange function Callback invoked after any condition is toggled
+	local function BuildHideVisibilityDropdownItems(rootDescription, entry, onChange)
+		if rootDescription.SetScrollMode then
+			rootDescription:SetScrollMode(400)
+		end
+
+		entry.hideConditions = entry.hideConditions or TRB.Functions.Settings:LoadDefaultBarVisibilityHideConditions()
+
+		for groupIndex, group in ipairs(hideConditionGroups) do
+			local groupTitle = group.title
+			local groupKeys = group.keys
+			rootDescription:CreateTitle(groupTitle)
+			for _, key in ipairs(groupKeys) do
+				local capturedKey = key
+				rootDescription:CreateCheckbox(
+					hideConditionLabels[capturedKey],
+					function()
+						return entry.hideConditions and entry.hideConditions[capturedKey] == true
+					end,
+					function()
+						entry.hideConditions = entry.hideConditions or {}
+						entry.hideConditions[capturedKey] = not (entry.hideConditions[capturedKey] == true)
+						onChange()
+					end
+				)
+			end
+			if groupIndex < #hideConditionGroups then
+				rootDescription:CreateDivider()
+			end
 		end
 	end
 
@@ -8670,13 +8840,18 @@ function TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, 
 			["align"] = "LEFT",
 		},
 		{
-			["name"] = L["BarVisibilityTableHeaderVisibility"],
-			["width"] = 75,
+			["name"] = L["BarVisibilityTableHeaderShow"],
+			["width"] = 95,
+			["align"] = "LEFT",
+		},
+		{
+			["name"] = L["BarVisibilityTableHeaderAlwaysHide"],
+			["width"] = 105,
 			["align"] = "LEFT",
 		},
 		{
 			["name"] = L["BarVisibilityTableHeaderSettingsSource"],
-			["width"] = 285,
+			["width"] = 255,
 			["align"] = "LEFT",
 		},
 	}
@@ -8690,11 +8865,11 @@ function TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, 
 
 	local barVisibilityTable = TRB.Details.addonData.libs.ScrollingTable:CreateST(columns, tableRowCount, 15, nil, bvc, false, false)
 
-	-- Dynamically resize the Visibility column to fill available width
+	-- Dynamically resize the Settings Source column to fill available width
 	bvc:HookScript("OnSizeChanged", function(self, w, h)
-		local fixedWidth = columns[1].width + columns[2].width + columns[4].width
-		local newVisibilityWidth = math.max(60, w - fixedWidth - 30)
-		columns[3].width = newVisibilityWidth
+		local fixedWidth = columns[1].width + columns[2].width + columns[3].width + columns[4].width
+		local newSettingsSourceWidth = math.max(180, w - fixedWidth - 30)
+		columns[5].width = newSettingsSourceWidth
 		barVisibilityTable:SetDisplayCols(columns)
 	end)
 
@@ -8712,15 +8887,18 @@ function TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, 
 			else
 				visSettings = spec.displayBar[entry.displayBarKey]
 			end
-			local statusText = ""
+			local showText = ""
+			local hideText = ""
 			if visSettings then
-				statusText = GetVisibilityDisplayName(visSettings)
+				showText = GetShowVisibilityTableDisplayName(visSettings)
+				hideText = GetHideVisibilityTableDisplayName(visSettings)
 			end
 			local rowData = {
 				cols = {
 					{ value = entry.key },
 					{ value = entry.label },
-					{ value = statusText },
+					{ value = showText },
+					{ value = hideText },
 					{ value = (classId == nil or isControlledByGlobal) and (classId ~= nil and entry.globalLabel and string.format(L["BarVisibilitySettingsSourceGlobalNamed"], entry.globalLabel) or L["BarVisibilitySettingsSourceGlobal"]) or L["BarVisibilitySettingsSourceSpec"] },
 				}
 			}
@@ -8734,7 +8912,7 @@ function TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, 
 	end
 
 	-- Detail panel below the table
-	local detailHeight = 320
+	local detailHeight = 360
 	controls.barVisibilityDetail = CreateFrame("Frame", "TwintopResourceBar_" .. namePrefix .. "_BarVisibilityDetail", parent, "BackdropTemplate")
 	local detailFrame = controls.barVisibilityDetail
 	detailFrame:SetPoint("TOPLEFT", bvc, "BOTTOMLEFT", 0, 0)
@@ -8745,30 +8923,39 @@ function TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, 
 	local detailYCoord = 0
 	local selectedBarKey = nil
 
-	-- Detail panel contents: header, dropdown, smooth checkbox, sliders
+	-- Detail panel contents: header, show/hide dropdowns, smooth checkbox, sliders
 	local detailHeader = TRB.Functions.OptionsUi:BuildSectionHeader(detailFrame, "", oUi.xCoord, detailYCoord)
 
 	detailYCoord = detailYCoord - 30
 	controls.dropDown = controls.dropDown or {}
 	controls.dropDown.selectedBarVisibility = CreateFrame("DropdownButton", "TwintopResourceBar_" .. namePrefix .. "_SelectedBarVisibility", detailFrame, "WowStyle1DropdownTemplate")
 	controls.dropDown.selectedBarVisibility:SetWidth(oUi.sliderWidth)
-	controls.dropDown.selectedBarVisibility.label = TRB.Functions.OptionsUi:BuildSectionHeader(detailFrame, L["BarVisibilityConditionsLabel"], oUi.xCoord, detailYCoord)
+	controls.dropDown.selectedBarVisibility.label = TRB.Functions.OptionsUi:BuildSectionHeader(detailFrame, L["ShowBarVisibilityShowColumnHeader"], oUi.xCoord, detailYCoord)
 	controls.dropDown.selectedBarVisibility.label.font:SetFontObject(GameFontNormal)
 	controls.dropDown.selectedBarVisibility:SetPoint("TOPLEFT", oUi.xCoord, detailYCoord - 30)
 	InstallDropdownDisplayTextHook(controls.dropDown.selectedBarVisibility)
+	SetDropdownTooltip(controls.dropDown.selectedBarVisibility, L["ShowBarVisibilityShowDropdownTooltip"])
 
-	-- Smooth checkbox (to the right of the dropdown)
+	controls.dropDown.selectedHideVisibility = CreateFrame("DropdownButton", "TwintopResourceBar_" .. namePrefix .. "_SelectedHideVisibility", detailFrame, "WowStyle1DropdownTemplate")
+	controls.dropDown.selectedHideVisibility:SetWidth(oUi.sliderWidth)
+	controls.dropDown.selectedHideVisibility.label = TRB.Functions.OptionsUi:BuildSectionHeader(detailFrame, L["ShowBarVisibilityForceHideColumnHeader"], oUi.xCoord2, detailYCoord)
+	controls.dropDown.selectedHideVisibility.label.font:SetFontObject(GameFontNormal)
+	controls.dropDown.selectedHideVisibility:SetPoint("TOPLEFT", oUi.xCoord2, detailYCoord - 30)
+	InstallDropdownDisplayTextHook(controls.dropDown.selectedHideVisibility)
+	SetDropdownTooltip(controls.dropDown.selectedHideVisibility, L["ShowBarVisibilityForceHideDropdownTooltip"])
+
+	-- Smooth checkbox (separate row below dropdowns)
 	controls.checkBoxes = controls.checkBoxes or {}
 	controls.checkBoxes.selectedSmooth = CreateFrame("CheckButton", "TwintopResourceBar_" .. namePrefix .. "_SelectedSmooth", detailFrame, "ChatConfigCheckButtonTemplate")
 	f = controls.checkBoxes.selectedSmooth
-	f:SetPoint("TOPLEFT", oUi.xCoord2, detailYCoord - 30)
+	f:SetPoint("TOPLEFT", oUi.xCoord, detailYCoord - 70)
 	getglobal(f:GetName() .. 'Text'):SetText(L["CheckboxSmoothBar"])
 	f.tooltip = L["CheckboxSmoothBarTooltip"]
 
 	-- Alpha/fade sliders
 	controls.sliders = controls.sliders or {}
 
-	detailYCoord = detailYCoord - 70
+	detailYCoord = detailYCoord - 105
 	controls.sliders.selectedActiveAlpha = TRB.Functions.OptionsUi:BuildSlider(detailFrame, L["ShowBarVisibilityActiveAlpha"],
 		0, 100, 100, 1, 0,
 		oUi.sliderWidth, oUi.sliderHeight, oUi.xCoord, detailYCoord)
@@ -8922,9 +9109,9 @@ function TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, 
 		-- Determine if this bar needs the appearance refresh (custom bars)
 		local refreshFunc = barEntry.isCustomBar and RefreshVisibilityAndAppearance or RefreshVisibilitySettings
 
-		-- Visibility dropdown
+		-- Visibility dropdowns
 		local function OnVisibilityChange()
-			local displayText = GetVisibilityDisplayName(visSettings)
+			local displayText = GetShowVisibilityDisplayName(visSettings)
 			controls.dropDown.selectedBarVisibility:SetDefaultText(displayText)
 			controls.dropDown.selectedBarVisibility:SetText(displayText)
 			ShowThresholdControls(visSettings.resourceConditionType or "none", visSettings)
@@ -8939,12 +9126,36 @@ function TRB.Functions.OptionsUi:GenerateBarVisibilityOptions(parent, controls, 
 			end
 		end
 
+		local function OnHideVisibilityChange()
+			local displayText = GetHideVisibilityDisplayName(visSettings)
+			controls.dropDown.selectedHideVisibility:SetDefaultText(displayText)
+			controls.dropDown.selectedHideVisibility:SetText(displayText)
+			refreshFunc()
+			SetTableValues()
+			-- Re-select the current row
+			for i, e in ipairs(barEntries) do
+				if e.key == barKey then
+					barVisibilityTable:SetSelection(i)
+					break
+				end
+			end
+		end
+
 		local function VisibilityGenerator(dropdown, rootDescription)
-			BuildVisibilityDropdownItems(rootDescription, visSettings, OnVisibilityChange)
+			BuildShowVisibilityDropdownItems(rootDescription, visSettings, OnVisibilityChange)
+		end
+
+		local function HideVisibilityGenerator(dropdown, rootDescription)
+			BuildHideVisibilityDropdownItems(rootDescription, visSettings, OnHideVisibilityChange)
 		end
 
 		controls.dropDown.selectedBarVisibility:SetupMenu(VisibilityGenerator)
-		UpdateDropdownDisplayText(controls.dropDown.selectedBarVisibility, function() return GetVisibilityDisplayName(visSettings) end)
+		UpdateDropdownDisplayText(controls.dropDown.selectedBarVisibility, function() return GetShowVisibilityDisplayName(visSettings) end)
+		controls.dropDown.selectedHideVisibility:SetupMenu(HideVisibilityGenerator)
+		UpdateDropdownDisplayText(controls.dropDown.selectedHideVisibility, function()
+			local displayText = GetHideVisibilityDisplayName(visSettings)
+			return displayText
+		end)
 
 		-- Smooth checkbox
 		controls.checkBoxes.selectedSmooth:SetChecked(visSettings.smooth)

--- a/TwintopInsanityBar.toc
+++ b/TwintopInsanityBar.toc
@@ -13,9 +13,9 @@
 ## Title-zhTW: Twintop 的資源欄
 ## Author: Twintop
 ## X-AuthorServer: Frostmourne-US/OCE
-## Version: 12.0.5.8
+## Version: 12.0.5.9
 ## X-ReleaseType: release
-## X-ReleaseDate: 2026-05-20
+## X-ReleaseDate: 2026-05-24
 ## SavedVariables: TwintopInsanityBarSettings
 ## IconTexture: 1386550
 ## DefaultState: enabled


### PR DESCRIPTION
# Summary

Completes #529.

Adds configurable “Always Hide Bar When” visibility rules that force bars hidden when selected conditions are met, taking precedence over normal show conditions, Always Show, opacity, and threshold-based display logic.

# Changes

- Added hard-hide visibility settings for mounted states, skyriding, vehicles, pet battles, and flight paths.
- Replaced previous hardcoded pet battle / flight path hiding with configurable defaults, while keeping those conditions enabled by default.
- Split visibility configuration into separate “Show Bar When” and “Always Hide Bar When” dropdowns.
- Added table columns and dropdown tooltips so precedence and selected visibility rules are clearer.
- Added settings migration/backfill so existing profiles receive the new hide-condition structure safely.