### PR TITLE
Fix threshold flicker when docked to Cooldown Manager

### DIFF
--- a/Functions/Bar.lua
+++ b/Functions/Bar.lua
@@ -1009,14 +1009,6 @@ function TRB.Functions.Bar:ApplyBarGroupsLayout(settings, barGroups)
 			if self:IsRenderTransitionActive() then
 				SetBarGroupsAlpha(0)
 			end
-
-			-- Redraw thresholds to match new bar dimensions
-			local thresholds = primaryNode:GetThresholds()
-			if thresholds and #thresholds > 0 then
-				for _, threshold in ipairs(thresholds) do
-					TRB.Functions.Threshold:ResetThresholdLine(threshold, settings, true)
-				end
-			end
 		end
 	end
 
@@ -1056,28 +1048,14 @@ function TRB.Functions.Bar:ApplyBarGroupsLayout(settings, barGroups)
 			end
 		end
 
-		-- Redraw thresholds on secondary nodes to match new bar dimensions
-		for i = 1, barGroups.secondary.maxNodes do
-			local node = barGroups.secondary:GetNode(i)
-			if node then
-				local thresholds = node:GetThresholds()
-				if thresholds and #thresholds > 0 then
-					for _, threshold in ipairs(thresholds) do
-						TRB.Functions.Threshold:ResetThresholdLineComboPoint(threshold, layoutSettings)
-					end
-				end
-			end
-		end
 	elseif barGroups.secondary then
 		-- No combo point settings for this spec/configuration - hide the secondary bar
 		barGroups.secondary:Hide()
 	end
 
-	-- Clear threshold color cache so AdjustThresholdDisplay recalculates colors correctly
+	-- Clear RGBA memoization cache so AdjustThresholdDisplay recalculates colors correctly
 	-- This fixes a bug where moving the bar caused threshold colors to reset and stay wrong
-	-- Also clear colors cache in general
 	if TRB.Data.cache and TRB.Data.cache.values then
-		wipe(TRB.Data.cache.values.threshold)
 		TRB.Functions.Character:ResetColorCaches()
 	end
 

--- a/Functions/News.lua
+++ b/Functions/News.lua
@@ -12,6 +12,13 @@ local content = [====[
 
 ---
 
+# 12.0.7.3-release (2026-06-29)
+## General
+
+- [#784](#784 - @EricaPomme) Fix threshold flickering when bar is anchored to Cooldown Manager frames.
+
+---
+
 # 12.0.7.2-release (2026-06-28)
 ## General
 ### Localization

--- a/TwintopInsanityBar.toc
+++ b/TwintopInsanityBar.toc
@@ -13,9 +13,9 @@
 ## Title-zhTW: Twintop 的資源欄
 ## Author: Twintop
 ## X-AuthorServer: Frostmourne-US/OCE
-## Version: 12.0.7.2
+## Version: 12.0.7.3
 ## X-ReleaseType: release
-## X-ReleaseDate: 2026-06-28
+## X-ReleaseDate: 2026-06-29
 ## SavedVariables: TwintopInsanityBarSettings
 ## IconTexture: 1386550
 ## DefaultState: enabled


### PR DESCRIPTION
## Symptoms

When the resource bar is docked to Blizzard's Cooldown Manager (CDM) via Edit Mode, threshold lines and their associated icons flicker--disappearing entirely for a fraction of a second before reappearing. The flicker is:

- Worse when more Blizzard UI elements are on screen (e.g., Extra Action Buttons)
- More frequent while moving, but also present while standing in town
- Not present when the bar is free-floating (not docked to CDM)
- Unaffected by addon resets or running with only stock addons

## Root Cause

The CDM frame fires OnSizeChanged frequently--not just when the player resizes it, but whenever other Blizzard UI elements cause the CDM to reflow. TRB hooks this event and calls ReapplyAnchorFrameLayout() -> ApplyBarGroupsLayout() on every resize.
Inside ApplyBarGroupsLayout, two operations cause the flicker:

1. ResetThresholdLine() called on every primary threshold--This function unconditionally calls threshold:Hide() and resets the threshold color to the default "over" (green). Thresholds stay hidden until the next render tick calls AdjustThresholdDisplay to show them again--a gap of at least one frame.
2. wipe(TRB.Data.cache.values.threshold)--This forces SetThresholdIcon to re-run on the next tick, which calls SetBackdrop on every icon frame, resetting border colors.
   Both operations are redundant because the per-frame render tick already handles threshold positioning (RepositionThreshold reads live parent frame dimensions) and coloring (AdjustThresholdDisplay computes colors from spell/resource state).

## Fix

Remove the redundant threshold operations from ApplyBarGroupsLayout in Functions/Bar.lua:

- Primary threshold loop (ResetThresholdLine)--thresholds are positioned by RepositionThreshold in the render tick, which reads parentFrame:GetWidth() dynamically. The hide/color-reset was the direct cause of the flicker.
- Secondary threshold loop (ResetThresholdLineComboPoint)--same reasoning; render tick handles positioning.
- Threshold cache wipe (wipe(TRB.Data.cache.values.threshold))--forced unnecessary SetBackdrop re-application. Position changes are detected by comparing cache.effectiveSize against the live value, so the cache wipe was not needed for recalculation.
  ResetColorCaches() is preserved--it clears RGBA memoization which is the actual fix for the stale-colors-on-move bug that the original cache wipe was addressing.
  Testing
- Verified threshold lines, icons, and borders remain visible and correctly colored while docked to CDM
- Verified thresholds still reposition correctly when bar width changes (CDM width matching)
- Verified RedrawThresholdLines still works for explicit redraws
