### PR TITLE
Fix Dominion of Argus Soul Shard prediction

### DIFF
--- a/ClassModules/Classes/WarlockClasses.lua
+++ b/ClassModules/Classes/WarlockClasses.lua
@@ -120,8 +120,7 @@ function TRB.Classes.Warlock.DemonologySpells:New()
     })
     self.ruination = TRB.Classes.SpellBase:New({
         id = 434635,
-        isTalent = true,
-        resource = 1
+        isTalent = true
     })
     self.handOfGuldan = TRB.Classes.SpellBase:New({
         id = 105174,

--- a/ClassModules/Warlock.lua
+++ b/ClassModules/Warlock.lua
@@ -679,6 +679,8 @@ local function UpdateCastingResourceFinal_Demonology()
 	casting.resourceFinal = casting.resourceRaw
 	casting.resource2Casting = 0
 	casting.resource2Spending = 0
+	local dominionOfArgusSnapshot = snapshotData.snapshots[spells.dominionOfArgus.id]
+	local dominionOfArgusActive = dominionOfArgusSnapshot ~= nil and dominionOfArgusSnapshot.buff.isActive
 
 	if casting.spellId == spells.shadowBolt.id then
 		casting.resource2Casting = spells.shadowBolt.resource
@@ -686,17 +688,15 @@ local function UpdateCastingResourceFinal_Demonology()
 		casting.resource2Casting = spells.demonbolt.resource
 	elseif casting.spellId == spells.infernalBolt.id then
 		casting.resource2Casting = spells.infernalBolt.resource
-	elseif casting.spellId == spells.ruination.id then
-		casting.resource2Casting = spells.ruination.resource
+	elseif casting.spellId == spells.ruination.id and dominionOfArgusActive then
+		casting.resource2Casting = spells.dominionOfArgus.attributes.resourceMod
 	elseif casting.spellId == spells.summonDemonicTyrant.id and talents:IsTalentActive(spells.shadowOfDeath) then
 		casting.resource2Casting = spells.shadowOfDeath.resource
 	elseif casting.spellId == spells.handOfGuldan.id then
-		local mod = 0
-		local dominionOfArgusTalent = talents.talents[spells.dominionOfArgus.id]
-		if dominionOfArgusTalent and dominionOfArgusTalent.currentRank == dominionOfArgusTalent.maxRank then
-			mod = spells.demonicCalling.attributes.resourceMod
+		casting.resource2Spending = spells.handOfGuldan.resource
+		if dominionOfArgusActive then
+			casting.resource2Spending = casting.resource2Spending + spells.dominionOfArgus.attributes.resourceMod
 		end
-		casting.resource2Spending = spells.handOfGuldan.resource + mod
 	elseif casting.spellId == spells.summonFelguard.id then
 		casting.resource2Spending = spells.summonFelguard.resource
 	elseif casting.spellId == spells.callDreadstalkers.id then


### PR DESCRIPTION
## Summary

- remove Ruination's unconditional Soul Shard generation prediction
- base Dominion of Argus refunds on the active buff instead of the talent rank
- predict Hand of Gul'dan and Ruination correctly during the Dominion of Argus window

## Mechanic

Dominion of Argus refunds one Soul Shard when Hand of Gul'dan is cast during its active window. This changes the predictions as follows:

- Hand of Gul'dan normally spends 3 Soul Shards
- Hand of Gul'dan spends 3 and refunds 1 during Dominion of Argus, for a net cost of 2
- Ruination normally has no Soul Shard change
- Ruination is free and still receives the refund during Dominion of Argus, for a net gain of 1

## Root cause

Ruination was configured with an unconditional `resource = 1`, causing a false incoming Soul Shard prediction outside Dominion of Argus. The Hand of Gul'dan adjustment also checked the Dominion of Argus talent rank rather than whether its buff was currently active, and reused Demonic Calling's resource modifier.

## Impact

Demonology Warlock Soul Shard overlays now reflect the actual net resource change for Hand of Gul'dan and Ruination both inside and outside the Dominion of Argus burst window.

## Validation

- parsed all Lua files with `luac -p`
- verified the committed prediction branches for all four resource outcomes
- ran `git diff --check`
