### PR TITLE
Bar text and update loop performance

### DIFF
--- a/ClassModules/DeathKnight.lua
+++ b/ClassModules/DeathKnight.lua
@@ -1188,8 +1188,16 @@ local function UpdateResourceBar()
 					end
 
 					pairOffset = (thresholdId - 1) * 3
-					local resourceAmount = spell:GetPrimaryResourceCost()
-					local isUsable = spell:IsUsable()
+					-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+					-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+					local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+					local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+						or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+					local resourceAmount, isUsable = 0, false
+					if thresholdActive then
+						resourceAmount = spell:GetPrimaryResourceCost()
+						isUsable = spell:IsUsable()
+					end
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
 					local frameLevel = frameLevels.thresholdOver
@@ -1296,8 +1304,16 @@ local function UpdateResourceBar()
 					end
 
 					pairOffset = (thresholdId - 1) * 3
-					local resourceAmount = spell:GetPrimaryResourceCost()
-					local isUsable = spell:IsUsable()
+					-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+					-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+					local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+					local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+						or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+					local resourceAmount, isUsable = 0, false
+					if thresholdActive then
+						resourceAmount = spell:GetPrimaryResourceCost()
+						isUsable = spell:IsUsable()
+					end
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
 					local frameLevel = frameLevels.thresholdOver
@@ -1394,8 +1410,16 @@ local function UpdateResourceBar()
 					end
 
 					pairOffset = (thresholdId - 1) * 3
-					local resourceAmount = spell:GetPrimaryResourceCost()
-					local isUsable = spell:IsUsable()
+					-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+					-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+					local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+					local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+						or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+					local resourceAmount, isUsable = 0, false
+					if thresholdActive then
+						resourceAmount = spell:GetPrimaryResourceCost()
+						isUsable = spell:IsUsable()
+					end
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
 					local frameLevel = frameLevels.thresholdOver

--- a/ClassModules/DeathKnight.lua
+++ b/ClassModules/DeathKnight.lua
@@ -19,6 +19,16 @@ local spellEventFrame = CreateFrame("Frame")
 
 local talents --[[@as TRB.Classes.Talents]]
 
+-- Per-tick scratch tables, reused so the color resolution path allocates nothing.
+local scratch = {
+	runicPowerBarColors1 = {},
+	barColorMap1 = {},
+	runeBarColors1 = {},
+	barColorMap2 = {},
+	coagulatingBloodColors1 = {},
+	barColorMap3 = {},
+}
+
 -- Max currently applied to the Coagulating Blood node. Its min/max can be tainted by the secret stack
 -- count, so the applied scale is tracked here instead of read back off the frame.
 local coagulatingBloodAppliedMax = nil
@@ -784,13 +794,16 @@ end
 
 local function ApplyPrimaryRunicPowerColors(specSettings, primaryNode)
 	local indicatorColors, _, gradientOrder, conditionMap, sharedColors = GetDeathKnightIndicatorState(specSettings)
-	local runicPowerBarColors = {
-		bar = specSettings.colors.bar.base,
-		border = specSettings.colors.bar.border.color,
-		background = specSettings.colors.bar.background.color,
-	}
+	local runicPowerBarColors = scratch.runicPowerBarColors1
+	wipe(runicPowerBarColors)
+	runicPowerBarColors.bar = specSettings.colors.bar.base
+	runicPowerBarColors.border = specSettings.colors.bar.border.color
+	runicPowerBarColors.background = specSettings.colors.bar.background.color
+	local barColorMap = scratch.barColorMap1
+	wipe(barColorMap)
+	barColorMap.runicPowerBar = runicPowerBarColors
 
-	TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, { runicPowerBar = runicPowerBarColors })
+	TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
 
 	local gradientIndicator = GetActiveGradientIndicator(indicatorColors, gradientOrder, conditionMap)
 	local overcapCurves = BuildGradientCurves(specSettings, "runicPowerBar", runicPowerBarColors, gradientIndicator)
@@ -834,13 +847,16 @@ local function UpdateRunes(specSettings, specCacheSettings)
 	local runeRegenIndicator = indicatorColors and indicatorColors.runeRegenOvercap
 	local runeTargets = runeRegenIndicator and runeRegenIndicator.enabled and conditionMap.runeRegenOvercap
 		and runeRegenIndicator.targets and runeRegenIndicator.targets.runesBar or nil
-	local runeBarColors = {
-		bar = cpBaseColor,
-		border = cpBorderColor,
-		background = cpBackgroundColor,
-	}
+	local runeBarColors = scratch.runeBarColors1
+	wipe(runeBarColors)
+	runeBarColors.bar = cpBaseColor
+	runeBarColors.border = cpBorderColor
+	runeBarColors.background = cpBackgroundColor
+	local barColorMap = scratch.barColorMap2
+	wipe(barColorMap)
+	barColorMap.runesBar = runeBarColors
 
-	TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, { runesBar = runeBarColors })
+	TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
 	local gradientIndicator = GetActiveGradientIndicator(indicatorColors, gradientOrder, conditionMap)
 	local runeGradientCurves = BuildGradientCurves(specSettings, "runesBar", runeBarColors, gradientIndicator)
 	local runeGradientResults = {}
@@ -1074,13 +1090,16 @@ local function UpdateCoagulatingBlood(specSettings, specCacheSettings)
 	-- Same color resolution as the primary bar. Unlike Bone Shield the fill has no positional scheme
 	-- of its own, so the gradient can target it too.
 	local indicatorColors, _, gradientOrder, conditionMap, sharedColors = GetDeathKnightIndicatorState(specSettings)
-	local coagulatingBloodColors = {
-		bar = colors.bar,
-		border = colors.border.color,
-		background = colors.background.color,
-	}
+	local coagulatingBloodColors = scratch.coagulatingBloodColors1
+	wipe(coagulatingBloodColors)
+	coagulatingBloodColors.bar = colors.bar
+	coagulatingBloodColors.border = colors.border.color
+	coagulatingBloodColors.background = colors.background.color
+	local barColorMap = scratch.barColorMap3
+	wipe(barColorMap)
+	barColorMap.coagulatingBlood = coagulatingBloodColors
 
-	Color:ApplyIndicatorColors(sharedColors, conditionMap, { coagulatingBlood = coagulatingBloodColors })
+	Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
 
 	local gradientIndicator = GetActiveGradientIndicator(indicatorColors, gradientOrder, conditionMap)
 	local overcapCurves = BuildGradientCurves(specSettings, "coagulatingBlood", coagulatingBloodColors, gradientIndicator)

--- a/ClassModules/DemonHunter.lua
+++ b/ClassModules/DemonHunter.lua
@@ -963,6 +963,30 @@ local function UpdateSnapshot_Devourer()
 
 end
 
+
+-- Reused per-tick scratch tables for UpdateResourceBar (see conditionMap/barColorMap sites).
+-- Held in one table so UpdateResourceBar gains a single upvalue rather than one per site.
+local scratch = {
+	conditionMap1 = {},
+	furyBarColors1 = {},
+	barColorMap1 = {},
+	overcapCurves1 = {},
+	conditionMap2 = {},
+	furyBarColors2 = {},
+	barColorMap2 = {},
+	overcapCurves2 = {},
+	conditionMap3 = {},
+	sfOvercapCurves1 = {},
+	gradientConditionMap1 = {},
+	conditionMap4 = {},
+	furyBarColors3 = {},
+	barColorMap3 = {},
+	overcapCurves3 = {},
+	sfConditionMap1 = {},
+	sfOvercapCurves2 = {},
+	sfGradientConditionMap1 = {},
+}
+
 local function UpdateResourceBar()
 	local currentTime = GetTime()
 	local refreshText = false
@@ -1020,15 +1044,21 @@ local function UpdateResourceBar()
 				metamorphosisEndMet = metaTime <= timeThreshold
 			end
 
-			local conditionMap = {
-				metamorphosisEnd = metamorphosisActive and metamorphosisEndMet,
-				metamorphosis = metamorphosisActive,
-				borderOvercap = affectingCombat,
-			}
+			local conditionMap = scratch.conditionMap1
+			wipe(conditionMap)
+			conditionMap.metamorphosisEnd = metamorphosisActive and metamorphosisEndMet
+			conditionMap.metamorphosis = metamorphosisActive
+			conditionMap.borderOvercap = affectingCombat
 
 			-- Color targets: barKey -> elementKey -> current color
-			local furyBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
-			local barColorMap = { furyBar = furyBarColors }
+			local furyBarColors = scratch.furyBarColors1
+			wipe(furyBarColors)
+			furyBarColors.bar = barColor
+			furyBarColors.border = barBorderColor
+			furyBarColors.background = barBackgroundColor
+			local barColorMap = scratch.barColorMap1
+			wipe(barColorMap)
+			barColorMap.furyBar = furyBarColors
 
 			-- Apply flat indicator colors (priority order, last writer wins)
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
@@ -1167,7 +1197,8 @@ local function UpdateResourceBar()
 					barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 
 					-- Build gradient curves for targeted elements (gradient always wins over flat indicators)
-					local overcapCurves = {}
+					local overcapCurves = scratch.overcapCurves1
+					wipe(overcapCurves)
 					if overcapIndicator and overcapIndicator.targets then
 						local furyTargets = overcapIndicator.targets.furyBar
 						if furyTargets then
@@ -1251,15 +1282,21 @@ local function UpdateResourceBar()
 				metamorphosisEndMet = metaTime <= timeThreshold
 			end
 
-			local conditionMap = {
-				metamorphosisEnd = metamorphosisActive and metamorphosisEndMet,
-				metamorphosis = metamorphosisActive,
-				borderOvercap = affectingCombat,
-			}
+			local conditionMap = scratch.conditionMap2
+			wipe(conditionMap)
+			conditionMap.metamorphosisEnd = metamorphosisActive and metamorphosisEndMet
+			conditionMap.metamorphosis = metamorphosisActive
+			conditionMap.borderOvercap = affectingCombat
 
 			-- Color targets: barKey -> elementKey -> current color
-			local furyBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
-			local barColorMap = { furyBar = furyBarColors }
+			local furyBarColors = scratch.furyBarColors2
+			wipe(furyBarColors)
+			furyBarColors.bar = barColor
+			furyBarColors.border = barBorderColor
+			furyBarColors.background = barBackgroundColor
+			local barColorMap = scratch.barColorMap2
+			wipe(barColorMap)
+			barColorMap.furyBar = furyBarColors
 
 			-- Apply flat indicator colors (priority order, last writer wins)
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
@@ -1367,7 +1404,8 @@ local function UpdateResourceBar()
 					barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 
 					-- Build gradient curves for targeted elements (gradient always wins over flat indicators)
-					local overcapCurves = {}
+					local overcapCurves = scratch.overcapCurves2
+					wipe(overcapCurves)
 					if overcapIndicator and overcapIndicator.targets then
 						local furyTargets = overcapIndicator.targets.furyBar
 						if furyTargets then
@@ -1444,10 +1482,10 @@ local function UpdateResourceBar()
 						metamorphosisEndMet = metaTime <= timeThreshold
 					end
 
-					local conditionMap = {
-						metamorphosisEnd = metamorphosisActive and metamorphosisEndMet,
-						metamorphosis = metamorphosisActive,
-					}
+					local conditionMap = scratch.conditionMap3
+					wipe(conditionMap)
+					conditionMap.metamorphosisEnd = metamorphosisActive and metamorphosisEndMet
+					conditionMap.metamorphosis = metamorphosisActive
 
 					-- Apply flat indicators to soul fragment targets (reverse iteration, last writer wins)
 					for i = #nodeOrder, 1, -1 do
@@ -1465,13 +1503,14 @@ local function UpdateResourceBar()
 				end
 
 				-- Build gradient curves for soul fragment targets (border/background only, uses fury scale)
-				local sfOvercapCurves = {}
+				local sfOvercapCurves = scratch.sfOvercapCurves1
+				wipe(sfOvercapCurves)
 				local gradientOrder = sharedColors and sharedColors.gradientOrder
 				if gradientOrder and indicatorColors then
 					local affectingCombat = TRB.Data.character.inCombat
-					local gradientConditionMap = {
-						borderOvercap = affectingCombat,
-					}
+					local gradientConditionMap = scratch.gradientConditionMap1
+					wipe(gradientConditionMap)
+					gradientConditionMap.borderOvercap = affectingCombat
 					for i = #gradientOrder, 1, -1 do
 						local key = gradientOrder[i]
 						local indicator = indicatorColors[key]
@@ -1569,17 +1608,23 @@ local function UpdateResourceBar()
 
 			local voidRayUsable = (not metaActive) and spells.voidRay:IsUsable()
 
-			local conditionMap = {
-				voidMetamorphosisReady = metaUsable,
-				collapsingStarReady = collapsingStarUsable,
-				voidMetamorphosis = metaActive,
-				voidRayReady = voidRayUsable,
-				borderOvercap = affectingCombat,
-			}
+			local conditionMap = scratch.conditionMap4
+			wipe(conditionMap)
+			conditionMap.voidMetamorphosisReady = metaUsable
+			conditionMap.collapsingStarReady = collapsingStarUsable
+			conditionMap.voidMetamorphosis = metaActive
+			conditionMap.voidRayReady = voidRayUsable
+			conditionMap.borderOvercap = affectingCombat
 
 			-- Color targets: barKey -> elementKey -> current color
-			local furyBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
-			local barColorMap = { furyBar = furyBarColors }
+			local furyBarColors = scratch.furyBarColors3
+			wipe(furyBarColors)
+			furyBarColors.bar = barColor
+			furyBarColors.border = barBorderColor
+			furyBarColors.background = barBackgroundColor
+			local barColorMap = scratch.barColorMap3
+			wipe(barColorMap)
+			barColorMap.furyBar = furyBarColors
 
 			-- Apply flat indicator colors (priority order, last writer wins)
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
@@ -1700,7 +1745,8 @@ local function UpdateResourceBar()
 					barGroups.primary:GetContainerFrame():SetAlpha(barGroups.primary.currentAlpha or 1.0)
 
 					-- Build gradient curves for targeted elements (gradient always wins over flat indicators)
-					local overcapCurves = {}
+					local overcapCurves = scratch.overcapCurves3
+					wipe(overcapCurves)
 					if overcapIndicator and overcapIndicator.targets then
 						local furyTargets = overcapIndicator.targets.furyBar
 						if furyTargets then
@@ -1771,12 +1817,12 @@ local function UpdateResourceBar()
 				local sfNodeOrder = sfSharedColors and sfSharedColors.nodeOrder
 
 				if sfNodeOrder and sfIndicatorColors then
-					local sfConditionMap = {
-						voidMetamorphosisReady = metaUsable,
-						collapsingStarReady = collapsingStarUsable,
-						voidMetamorphosis = metaActive,
-						voidRayReady = (not metaActive) and spells.voidRay:IsUsable(),
-					}
+					local sfConditionMap = scratch.sfConditionMap1
+					wipe(sfConditionMap)
+					sfConditionMap.voidMetamorphosisReady = metaUsable
+					sfConditionMap.collapsingStarReady = collapsingStarUsable
+					sfConditionMap.voidMetamorphosis = metaActive
+					sfConditionMap.voidRayReady = (not metaActive) and spells.voidRay:IsUsable()
 
 					for i = #sfNodeOrder, 1, -1 do
 						local key = sfNodeOrder[i]
@@ -1793,13 +1839,14 @@ local function UpdateResourceBar()
 				end
 
 				-- Build gradient curves for soul fragment targets (border/background only, uses fury scale)
-				local sfOvercapCurves = {}
+				local sfOvercapCurves = scratch.sfOvercapCurves2
+				wipe(sfOvercapCurves)
 				local sfGradientOrder = sfSharedColors and sfSharedColors.gradientOrder
 				local sfAffectingCombat = TRB.Data.character.inCombat
 				if sfGradientOrder and sfIndicatorColors then
-					local sfGradientConditionMap = {
-						borderOvercap = sfAffectingCombat,
-					}
+					local sfGradientConditionMap = scratch.sfGradientConditionMap1
+					wipe(sfGradientConditionMap)
+					sfGradientConditionMap.borderOvercap = sfAffectingCombat
 					for i = #sfGradientOrder, 1, -1 do
 						local key = sfGradientOrder[i]
 						local indicator = sfIndicatorColors[key]

--- a/ClassModules/DemonHunter.lua
+++ b/ClassModules/DemonHunter.lua
@@ -1080,8 +1080,16 @@ local function UpdateResourceBar()
 					local pairOffset = 0
 					for thresholdId, spell in ipairs(TRB.Data.cache.thresholdSpells--[=[@as TRB.Classes.SpellThreshold[]]=]) do
 						pairOffset = (thresholdId - 1) * 3
-						local resourceAmount = spell:GetPrimaryResourceCost()
-						local isUsable = spell:IsUsable()
+						-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+						-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+						local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+						local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+							or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+						local resourceAmount, isUsable = 0, false
+						if thresholdActive then
+							resourceAmount = spell:GetPrimaryResourceCost()
+							isUsable = spell:IsUsable()
+						end
 						local showThreshold = true
 						local thresholdColor = specCacheSettings.colors.threshold.over.color
 						local frameLevel = frameLevels.thresholdOver
@@ -1319,8 +1327,16 @@ local function UpdateResourceBar()
 					local pairOffset = 0
 					for thresholdId, spell in ipairs(TRB.Data.cache.thresholdSpells--[=[@as TRB.Classes.SpellThreshold[]]=]) do
 						pairOffset = (thresholdId - 1) * 3
-						local resourceAmount = spell:GetPrimaryResourceCost()
-						local isUsable = spell:IsUsable()
+						-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+						-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+						local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+						local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+							or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+						local resourceAmount, isUsable = 0, false
+						if thresholdActive then
+							resourceAmount = spell:GetPrimaryResourceCost()
+							isUsable = spell:IsUsable()
+						end
 						local showThreshold = true
 						local thresholdColor = specCacheSettings.colors.threshold.over.color
 						local frameLevel = frameLevels.thresholdOver
@@ -1648,8 +1664,16 @@ local function UpdateResourceBar()
 					local pairOffset = 0
 					for thresholdId, spell in ipairs(TRB.Data.cache.thresholdSpells--[=[@as TRB.Classes.SpellThreshold[]]=]) do
 						pairOffset = (thresholdId - 1) * 3
-						local resourceAmount = spell:GetPrimaryResourceCost()
-						local isUsable = spell:IsUsable()
+						-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+						-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+						local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+						local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+							or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+						local resourceAmount, isUsable = 0, false
+						if thresholdActive then
+							resourceAmount = spell:GetPrimaryResourceCost()
+							isUsable = spell:IsUsable()
+						end
 						local showThreshold = true
 						local thresholdColor = specCacheSettings.colors.threshold.over.color
 						local frameLevel = frameLevels.thresholdOver

--- a/ClassModules/Druid.lua
+++ b/ClassModules/Druid.lua
@@ -343,9 +343,22 @@ local function UpdateResourceValues()
 	end
 end
 
+-- Unified bar mana formatting: power events set the dirty flags; RefreshLookupData_Unified
+-- re-derives the abbreviations at most once per tick.
+local unifiedManaDirty = true
+local unifiedManaMaxDirty = true
+local unifiedManaFormatted = nil
+local unifiedManaMaxFormatted = nil
+local unifiedManaPercentFormatted = nil
+local unifiedManaPercentPrecision = nil
+
 local function DruidPowerEvent(self, event, ...)
 	if event == "UNIT_POWER_UPDATE" or event == "UNIT_POWER_FREQUENT" then
 		UpdateResourceValues()
+		local _, powerType = ...
+		if powerType == "MANA" then
+			unifiedManaDirty = true
+		end
 		if TRB.Functions.BarVisibility.hasResourceCurve then
 			TRB.Functions.BarVisibility:MarkDirty()
 		end
@@ -362,6 +375,7 @@ local function DruidPowerEvent(self, event, ...)
 				TRB.Data.character.maxRage = UnitPowerMax("player", Enum.PowerType.Rage, true)
 			elseif powerType == "MANA" then
 				TRB.Data.character.maxMana = UnitPowerMax("player", Enum.PowerType.Mana, true)
+				unifiedManaMaxDirty = true
 			elseif powerType == "LUNAR_POWER" then
 				TRB.Data.character.maxAstralPower = UnitPowerMax("player", Enum.PowerType.LunarPower, true)
 			end
@@ -832,27 +846,26 @@ local function RefreshLookupData_Balance()
 	-- Block C: Mana ($mana, $manaMax, $manaPercent)
 	if not activeVars or activeVars["$mana"] or activeVars["$manaMax"] or activeVars["$manaPercent"] then
 		local currentManaColor = (sharedSettings.colors.text.manaBar and sharedSettings.colors.text.manaBar.color) or sharedSettings.colors.text.current.color
-		local normalizedMana = UnitPower("player", Enum.PowerType.Mana)
-		local normalizedManaMax = UnitPowerMax("player", Enum.PowerType.Mana)
 		local manaPrecision = sharedSettings.precision.mana or 1
-		local _manaPercent = UnitPowerPercent("player", Enum.PowerType.Mana)
-		local manaPercentRaw = UnitPowerPercent("player", Enum.PowerType.Mana, false, CurveConstants.ScaleTo100)
-
-		lookupLogic["$mana"] = normalizedMana
-		lookupLogic["$manaMax"] = normalizedManaMax
-		lookupLogic["$manaPercent"] = _manaPercent
-
-		local manaFormatted = TRB.Functions.String:ConvertToAbbreviatedNumber(normalizedMana)
-		if lookupChanged(prevState, "$mana", manaFormatted, currentManaColor) then
-			lookup["$mana"] = string.format("|c%s%s|r", currentManaColor, manaFormatted)
+		-- Power events only mark dirty; re-derive here at most once per tick, plus first read and
+		-- precision changes.
+		local additionalPower = snapshotData.formatted.additionalPower
+		local mana = additionalPower and additionalPower["MANA"]
+		if mana == nil or mana.dirty or mana.precision ~= manaPrecision then
+			TRB.Functions.Character:UpdateAdditionalPowerValues("MANA")
+			mana = snapshotData.formatted.additionalPower["MANA"]
 		end
-		local manaMaxFormatted = TRB.Functions.String:ConvertToAbbreviatedNumber(normalizedManaMax)
-		if lookupChanged(prevState, "$manaMax", manaMaxFormatted, currentManaColor) then
-			lookup["$manaMax"] = string.format("|c%s%s|r", currentManaColor, manaMaxFormatted)
+		lookupLogic["$mana"] = mana.current
+		lookupLogic["$manaMax"] = mana.max
+		lookupLogic["$manaPercent"] = mana.percent
+		if lookupChanged(prevState, "$mana", mana.currentFormatted, currentManaColor) then
+			lookup["$mana"] = string.format("|c%s%s|r", currentManaColor, mana.currentFormatted)
 		end
-		local manaPercentFormatted = string.format("%." .. manaPrecision .. "f", manaPercentRaw)
-		if lookupChanged(prevState, "$manaPercent", manaPercentFormatted, currentManaColor) then
-			lookup["$manaPercent"] = string.format("|c%s%s|r", currentManaColor, manaPercentFormatted)
+		if lookupChanged(prevState, "$manaMax", mana.maxFormatted, currentManaColor) then
+			lookup["$manaMax"] = string.format("|c%s%s|r", currentManaColor, mana.maxFormatted)
+		end
+		if lookupChanged(prevState, "$manaPercent", mana.percentFormatted, currentManaColor) then
+			lookup["$manaPercent"] = string.format("|c%s%s|r", currentManaColor, mana.percentFormatted)
 		end
 	end
 
@@ -1277,14 +1290,28 @@ local function RefreshLookupData_Unified()
 		lookup["$rageMax"] = TRB.Data.character.maxRage / RAGE_RESOURCE_FACTOR
 
 		-- FCS: Mana ($mana, $manaMax, $manaPercent)
-		if lookupChanged(prevState, "u$mana", mana, manaColor, true) then
-			lookup["$mana"] = string.format("|c%s%s|r", manaColor, TRB.Functions.String:ConvertToAbbreviatedNumber(mana))
+		if unifiedManaFormatted == nil or unifiedManaDirty then
+			unifiedManaFormatted = TRB.Functions.String:ConvertToAbbreviatedNumber(mana)
+			unifiedManaPercentFormatted = nil
+			unifiedManaDirty = false
 		end
-		if lookupChanged(prevState, "u$manaMax", TRB.Data.character.maxMana, manaColor, true) then
-			lookup["$manaMax"] = string.format("|c%s%s|r", manaColor, TRB.Functions.String:ConvertToAbbreviatedNumber(TRB.Data.character.maxMana))
+		if unifiedManaMaxFormatted == nil or unifiedManaMaxDirty then
+			unifiedManaMaxFormatted = TRB.Functions.String:ConvertToAbbreviatedNumber(TRB.Data.character.maxMana)
+			unifiedManaPercentFormatted = nil
+			unifiedManaMaxDirty = false
 		end
-		if lookupChanged(prevState, "u$manaPercent", manaPercent, manaColor, true) then
-			lookup["$manaPercent"] = string.format("|c%s%." .. manaPrecision .. "f|r", manaColor, manaPercent)
+		if unifiedManaPercentFormatted == nil or unifiedManaPercentPrecision ~= manaPrecision then
+			unifiedManaPercentFormatted = string.format("%." .. manaPrecision .. "f", manaPercent)
+			unifiedManaPercentPrecision = manaPrecision
+		end
+		if lookupChanged(prevState, "u$mana", unifiedManaFormatted, manaColor) then
+			lookup["$mana"] = string.format("|c%s%s|r", manaColor, unifiedManaFormatted)
+		end
+		if lookupChanged(prevState, "u$manaMax", unifiedManaMaxFormatted, manaColor) then
+			lookup["$manaMax"] = string.format("|c%s%s|r", manaColor, unifiedManaMaxFormatted)
+		end
+		if lookupChanged(prevState, "u$manaPercent", unifiedManaPercentFormatted, manaColor) then
+			lookup["$manaPercent"] = string.format("|c%s%s|r", manaColor, unifiedManaPercentFormatted)
 		end
 
 		-- FCS: Astral Power ($astralPower, $astralPowerMax) - Balance only
@@ -3694,6 +3721,8 @@ function TRB.Functions.Class:CheckCharacter()
 	TRB.Data.character.maxRage = UnitPowerMax("player", Enum.PowerType.Rage, true)
 	TRB.Data.character.maxMana = UnitPowerMax("player", Enum.PowerType.Mana, true)
 	TRB.Data.character.maxAstralPower = UnitPowerMax("player", Enum.PowerType.LunarPower, true)
+	unifiedManaDirty = true
+	unifiedManaMaxDirty = true
 	TRB.Data.character.maxComboPoints = UnitPowerMax("player", Enum.PowerType.ComboPoints)
 
 	local function SetupSharedSettingsForSpec()
@@ -3798,6 +3827,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.resourceFactor = ASTRAL_POWER_RESOURCE_FACTOR
 		TRB.Data.resource2 = nil
 		TRB.Data.resource2Factor = nil
+		TRB.Data.additionalPowerTokens = { ["MANA"] = true }
 		primaryResourceToken = "LUNAR_POWER"
 		-- Track all resources for form-based switching
 		TRB.Data.resourceEnergy = Enum.PowerType.Energy
@@ -3811,6 +3841,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.resourceFactor = ENERGY_RESOURCE_FACTOR
 		TRB.Data.resource2 = Enum.PowerType.ComboPoints
 		TRB.Data.resource2Factor = 1
+		TRB.Data.additionalPowerTokens = nil
 		primaryResourceToken = "ENERGY"
 		-- Track all resources for form-based switching
 		TRB.Data.resourceRage = Enum.PowerType.Rage
@@ -3822,6 +3853,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.resourceFactor = RAGE_RESOURCE_FACTOR
 		TRB.Data.resource2 = nil
 		TRB.Data.resource2Factor = nil
+		TRB.Data.additionalPowerTokens = nil
 		primaryResourceToken = "RAGE"
 		-- Track all resources for form-based switching
 		TRB.Data.resourceEnergy = Enum.PowerType.Energy
@@ -3835,6 +3867,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.resourceFactor = MANA_RESOURCE_FACTOR
 		TRB.Data.resource2 = nil
 		TRB.Data.resource2Factor = nil
+		TRB.Data.additionalPowerTokens = nil
 		primaryResourceToken = "MANA"
 		-- Track all resources for form-based switching
 		TRB.Data.resourceEnergy = Enum.PowerType.Energy
@@ -3843,6 +3876,7 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.resourceComboPoints = Enum.PowerType.ComboPoints
 	else
 		TRB.Data.specSupported = false
+		TRB.Data.additionalPowerTokens = nil
 	end
 
 	Character:EventRegistration()

--- a/ClassModules/Druid.lua
+++ b/ClassModules/Druid.lua
@@ -1830,8 +1830,16 @@ local function UpdateResourceBar()
 				end
 			else
 				pairOffset = (thresholdId - 1) * 3
-				local resourceAmount = spell:GetPrimaryResourceCost()
-				local isUsable = spell:IsUsable()
+				-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+				-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+				local thresholdSettings = formSpecCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+				local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+					or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+				local resourceAmount, isUsable = 0, false
+				if thresholdActive then
+					resourceAmount = spell:GetPrimaryResourceCost()
+					isUsable = spell:IsUsable()
+				end
 				local showThreshold = true
 				local thresholdColor = formSpecCacheSettings.colors.threshold.over.color
 				local frameLevel = frameLevels.thresholdOver
@@ -2050,7 +2058,15 @@ local function UpdateResourceBar()
 								thresholds = primaryNode:GetThresholds()
 							end
 							pairOffset = (thresholdId - 1) * 3
-							local resourceAmount = spell:GetPrimaryResourceCost()
+							-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+							-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+							local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+							local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+								or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+							local resourceAmount = 0
+							if thresholdActive then
+								resourceAmount = spell:GetPrimaryResourceCost()
+							end
 							local showThreshold = true
 							local thresholdColor = specCacheSettings.colors.threshold.over.color --[[@as string?]]
 							local frameLevel = frameLevels.thresholdOver
@@ -2375,8 +2391,16 @@ local function UpdateResourceBar()
 								thresholds = primaryNode:GetThresholds()
 							end
 							pairOffset = (thresholdId - 1) * 3
-							local resourceAmount = spell:GetPrimaryResourceCost()
-							local isUsable = spell:IsUsable()
+							-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+							-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+							local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+							local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+								or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+							local resourceAmount, isUsable = 0, false
+							if thresholdActive then
+								resourceAmount = spell:GetPrimaryResourceCost()
+								isUsable = spell:IsUsable()
+							end
 							local showThreshold = true
 							---@type string?
 							local thresholdColor = specCacheSettings.colors.threshold.over.color
@@ -2906,8 +2930,16 @@ local function UpdateResourceBar()
 								thresholds = primaryNode:GetThresholds()
 							end
 							pairOffset = (thresholdId - 1) * 3
-							local resourceAmount = spell:GetPrimaryResourceCost()
-							local isUsable = spell:IsUsable()
+							-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+							-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+							local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+							local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+								or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+							local resourceAmount, isUsable = 0, false
+							if thresholdActive then
+								resourceAmount = spell:GetPrimaryResourceCost()
+								isUsable = spell:IsUsable()
+							end
 							local showThreshold = true
 							local thresholdColor = specCacheSettings.colors.threshold.over.color --[[@as string?]]
 							local frameLevel = frameLevels.thresholdOver

--- a/ClassModules/Druid.lua
+++ b/ClassModules/Druid.lua
@@ -1636,6 +1636,29 @@ local function UpdateSnapshot_Restoration()
 	UpdateSnapshot()
 end
 
+
+-- Reused per-tick scratch tables for UpdateResourceBar (see conditionMap/barColorMap sites).
+-- Held in one table so UpdateResourceBar gains a single upvalue rather than one per site.
+local scratch = {
+	conditionMap1 = {},
+	astralPowerBarColors1 = {},
+	comboPointColors1 = {},
+	barColorMap1 = {},
+	conditionMap2 = {},
+	energyBarColors1 = {},
+	comboPointColors2 = {},
+	barColorMap2 = {},
+	cpBaseColors1 = {},
+	conditionMap3 = {},
+	rageBarColors1 = {},
+	comboPointColors3 = {},
+	barColorMap3 = {},
+	conditionMap4 = {},
+	manaBarColors1 = {},
+	comboPointColors4 = {},
+	barColorMap4 = {},
+}
+
 local function UpdateResourceBar()
 	local currentTime = GetTime()
 	local refreshText = false
@@ -2165,17 +2188,28 @@ local function UpdateResourceBar()
 
 				local celestialActive = snapshots[spells.celestialAlignment.id].buff.isActive or snapshots[spells.incarnationChosenOfElune.id].buff.isActive or (snapshots[spells.eclipseSolar.id].buff.isActive and snapshots[spells.eclipseLunar.id].buff.isActive)
 
-				local conditionMap = {
-					eclipseEnd = eclipseActive and eclipseEndMet,
-					celestial = celestialActive,
-					solar = snapshots[spells.eclipseSolar.id].buff.isActive and not celestialActive,
-					lunar = snapshots[spells.eclipseLunar.id].buff.isActive and not celestialActive and not snapshots[spells.eclipseSolar.id].buff.isActive,
-					borderOvercap = affectingCombat and displaySpecId == TRB.Data.character.specId,
-				}
+				local conditionMap = scratch.conditionMap1
+				wipe(conditionMap)
+				conditionMap.eclipseEnd = eclipseActive and eclipseEndMet
+				conditionMap.celestial = celestialActive
+				conditionMap.solar = snapshots[spells.eclipseSolar.id].buff.isActive and not celestialActive
+				conditionMap.lunar = snapshots[spells.eclipseLunar.id].buff.isActive and not celestialActive and not snapshots[spells.eclipseSolar.id].buff.isActive
+				conditionMap.borderOvercap = affectingCombat and displaySpecId == TRB.Data.character.specId
 
-				local astralPowerBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
-				local comboPointColors = { bar = nil, border = nil, background = nil }
-				local barColorMap = { astralPowerBar = astralPowerBarColors, comboPoints = comboPointColors }
+				local astralPowerBarColors = scratch.astralPowerBarColors1
+				wipe(astralPowerBarColors)
+				astralPowerBarColors.bar = barColor
+				astralPowerBarColors.border = barBorderColor
+				astralPowerBarColors.background = barBackgroundColor
+				local comboPointColors = scratch.comboPointColors1
+				wipe(comboPointColors)
+				comboPointColors.bar = nil
+				comboPointColors.border = nil
+				comboPointColors.background = nil
+				local barColorMap = scratch.barColorMap1
+				wipe(barColorMap)
+				barColorMap.astralPowerBar = astralPowerBarColors
+				barColorMap.comboPoints = comboPointColors
 
 				-- Apply flat indicator colors (priority order, last writer wins)
 				TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
@@ -2515,19 +2549,30 @@ local function UpdateResourceBar()
 
 					local isStealthed = IsStealthed()
 
-					local conditionMap = {
-						apexPredator = apcActive,
-						ravage = snapshots[spells.ravageMinimum.id].buff.isActive,
-						clearcasting = snapshotData.attributes.clearcastingActive,
-						borderStealth = isStealthed,
-						halazzisFury = snapshots[spells.halazzisFury.id].buff.isActive,
-						maxBite = snapshotData.attributes.resource2 == 5 and not apcActive,
-						borderOvercap = affectingCombat and not isStealthed and displaySpecId == TRB.Data.character.specId,
-					}
+					local conditionMap = scratch.conditionMap2
+					wipe(conditionMap)
+					conditionMap.apexPredator = apcActive
+					conditionMap.ravage = snapshots[spells.ravageMinimum.id].buff.isActive
+					conditionMap.clearcasting = snapshotData.attributes.clearcastingActive
+					conditionMap.borderStealth = isStealthed
+					conditionMap.halazzisFury = snapshots[spells.halazzisFury.id].buff.isActive
+					conditionMap.maxBite = snapshotData.attributes.resource2 == 5 and not apcActive
+					conditionMap.borderOvercap = affectingCombat and not isStealthed and displaySpecId == TRB.Data.character.specId
 
-					local energyBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
-					local comboPointColors = { bar = nil, border = nil, background = nil }
-					local barColorMap = { energyBar = energyBarColors, comboPoints = comboPointColors }
+					local energyBarColors = scratch.energyBarColors1
+					wipe(energyBarColors)
+					energyBarColors.bar = barColor
+					energyBarColors.border = barBorderColor
+					energyBarColors.background = barBackgroundColor
+					local comboPointColors = scratch.comboPointColors2
+					wipe(comboPointColors)
+					comboPointColors.bar = nil
+					comboPointColors.border = nil
+					comboPointColors.background = nil
+					local barColorMap = scratch.barColorMap2
+					wipe(barColorMap)
+					barColorMap.energyBar = energyBarColors
+					barColorMap.comboPoints = comboPointColors
 
 					-- Apply flat indicator colors (priority order, last writer wins)
 					TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
@@ -2634,7 +2679,11 @@ local function UpdateResourceBar()
 						-- Process combo point elements
 						local maxBiteCpTargets = maxBiteActive and maxBiteInd.targets and maxBiteInd.targets.comboPoints
 						local overcapCpTargets = overcapActive and overcapInd.targets and overcapInd.targets.comboPoints
-						local cpBaseColors = { bar = specSettings.colors.comboPoints.base, border = specSettings.colors.comboPoints.border.color, background = specSettings.colors.comboPoints.background.color }
+						local cpBaseColors = scratch.cpBaseColors1
+						wipe(cpBaseColors)
+						cpBaseColors.bar = specSettings.colors.comboPoints.base
+						cpBaseColors.border = specSettings.colors.comboPoints.border.color
+						cpBaseColors.background = specSettings.colors.comboPoints.background.color
 						for _, elem in ipairs({"bar", "border", "background"}) do
 							local mbTargets = maxBiteCpTargets and maxBiteCpTargets[elem]
 							local ocTargets = overcapCpTargets and overcapCpTargets[elem]
@@ -3040,15 +3089,26 @@ local function UpdateResourceBar()
 
 				local berserkActive = snapshots[spells.berserk.id].buff.isActive or snapshots[spells.incarnationGuardianOfUrsoc.id].buff.isActive
 
-				local conditionMap = {
-					berserkEnd = berserkActive and guardianBerserkEndMet,
-					berserk = berserkActive,
-					borderOvercap = affectingCombat and displaySpecId == TRB.Data.character.specId,
-				}
+				local conditionMap = scratch.conditionMap3
+				wipe(conditionMap)
+				conditionMap.berserkEnd = berserkActive and guardianBerserkEndMet
+				conditionMap.berserk = berserkActive
+				conditionMap.borderOvercap = affectingCombat and displaySpecId == TRB.Data.character.specId
 
-				local rageBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
-				local comboPointColors = { bar = nil, border = nil, background = nil }
-				local barColorMap = { rageBar = rageBarColors, comboPoints = comboPointColors }
+				local rageBarColors = scratch.rageBarColors1
+				wipe(rageBarColors)
+				rageBarColors.bar = barColor
+				rageBarColors.border = barBorderColor
+				rageBarColors.background = barBackgroundColor
+				local comboPointColors = scratch.comboPointColors3
+				wipe(comboPointColors)
+				comboPointColors.bar = nil
+				comboPointColors.border = nil
+				comboPointColors.background = nil
+				local barColorMap = scratch.barColorMap3
+				wipe(barColorMap)
+				barColorMap.rageBar = rageBarColors
+				barColorMap.comboPoints = comboPointColors
 
 				-- Apply flat indicator colors (priority order, last writer wins)
 				TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
@@ -3160,16 +3220,27 @@ local function UpdateResourceBar()
 
 					local clearcastingActive = snapshotData.attributes.clearcastingActive
 
-					local conditionMap = {
-						incarnationEnd = isNativeForm and incarnationActive and incarnationEndMet,
-						incarnation = isNativeForm and incarnationActive,
-						noEfflorescence = isNativeForm and affectingCombat and talents:IsTalentActive(spells.efflorescence) and not snapshots[spells.efflorescence.id].buff.isActive,
-						clearcasting = isNativeForm and clearcastingActive,
-					}
+					local conditionMap = scratch.conditionMap4
+					wipe(conditionMap)
+					conditionMap.incarnationEnd = isNativeForm and incarnationActive and incarnationEndMet
+					conditionMap.incarnation = isNativeForm and incarnationActive
+					conditionMap.noEfflorescence = isNativeForm and affectingCombat and talents:IsTalentActive(spells.efflorescence) and not snapshots[spells.efflorescence.id].buff.isActive
+					conditionMap.clearcasting = isNativeForm and clearcastingActive
 
-					local manaBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
-					local comboPointColors = { bar = nil, border = nil, background = nil }
-					local barColorMap = { manaBar = manaBarColors, comboPoints = comboPointColors }
+					local manaBarColors = scratch.manaBarColors1
+					wipe(manaBarColors)
+					manaBarColors.bar = barColor
+					manaBarColors.border = barBorderColor
+					manaBarColors.background = barBackgroundColor
+					local comboPointColors = scratch.comboPointColors4
+					wipe(comboPointColors)
+					comboPointColors.bar = nil
+					comboPointColors.border = nil
+					comboPointColors.background = nil
+					local barColorMap = scratch.barColorMap4
+					wipe(barColorMap)
+					barColorMap.manaBar = manaBarColors
+					barColorMap.comboPoints = comboPointColors
 
 					-- Apply flat indicator colors (priority order, last writer wins)
 					TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)

--- a/ClassModules/Druid.lua
+++ b/ClassModules/Druid.lua
@@ -2231,9 +2231,6 @@ local function UpdateResourceBar()
 				astralPowerBarColors.background = barBackgroundColor
 				local comboPointColors = scratch.comboPointColors1
 				wipe(comboPointColors)
-				comboPointColors.bar = nil
-				comboPointColors.border = nil
-				comboPointColors.background = nil
 				local barColorMap = scratch.barColorMap1
 				wipe(barColorMap)
 				barColorMap.astralPowerBar = astralPowerBarColors
@@ -2594,9 +2591,6 @@ local function UpdateResourceBar()
 					energyBarColors.background = barBackgroundColor
 					local comboPointColors = scratch.comboPointColors2
 					wipe(comboPointColors)
-					comboPointColors.bar = nil
-					comboPointColors.border = nil
-					comboPointColors.background = nil
 					local barColorMap = scratch.barColorMap2
 					wipe(barColorMap)
 					barColorMap.energyBar = energyBarColors
@@ -3130,9 +3124,6 @@ local function UpdateResourceBar()
 				rageBarColors.background = barBackgroundColor
 				local comboPointColors = scratch.comboPointColors3
 				wipe(comboPointColors)
-				comboPointColors.bar = nil
-				comboPointColors.border = nil
-				comboPointColors.background = nil
 				local barColorMap = scratch.barColorMap3
 				wipe(barColorMap)
 				barColorMap.rageBar = rageBarColors
@@ -3262,9 +3253,6 @@ local function UpdateResourceBar()
 					manaBarColors.background = barBackgroundColor
 					local comboPointColors = scratch.comboPointColors4
 					wipe(comboPointColors)
-					comboPointColors.bar = nil
-					comboPointColors.border = nil
-					comboPointColors.background = nil
 					local barColorMap = scratch.barColorMap4
 					wipe(barColorMap)
 					barColorMap.manaBar = manaBarColors

--- a/ClassModules/Druid.lua
+++ b/ClassModules/Druid.lua
@@ -846,26 +846,27 @@ local function RefreshLookupData_Balance()
 	-- Block C: Mana ($mana, $manaMax, $manaPercent)
 	if not activeVars or activeVars["$mana"] or activeVars["$manaMax"] or activeVars["$manaPercent"] then
 		local currentManaColor = (sharedSettings.colors.text.manaBar and sharedSettings.colors.text.manaBar.color) or sharedSettings.colors.text.current.color
+		local normalizedMana = UnitPower("player", Enum.PowerType.Mana)
+		local normalizedManaMax = UnitPowerMax("player", Enum.PowerType.Mana)
 		local manaPrecision = sharedSettings.precision.mana or 1
-		-- Power events only mark dirty; re-derive here at most once per tick, plus first read and
-		-- precision changes.
-		local additionalPower = snapshotData.formatted.additionalPower
-		local mana = additionalPower and additionalPower["MANA"]
-		if mana == nil or mana.dirty or mana.precision ~= manaPrecision then
-			TRB.Functions.Character:UpdateAdditionalPowerValues("MANA")
-			mana = snapshotData.formatted.additionalPower["MANA"]
+		local _manaPercent = UnitPowerPercent("player", Enum.PowerType.Mana)
+		local manaPercentRaw = UnitPowerPercent("player", Enum.PowerType.Mana, false, CurveConstants.ScaleTo100)
+
+		lookupLogic["$mana"] = normalizedMana
+		lookupLogic["$manaMax"] = normalizedManaMax
+		lookupLogic["$manaPercent"] = _manaPercent
+
+		local manaFormatted = TRB.Functions.String:ConvertToAbbreviatedNumber(normalizedMana)
+		if lookupChanged(prevState, "$mana", manaFormatted, currentManaColor) then
+			lookup["$mana"] = string.format("|c%s%s|r", currentManaColor, manaFormatted)
 		end
-		lookupLogic["$mana"] = mana.current
-		lookupLogic["$manaMax"] = mana.max
-		lookupLogic["$manaPercent"] = mana.percent
-		if lookupChanged(prevState, "$mana", mana.currentFormatted, currentManaColor) then
-			lookup["$mana"] = string.format("|c%s%s|r", currentManaColor, mana.currentFormatted)
+		local manaMaxFormatted = TRB.Functions.String:ConvertToAbbreviatedNumber(normalizedManaMax)
+		if lookupChanged(prevState, "$manaMax", manaMaxFormatted, currentManaColor) then
+			lookup["$manaMax"] = string.format("|c%s%s|r", currentManaColor, manaMaxFormatted)
 		end
-		if lookupChanged(prevState, "$manaMax", mana.maxFormatted, currentManaColor) then
-			lookup["$manaMax"] = string.format("|c%s%s|r", currentManaColor, mana.maxFormatted)
-		end
-		if lookupChanged(prevState, "$manaPercent", mana.percentFormatted, currentManaColor) then
-			lookup["$manaPercent"] = string.format("|c%s%s|r", currentManaColor, mana.percentFormatted)
+		local manaPercentFormatted = string.format("%." .. manaPrecision .. "f", manaPercentRaw)
+		if lookupChanged(prevState, "$manaPercent", manaPercentFormatted, currentManaColor) then
+			lookup["$manaPercent"] = string.format("|c%s%s|r", currentManaColor, manaPercentFormatted)
 		end
 	end
 
@@ -3827,7 +3828,6 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.resourceFactor = ASTRAL_POWER_RESOURCE_FACTOR
 		TRB.Data.resource2 = nil
 		TRB.Data.resource2Factor = nil
-		TRB.Data.additionalPowerTokens = { ["MANA"] = true }
 		primaryResourceToken = "LUNAR_POWER"
 		-- Track all resources for form-based switching
 		TRB.Data.resourceEnergy = Enum.PowerType.Energy
@@ -3841,7 +3841,6 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.resourceFactor = ENERGY_RESOURCE_FACTOR
 		TRB.Data.resource2 = Enum.PowerType.ComboPoints
 		TRB.Data.resource2Factor = 1
-		TRB.Data.additionalPowerTokens = nil
 		primaryResourceToken = "ENERGY"
 		-- Track all resources for form-based switching
 		TRB.Data.resourceRage = Enum.PowerType.Rage
@@ -3853,7 +3852,6 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.resourceFactor = RAGE_RESOURCE_FACTOR
 		TRB.Data.resource2 = nil
 		TRB.Data.resource2Factor = nil
-		TRB.Data.additionalPowerTokens = nil
 		primaryResourceToken = "RAGE"
 		-- Track all resources for form-based switching
 		TRB.Data.resourceEnergy = Enum.PowerType.Energy
@@ -3867,7 +3865,6 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.resourceFactor = MANA_RESOURCE_FACTOR
 		TRB.Data.resource2 = nil
 		TRB.Data.resource2Factor = nil
-		TRB.Data.additionalPowerTokens = nil
 		primaryResourceToken = "MANA"
 		-- Track all resources for form-based switching
 		TRB.Data.resourceEnergy = Enum.PowerType.Energy
@@ -3876,7 +3873,6 @@ function TRB.Functions.Class:EventRegistration()
 		TRB.Data.resourceComboPoints = Enum.PowerType.ComboPoints
 	else
 		TRB.Data.specSupported = false
-		TRB.Data.additionalPowerTokens = nil
 	end
 
 	Character:EventRegistration()

--- a/ClassModules/Evoker.lua
+++ b/ClassModules/Evoker.lua
@@ -1179,9 +1179,6 @@ local function UpdateResourceBar()
 			manaBarColors.background = barBackgroundColor
 			local essenceColors = scratch.essenceColors1
 			wipe(essenceColors)
-			essenceColors.bar = nil
-			essenceColors.border = nil
-			essenceColors.background = nil
 			local barColorMap = scratch.barColorMap1
 			wipe(barColorMap)
 			barColorMap.manaBar = manaBarColors
@@ -1247,9 +1244,6 @@ local function UpdateResourceBar()
 			manaBarColors.background = barBackgroundColor
 			local essenceColors = scratch.essenceColors2
 			wipe(essenceColors)
-			essenceColors.bar = nil
-			essenceColors.border = nil
-			essenceColors.background = nil
 			local barColorMap = scratch.barColorMap2
 			wipe(barColorMap)
 			barColorMap.manaBar = manaBarColors
@@ -1321,9 +1315,6 @@ local function UpdateResourceBar()
 			manaBarColors.background = barBackgroundColor
 			local essenceColors = scratch.essenceColors3
 			wipe(essenceColors)
-			essenceColors.bar = nil
-			essenceColors.border = nil
-			essenceColors.background = nil
 			local ebonMightColors = scratch.ebonMightColors1
 			wipe(ebonMightColors)
 			ebonMightColors.bar = ebonMightBarColor

--- a/ClassModules/Evoker.lua
+++ b/ClassModules/Evoker.lua
@@ -1081,6 +1081,25 @@ local function UpdateEssence(specSettings, specCacheSettings, essenceOverrides)
 	end
 end
 
+
+-- Reused per-tick scratch tables for UpdateResourceBar (see conditionMap/barColorMap sites).
+-- Held in one table so UpdateResourceBar gains a single upvalue rather than one per site.
+local scratch = {
+	conditionMap1 = {},
+	manaBarColors1 = {},
+	essenceColors1 = {},
+	barColorMap1 = {},
+	conditionMap2 = {},
+	manaBarColors2 = {},
+	essenceColors2 = {},
+	barColorMap2 = {},
+	conditionMap3 = {},
+	manaBarColors3 = {},
+	essenceColors3 = {},
+	ebonMightColors1 = {},
+	barColorMap3 = {},
+}
+
 local function UpdateResourceBar()
 	local currentTime = GetTime()
 	local refreshText = false
@@ -1146,16 +1165,27 @@ local function UpdateResourceBar()
 				dragonrageEndMet = dragonrageTimeLeft <= timeThreshold
 			end
 
-			local conditionMap = {
-				dragonrageEnd = dragonrageActive and dragonrageEndMet,
-				dragonrage = dragonrageActive,
-				essenceBurst = snapshots[spells.essenceBurst.id].buff.isActive,
-			}
+			local conditionMap = scratch.conditionMap1
+			wipe(conditionMap)
+			conditionMap.dragonrageEnd = dragonrageActive and dragonrageEndMet
+			conditionMap.dragonrage = dragonrageActive
+			conditionMap.essenceBurst = snapshots[spells.essenceBurst.id].buff.isActive
 
 			-- Color targets: barKey -> elementKey -> current color
-			local manaBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
-			local essenceColors = { bar = nil, border = nil, background = nil }
-			local barColorMap = { manaBar = manaBarColors, essences = essenceColors }
+			local manaBarColors = scratch.manaBarColors1
+			wipe(manaBarColors)
+			manaBarColors.bar = barColor
+			manaBarColors.border = barBorderColor
+			manaBarColors.background = barBackgroundColor
+			local essenceColors = scratch.essenceColors1
+			wipe(essenceColors)
+			essenceColors.bar = nil
+			essenceColors.border = nil
+			essenceColors.background = nil
+			local barColorMap = scratch.barColorMap1
+			wipe(barColorMap)
+			barColorMap.manaBar = manaBarColors
+			barColorMap.essences = essenceColors
 
 			-- Apply flat indicator colors (priority order, last writer wins)
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
@@ -1204,15 +1234,26 @@ local function UpdateResourceBar()
 			local sharedColors = specSettings.colors.shared
 			local indicatorColors = sharedColors and sharedColors.indicatorColors
 
-			local conditionMap = {
-				innervate = false,
-				essenceBurst = snapshots[spells.essenceBurst.id].buff.isActive,
-			}
+			local conditionMap = scratch.conditionMap2
+			wipe(conditionMap)
+			conditionMap.innervate = false
+			conditionMap.essenceBurst = snapshots[spells.essenceBurst.id].buff.isActive
 
 			-- Color targets: barKey -> elementKey -> current color
-			local manaBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
-			local essenceColors = { bar = nil, border = nil, background = nil }
-			local barColorMap = { manaBar = manaBarColors, essences = essenceColors }
+			local manaBarColors = scratch.manaBarColors2
+			wipe(manaBarColors)
+			manaBarColors.bar = barColor
+			manaBarColors.border = barBorderColor
+			manaBarColors.background = barBackgroundColor
+			local essenceColors = scratch.essenceColors2
+			wipe(essenceColors)
+			essenceColors.bar = nil
+			essenceColors.border = nil
+			essenceColors.background = nil
+			local barColorMap = scratch.barColorMap2
+			wipe(barColorMap)
+			barColorMap.manaBar = manaBarColors
+			barColorMap.essences = essenceColors
 
 			-- Apply flat indicator colors (priority order, last writer wins)
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
@@ -1267,16 +1308,32 @@ local function UpdateResourceBar()
 			local ebonMightTrackedId = snapshotData.attributes.ebonMightTrackedId
 			local ebonMightActive = snapshotData.attributes.ebonMightActive == true
 
-			local conditionMap = {
-				ebonMight = ebonMightActive,
-				essenceBurst = snapshots[spells.essenceBurst.id].buff.isActive,
-			}
+			local conditionMap = scratch.conditionMap3
+			wipe(conditionMap)
+			conditionMap.ebonMight = ebonMightActive
+			conditionMap.essenceBurst = snapshots[spells.essenceBurst.id].buff.isActive
 
 			-- Color targets: barKey -> elementKey -> current color
-			local manaBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
-			local essenceColors = { bar = nil, border = nil, background = nil }
-			local ebonMightColors = { bar = ebonMightBarColor, border = ebonMightBorderColor, background = ebonMightBackgroundColor }
-			local barColorMap = { manaBar = manaBarColors, essences = essenceColors, ebonMight = ebonMightColors }
+			local manaBarColors = scratch.manaBarColors3
+			wipe(manaBarColors)
+			manaBarColors.bar = barColor
+			manaBarColors.border = barBorderColor
+			manaBarColors.background = barBackgroundColor
+			local essenceColors = scratch.essenceColors3
+			wipe(essenceColors)
+			essenceColors.bar = nil
+			essenceColors.border = nil
+			essenceColors.background = nil
+			local ebonMightColors = scratch.ebonMightColors1
+			wipe(ebonMightColors)
+			ebonMightColors.bar = ebonMightBarColor
+			ebonMightColors.border = ebonMightBorderColor
+			ebonMightColors.background = ebonMightBackgroundColor
+			local barColorMap = scratch.barColorMap3
+			wipe(barColorMap)
+			barColorMap.manaBar = manaBarColors
+			barColorMap.essences = essenceColors
+			barColorMap.ebonMight = ebonMightColors
 
 			-- Apply flat indicator colors (priority order, last writer wins)
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)

--- a/ClassModules/Hunter.lua
+++ b/ClassModules/Hunter.lua
@@ -814,6 +814,27 @@ local function UpdateSnapshot_Survival()
 	snapshots[spells.tipOfTheSpear.id].buff:GetRemainingTime(currentTime)
 end
 
+
+-- Reused per-tick scratch tables for UpdateResourceBar (see conditionMap/barColorMap sites).
+-- Held in one table so UpdateResourceBar gains a single upvalue rather than one per site.
+local scratch = {
+	conditionMap1 = {},
+	focusBarColors1 = {},
+	barColorMap1 = {},
+	overcapCurves1 = {},
+	conditionMap2 = {},
+	focusBarColors2 = {},
+	barColorMap2 = {},
+	overcapCurves2 = {},
+	conditionMap3 = {},
+	focusBarColors3 = {},
+	tipOfTheSpearBarColors1 = {},
+	tipOfTheSpearOverrides1 = {},
+	barColorMap3 = {},
+	focusOvercapCurves1 = {},
+	tipOfTheSpearOvercapCurves1 = {},
+}
+
 local function UpdateResourceBar()
 	local currentTime = GetTime()
 	local refreshText = false
@@ -863,19 +884,25 @@ local function UpdateResourceBar()
 			local sharedColors = specSettings.colors.shared
 			local indicatorColors = sharedColors and sharedColors.indicatorColors
 			local gradientOrder = sharedColors and sharedColors.gradientOrder
-			local conditionMap = {
-				bestialWrath = snapshots[spells.bestialWrath.id].buff.isActive and affectingCombat,
-				bestialWrathEnd = snapshots[spells.bestialWrath.id].buff.isActive and affectingCombat
+			local conditionMap = scratch.conditionMap1
+			wipe(conditionMap)
+			conditionMap.bestialWrath = snapshots[spells.bestialWrath.id].buff.isActive and affectingCombat
+			conditionMap.bestialWrathEnd = snapshots[spells.bestialWrath.id].buff.isActive and affectingCombat
 					and specSettings.endOf.bestialWrath.enabled
 					and (snapshots[spells.bestialWrath.id].buff:GetRemainingTime(currentTime) <=
 						(specSettings.endOf.bestialWrath.mode == "gcd"
 							and Character:GetCurrentGCDTime() * specSettings.endOf.bestialWrath.gcdsMax
-							or specSettings.endOf.bestialWrath.timeMax)),
-				beastCleave = snapshots[spells.beastCleave.id].buff.isActive,
-				borderOvercap = affectingCombat,
-			}
-			local focusBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
-			local barColorMap = { focusBar = focusBarColors }
+							or specSettings.endOf.bestialWrath.timeMax))
+			conditionMap.beastCleave = snapshots[spells.beastCleave.id].buff.isActive
+			conditionMap.borderOvercap = affectingCombat
+			local focusBarColors = scratch.focusBarColors1
+			wipe(focusBarColors)
+			focusBarColors.bar = barColor
+			focusBarColors.border = barBorderColor
+			focusBarColors.background = barBackgroundColor
+			local barColorMap = scratch.barColorMap1
+			wipe(barColorMap)
+			barColorMap.focusBar = focusBarColors
 
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
 
@@ -993,7 +1020,8 @@ local function UpdateResourceBar()
 					end
 				end
 
-				local overcapCurves = {}
+				local overcapCurves = scratch.overcapCurves1
+				wipe(overcapCurves)
 				if gradientOrder and indicatorColors then
 					for i = #gradientOrder, 1, -1 do
 						local key = gradientOrder[i]
@@ -1072,18 +1100,24 @@ local function UpdateResourceBar()
 			local sharedColors = specSettings.colors.shared
 			local indicatorColors = sharedColors and sharedColors.indicatorColors
 			local gradientOrder = sharedColors and sharedColors.gradientOrder
-			local conditionMap = {
-				trueshot = snapshots[spells.trueshot.id].buff.isActive,
-				trueshotEnd = snapshots[spells.trueshot.id].buff.isActive
+			local conditionMap = scratch.conditionMap2
+			wipe(conditionMap)
+			conditionMap.trueshot = snapshots[spells.trueshot.id].buff.isActive
+			conditionMap.trueshotEnd = snapshots[spells.trueshot.id].buff.isActive
 					and specSettings.endOf.trueshot.enabled
 					and (snapshots[spells.trueshot.id].buff:GetRemainingTime(currentTime) <=
 						(specSettings.endOf.trueshot.mode == "gcd"
 							and Character:GetCurrentGCDTime() * specSettings.endOf.trueshot.gcdsMax
-							or specSettings.endOf.trueshot.timeMax)),
-				borderOvercap = affectingCombat,
-			}
-			local focusBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
-			local barColorMap = { focusBar = focusBarColors }
+							or specSettings.endOf.trueshot.timeMax))
+			conditionMap.borderOvercap = affectingCombat
+			local focusBarColors = scratch.focusBarColors2
+			wipe(focusBarColors)
+			focusBarColors.bar = barColor
+			focusBarColors.border = barBorderColor
+			focusBarColors.background = barBackgroundColor
+			local barColorMap = scratch.barColorMap2
+			wipe(barColorMap)
+			barColorMap.focusBar = focusBarColors
 
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
 
@@ -1217,7 +1251,8 @@ local function UpdateResourceBar()
 					end
 				end
 
-				local overcapCurves = {}
+				local overcapCurves = scratch.overcapCurves2
+				wipe(overcapCurves)
 				if gradientOrder and indicatorColors then
 					for i = #gradientOrder, 1, -1 do
 						local key = gradientOrder[i]
@@ -1280,31 +1315,35 @@ local function UpdateResourceBar()
 			local sharedColors = specSettings.colors.shared
 			local indicatorColors = sharedColors and sharedColors.indicatorColors
 			local gradientOrder = sharedColors and sharedColors.gradientOrder
-			local conditionMap = {
-				takedown = snapshots[spells.takedown.id].buff.isActive,
-				takedownEnd = snapshots[spells.takedown.id].buff.isActive
+			local conditionMap = scratch.conditionMap3
+			wipe(conditionMap)
+			conditionMap.takedown = snapshots[spells.takedown.id].buff.isActive
+			conditionMap.takedownEnd = snapshots[spells.takedown.id].buff.isActive
 					and specSettings.endOf.takedown.enabled
 					and (snapshots[spells.takedown.id].buff:GetRemainingTime(currentTime) <=
 						(specSettings.endOf.takedown.mode == "gcd"
 							and Character:GetCurrentGCDTime() * specSettings.endOf.takedown.gcdsMax
-							or specSettings.endOf.takedown.timeMax)),
-				borderOvercap = affectingCombat,
-			}
-			local focusBarColors = {
-				bar = specSettings.colors.bar.base,
-				border = specSettings.colors.bar.border.color,
-				background = specSettings.colors.bar.background.color,
-			}
-			local tipOfTheSpearBarColors = {
-				bar = specSettings.colors.comboPoints.base,
-				border = specSettings.colors.comboPoints.border.color,
-				background = specSettings.colors.comboPoints.background.color,
-			}
-			local tipOfTheSpearOverrides = { bar = false, border = false, background = false }
-			local barColorMap = {
-				focusBar = focusBarColors,
-				tipOfTheSpearBar = tipOfTheSpearBarColors,
-			}
+							or specSettings.endOf.takedown.timeMax))
+			conditionMap.borderOvercap = affectingCombat
+			local focusBarColors = scratch.focusBarColors3
+			wipe(focusBarColors)
+			focusBarColors.bar = specSettings.colors.bar.base
+			focusBarColors.border = specSettings.colors.bar.border.color
+			focusBarColors.background = specSettings.colors.bar.background.color
+			local tipOfTheSpearBarColors = scratch.tipOfTheSpearBarColors1
+			wipe(tipOfTheSpearBarColors)
+			tipOfTheSpearBarColors.bar = specSettings.colors.comboPoints.base
+			tipOfTheSpearBarColors.border = specSettings.colors.comboPoints.border.color
+			tipOfTheSpearBarColors.background = specSettings.colors.comboPoints.background.color
+			local tipOfTheSpearOverrides = scratch.tipOfTheSpearOverrides1
+			wipe(tipOfTheSpearOverrides)
+			tipOfTheSpearOverrides.bar = false
+			tipOfTheSpearOverrides.border = false
+			tipOfTheSpearOverrides.background = false
+			local barColorMap = scratch.barColorMap3
+			wipe(barColorMap)
+			barColorMap.focusBar = focusBarColors
+			barColorMap.tipOfTheSpearBar = tipOfTheSpearBarColors
 
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap,
 				{ tipOfTheSpearBar = tipOfTheSpearOverrides })
@@ -1321,8 +1360,10 @@ local function UpdateResourceBar()
 				end
 			end
 
-			local focusOvercapCurves = {}
-			local tipOfTheSpearOvercapCurves = {}
+			local focusOvercapCurves = scratch.focusOvercapCurves1
+			wipe(focusOvercapCurves)
+			local tipOfTheSpearOvercapCurves = scratch.tipOfTheSpearOvercapCurves1
+			wipe(tipOfTheSpearOvercapCurves)
 			if overcapIndicator and overcapIndicator.targets then
 				local focusTargets = overcapIndicator.targets.focusBar
 				if focusTargets then

--- a/ClassModules/Hunter.lua
+++ b/ClassModules/Hunter.lua
@@ -934,8 +934,16 @@ local function UpdateResourceBar()
 						thresholds = primaryNode:GetThresholds()
 					end
 					pairOffset = (thresholdId - 1) * 3
-					local resourceAmount = spell:GetPrimaryResourceCost()
-					local isUsable = spell:IsUsable()
+					-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+					-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+					local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+					local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+						or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+					local resourceAmount, isUsable = 0, false
+					if thresholdActive then
+						resourceAmount = spell:GetPrimaryResourceCost()
+						isUsable = spell:IsUsable()
+					end
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
 					local frameLevel = frameLevels.thresholdOver
@@ -1150,8 +1158,16 @@ local function UpdateResourceBar()
 						thresholds = primaryNode:GetThresholds()
 					end
 					pairOffset = (thresholdId - 1) * 3
-					local resourceAmount = spell:GetPrimaryResourceCost()
-					local isUsable = spell:IsUsable()
+					-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+					-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+					local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+					local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+						or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+					local resourceAmount, isUsable = 0, false
+					if thresholdActive then
+						resourceAmount = spell:GetPrimaryResourceCost()
+						isUsable = spell:IsUsable()
+					end
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
 					local frameLevel = frameLevels.thresholdOver
@@ -1422,8 +1438,16 @@ local function UpdateResourceBar()
 						thresholds = primaryNode:GetThresholds()
 					end
 					pairOffset = (thresholdId - 1) * 3
-					local resourceAmount = spell:GetPrimaryResourceCost()
-					local isUsable = spell:IsUsable()
+					-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+					-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+					local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+					local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+						or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+					local resourceAmount, isUsable = 0, false
+					if thresholdActive then
+						resourceAmount = spell:GetPrimaryResourceCost()
+						isUsable = spell:IsUsable()
+					end
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
 					local frameLevel = frameLevels.thresholdOver

--- a/ClassModules/Hunter.lua
+++ b/ClassModules/Hunter.lua
@@ -830,6 +830,7 @@ local scratch = {
 	focusBarColors3 = {},
 	tipOfTheSpearBarColors1 = {},
 	tipOfTheSpearOverrides1 = {},
+	indicatorTargets1 = {},
 	barColorMap3 = {},
 	focusOvercapCurves1 = {},
 	tipOfTheSpearOvercapCurves1 = {},
@@ -1335,18 +1336,18 @@ local function UpdateResourceBar()
 			tipOfTheSpearBarColors.bar = specSettings.colors.comboPoints.base
 			tipOfTheSpearBarColors.border = specSettings.colors.comboPoints.border.color
 			tipOfTheSpearBarColors.background = specSettings.colors.comboPoints.background.color
+			-- Wiped, not reset to false: ApplyIndicatorColors only writes true and readers test truthiness.
 			local tipOfTheSpearOverrides = scratch.tipOfTheSpearOverrides1
 			wipe(tipOfTheSpearOverrides)
-			tipOfTheSpearOverrides.bar = false
-			tipOfTheSpearOverrides.border = false
-			tipOfTheSpearOverrides.background = false
 			local barColorMap = scratch.barColorMap3
 			wipe(barColorMap)
 			barColorMap.focusBar = focusBarColors
 			barColorMap.tipOfTheSpearBar = tipOfTheSpearBarColors
 
-			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap,
-				{ tipOfTheSpearBar = tipOfTheSpearOverrides })
+			local indicatorTargets = scratch.indicatorTargets1
+			wipe(indicatorTargets)
+			indicatorTargets.tipOfTheSpearBar = tipOfTheSpearOverrides
+			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap, indicatorTargets)
 
 			local overcapIndicator = nil
 			if gradientOrder and indicatorColors then

--- a/ClassModules/Mage.lua
+++ b/ClassModules/Mage.lua
@@ -955,6 +955,16 @@ local function UpdateShatter(specSettings, specCacheSettings, barColors, fillInd
 	end
 end
 
+
+-- Reused per-tick scratch tables for UpdateResourceBar (see conditionMap/barColorMap sites).
+-- Held in one table so UpdateResourceBar gains a single upvalue rather than one per site.
+local scratch = {
+	conditionMap1 = {},
+	manaBarColors1 = {},
+	iciclesBarColors1 = {},
+	indicatorTargets1 = {},
+}
+
 local function UpdateResourceBar()
 	local refreshText = false
 	local classSettings = TRB.Data.settings.mage
@@ -1130,33 +1140,33 @@ local function UpdateResourceBar()
 			local sharedColors = specSettings.colors.shared
 			local fingersOfFrostBuff = snapshots[spells.fingersOfFrost.id].buff
 			local fingersOfFrostCharges = fingersOfFrostBuff.isActive and (fingersOfFrostBuff.applications or 0) or 0
-			local conditionMap = {
-				fingersOfFrost = fingersOfFrostCharges >= 1,
-				fingersOfFrost2 = fingersOfFrostCharges >= 2,
-				brainFreeze = snapshots[spells.brainFreeze.id].buff.isActive,
-			}
+			local conditionMap = scratch.conditionMap1
+			wipe(conditionMap)
+			conditionMap.fingersOfFrost = fingersOfFrostCharges >= 1
+			conditionMap.fingersOfFrost2 = fingersOfFrostCharges >= 2
+			conditionMap.brainFreeze = snapshots[spells.brainFreeze.id].buff.isActive
 
-			local manaBarColors = {
-				bar = specSettings.colors.bar.base,
-				border = specSettings.colors.bar.border.color,
-				background = specSettings.colors.bar.background.color,
-			}
-			local iciclesBarColors = {
-				bar = specSettings.colors.comboPoints.base,
-				border = specSettings.colors.comboPoints.border.color,
-				background = specSettings.colors.comboPoints.background.color,
-			}
+			local manaBarColors = scratch.manaBarColors1
+			wipe(manaBarColors)
+			manaBarColors.bar = specSettings.colors.bar.base
+			manaBarColors.border = specSettings.colors.bar.border.color
+			manaBarColors.background = specSettings.colors.bar.background.color
+			local iciclesBarColors = scratch.iciclesBarColors1
+			wipe(iciclesBarColors)
+			iciclesBarColors.bar = specSettings.colors.comboPoints.base
+			iciclesBarColors.border = specSettings.colors.comboPoints.border.color
+			iciclesBarColors.background = specSettings.colors.comboPoints.background.color
 			local shatterColors = specSettings.colors.bars and specSettings.colors.bars.shatter
 			local shatterBarColors = shatterColors and {
 				bar = shatterColors.bar,
 				border = shatterColors.border.color,
 				background = shatterColors.background.color,
 			} or nil
-			local indicatorTargets = {
-				manaBar = { bar = false, border = false, background = false },
-				iciclesBar = { bar = false, border = false, background = false },
-				shatterBar = { bar = false, border = false, background = false },
-			}
+			local indicatorTargets = scratch.indicatorTargets1
+			wipe(indicatorTargets)
+			indicatorTargets.manaBar = { bar = false, border = false, background = false }
+			indicatorTargets.iciclesBar = { bar = false, border = false, background = false }
+			indicatorTargets.shatterBar = { bar = false, border = false, background = false }
 
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, {
 				manaBar = manaBarColors,

--- a/ClassModules/Mage.lua
+++ b/ClassModules/Mage.lua
@@ -962,7 +962,12 @@ local scratch = {
 	conditionMap1 = {},
 	manaBarColors1 = {},
 	iciclesBarColors1 = {},
+	shatterBarColors1 = {},
+	manaBarTargets1 = {},
+	iciclesBarTargets1 = {},
+	shatterBarTargets1 = {},
 	indicatorTargets1 = {},
+	barColorMap1 = {},
 }
 
 local function UpdateResourceBar()
@@ -1157,22 +1162,35 @@ local function UpdateResourceBar()
 			iciclesBarColors.border = specSettings.colors.comboPoints.border.color
 			iciclesBarColors.background = specSettings.colors.comboPoints.background.color
 			local shatterColors = specSettings.colors.bars and specSettings.colors.bars.shatter
-			local shatterBarColors = shatterColors and {
-				bar = shatterColors.bar,
-				border = shatterColors.border.color,
-				background = shatterColors.background.color,
-			} or nil
+			local shatterBarColors = nil
+			if shatterColors then
+				shatterBarColors = scratch.shatterBarColors1
+				wipe(shatterBarColors)
+				shatterBarColors.bar = shatterColors.bar
+				shatterBarColors.border = shatterColors.border.color
+				shatterBarColors.background = shatterColors.background.color
+			end
+			-- Wiped rather than reset to false: ApplyIndicatorColors only ever writes true, and every
+			-- reader tests truthiness.
+			local manaBarTargets = scratch.manaBarTargets1
+			wipe(manaBarTargets)
+			local iciclesBarTargets = scratch.iciclesBarTargets1
+			wipe(iciclesBarTargets)
+			local shatterBarTargets = scratch.shatterBarTargets1
+			wipe(shatterBarTargets)
 			local indicatorTargets = scratch.indicatorTargets1
 			wipe(indicatorTargets)
-			indicatorTargets.manaBar = { bar = false, border = false, background = false }
-			indicatorTargets.iciclesBar = { bar = false, border = false, background = false }
-			indicatorTargets.shatterBar = { bar = false, border = false, background = false }
+			indicatorTargets.manaBar = manaBarTargets
+			indicatorTargets.iciclesBar = iciclesBarTargets
+			indicatorTargets.shatterBar = shatterBarTargets
 
-			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, {
-				manaBar = manaBarColors,
-				iciclesBar = iciclesBarColors,
-				shatterBar = shatterBarColors,
-			}, indicatorTargets)
+			local barColorMap = scratch.barColorMap1
+			wipe(barColorMap)
+			barColorMap.manaBar = manaBarColors
+			barColorMap.iciclesBar = iciclesBarColors
+			barColorMap.shatterBar = shatterBarColors
+
+			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap, indicatorTargets)
 
 			if not specSettings.displayBar.primary.neverShow then
 				refreshText = true
@@ -1224,6 +1242,7 @@ local function UpdateResourceBar()
 
 			if specSettings.displayBar.shatter and not specSettings.displayBar.shatter.neverShow then
 				refreshText = true
+				---@diagnostic disable-next-line: param-type-mismatch
 				UpdateShatter(specSettings, specCacheSettings, shatterBarColors, indicatorTargets.shatterBar.bar)
 			end
 

--- a/ClassModules/Monk.lua
+++ b/ClassModules/Monk.lua
@@ -980,6 +980,7 @@ local scratch = {
 	energyBarColors2 = {},
 	chiBarColors1 = {},
 	chiBarOverrides1 = {},
+	indicatorTargets1 = {},
 	barColorMap3 = {},
 	energyOvercapCurves2 = {},
 	chiOvercapCurves1 = {},
@@ -1455,18 +1456,18 @@ local function UpdateResourceBar()
 		chiBarColors.bar = specSettings.colors.comboPoints.base
 		chiBarColors.border = specSettings.colors.comboPoints.border.color
 		chiBarColors.background = specSettings.colors.comboPoints.background.color
+		-- Wiped, not reset to false: ApplyIndicatorColors only writes true and readers test truthiness.
 		local chiBarOverrides = scratch.chiBarOverrides1
 		wipe(chiBarOverrides)
-		chiBarOverrides.bar = false
-		chiBarOverrides.border = false
-		chiBarOverrides.background = false
 		local barColorMap = scratch.barColorMap3
 		wipe(barColorMap)
 		barColorMap.energyBar = energyBarColors
 		barColorMap.chiBar = chiBarColors
 
-		TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap,
-			{ chiBar = chiBarOverrides })
+		local indicatorTargets = scratch.indicatorTargets1
+		wipe(indicatorTargets)
+		indicatorTargets.chiBar = chiBarOverrides
+		TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap, indicatorTargets)
 
 		local overcapIndicator = nil
 		if gradientOrder and indicatorColors then

--- a/ClassModules/Monk.lua
+++ b/ClassModules/Monk.lua
@@ -962,6 +962,29 @@ local function UpdateSnapshot_Windwalker()
 	snapshots[spells.heartOfTheJadeSerpent.id].buff:GetRemainingTime(currentTime)
 end
 
+
+-- Reused per-tick scratch tables for UpdateResourceBar (see conditionMap/barColorMap sites).
+-- Held in one table so UpdateResourceBar gains a single upvalue rather than one per site.
+local scratch = {
+	conditionMap1 = {},
+	energyBarColors1 = {},
+	barColorMap1 = {},
+	energyOvercapCurves1 = {},
+	stConditionMap1 = {},
+	stOvercapCurves1 = {},
+	stGradientConditionMap1 = {},
+	conditionMap2 = {},
+	manaBarColors1 = {},
+	barColorMap2 = {},
+	conditionMap3 = {},
+	energyBarColors2 = {},
+	chiBarColors1 = {},
+	chiBarOverrides1 = {},
+	barColorMap3 = {},
+	energyOvercapCurves2 = {},
+	chiOvercapCurves1 = {},
+}
+
 local function UpdateResourceBar()
 	local currentTime = GetTime()
 	local refreshText = false
@@ -1017,14 +1040,21 @@ local function UpdateResourceBar()
 				invokeNiuzaoEndMet = niuzaoTimeLeft <= timeThreshold
 			end
 
-			local conditionMap = {
-				invokeNiuzaoEnd = invokeNiuzaoActive and invokeNiuzaoEndMet,
-				invokeNiuzao = invokeNiuzaoActive,
-				borderOvercap = affectingCombat,
-			}
-			local energyBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
+			local conditionMap = scratch.conditionMap1
+			wipe(conditionMap)
+			conditionMap.invokeNiuzaoEnd = invokeNiuzaoActive and invokeNiuzaoEndMet
+			conditionMap.invokeNiuzao = invokeNiuzaoActive
+			conditionMap.borderOvercap = affectingCombat
+			local energyBarColors = scratch.energyBarColors1
+			wipe(energyBarColors)
+			energyBarColors.bar = barColor
+			energyBarColors.border = barBorderColor
+			energyBarColors.background = barBackgroundColor
 			-- Stagger border/background are colored bespoke below; this entry routes flat indicator end cap colors
-			local barColorMap = { energyBar = energyBarColors, staggerBar = {} }
+			local barColorMap = scratch.barColorMap1
+			wipe(barColorMap)
+			barColorMap.energyBar = energyBarColors
+			barColorMap.staggerBar = {}
 
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
 
@@ -1124,7 +1154,8 @@ local function UpdateResourceBar()
 					barBorderColor = energyBarColors.border
 					barBackgroundColor = energyBarColors.background
 
-					local energyOvercapCurves = {}
+					local energyOvercapCurves = scratch.energyOvercapCurves1
+					wipe(energyOvercapCurves)
 					if overcapIndicator and overcapIndicator.targets then
 						local energyTargets = overcapIndicator.targets.energyBar
 						if energyTargets then
@@ -1226,10 +1257,10 @@ local function UpdateResourceBar()
 								invokeNiuzaoEndMet = niuzaoTimeLeft <= timeThreshold
 							end
 
-							local stConditionMap = {
-								invokeNiuzaoEnd = invokeNiuzaoActive and invokeNiuzaoEndMet,
-								invokeNiuzao = invokeNiuzaoActive,
-							}
+							local stConditionMap = scratch.stConditionMap1
+							wipe(stConditionMap)
+							stConditionMap.invokeNiuzaoEnd = invokeNiuzaoActive and invokeNiuzaoEndMet
+							stConditionMap.invokeNiuzao = invokeNiuzaoActive
 
 							for i = #stNodeOrder, 1, -1 do
 								local key = stNodeOrder[i]
@@ -1245,13 +1276,14 @@ local function UpdateResourceBar()
 						end
 
 						-- Build gradient curves for stagger targets (border/background only, uses energy scale)
-						local stOvercapCurves = {}
+						local stOvercapCurves = scratch.stOvercapCurves1
+						wipe(stOvercapCurves)
 						local stGradientOrder = stSharedColors and stSharedColors.gradientOrder
 						local stAffectingCombat = TRB.Data.character.inCombat
 						if stGradientOrder and stIndicatorColors then
-							local stGradientConditionMap = {
-								borderOvercap = stAffectingCombat,
-							}
+							local stGradientConditionMap = scratch.stGradientConditionMap1
+							wipe(stGradientConditionMap)
+							stGradientConditionMap.borderOvercap = stAffectingCombat
 							for i = #stGradientOrder, 1, -1 do
 								local key = stGradientOrder[i]
 								local indicator = stIndicatorColors[key]
@@ -1353,13 +1385,19 @@ local function UpdateResourceBar()
 			local barBackgroundColor = specSettings.colors.bar.background.color
 			local sharedColors = specSettings.colors.shared
 			local indicatorColors = sharedColors and sharedColors.indicatorColors
-			local conditionMap = {
-				vivaciousVivification = affectingCombat and (snapshots[spells.vivaciousVivification.id].buff.isActive or snapshots[spells.sereneSurge.id].buff.isActive),
-				heartOfTheJadeSerpent = false,
-				heartOfTheJadeSerpentReady = false,
-			}
-			local manaBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
-			local barColorMap = { manaBar = manaBarColors }
+			local conditionMap = scratch.conditionMap2
+			wipe(conditionMap)
+			conditionMap.vivaciousVivification = affectingCombat and (snapshots[spells.vivaciousVivification.id].buff.isActive or snapshots[spells.sereneSurge.id].buff.isActive)
+			conditionMap.heartOfTheJadeSerpent = false
+			conditionMap.heartOfTheJadeSerpentReady = false
+			local manaBarColors = scratch.manaBarColors1
+			wipe(manaBarColors)
+			manaBarColors.bar = barColor
+			manaBarColors.border = barBorderColor
+			manaBarColors.background = barBackgroundColor
+			local barColorMap = scratch.barColorMap2
+			wipe(barColorMap)
+			barColorMap.manaBar = manaBarColors
 
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
 
@@ -1401,27 +1439,31 @@ local function UpdateResourceBar()
 		local sharedColors = specSettings.colors.shared
 		local indicatorColors = sharedColors and sharedColors.indicatorColors
 		local gradientOrder = sharedColors and sharedColors.gradientOrder
-		local conditionMap = {
-			heartOfTheJadeSerpentReady = heartOfTheJadeSerpentReady,
-			heartOfTheJadeSerpent = heartOfTheJadeSerpentActive,
-			danceOfChiJi = danceOfChiJiActive,
-			borderOvercap = affectingCombat,
-		}
-		local energyBarColors = {
-			bar = specSettings.colors.bar.base,
-			border = specSettings.colors.bar.border.color,
-			background = specSettings.colors.bar.background.color,
-		}
-		local chiBarColors = {
-			bar = specSettings.colors.comboPoints.base,
-			border = specSettings.colors.comboPoints.border.color,
-			background = specSettings.colors.comboPoints.background.color,
-		}
-		local chiBarOverrides = { bar = false, border = false, background = false }
-		local barColorMap = {
-			energyBar = energyBarColors,
-			chiBar = chiBarColors,
-		}
+		local conditionMap = scratch.conditionMap3
+		wipe(conditionMap)
+		conditionMap.heartOfTheJadeSerpentReady = heartOfTheJadeSerpentReady
+		conditionMap.heartOfTheJadeSerpent = heartOfTheJadeSerpentActive
+		conditionMap.danceOfChiJi = danceOfChiJiActive
+		conditionMap.borderOvercap = affectingCombat
+		local energyBarColors = scratch.energyBarColors2
+		wipe(energyBarColors)
+		energyBarColors.bar = specSettings.colors.bar.base
+		energyBarColors.border = specSettings.colors.bar.border.color
+		energyBarColors.background = specSettings.colors.bar.background.color
+		local chiBarColors = scratch.chiBarColors1
+		wipe(chiBarColors)
+		chiBarColors.bar = specSettings.colors.comboPoints.base
+		chiBarColors.border = specSettings.colors.comboPoints.border.color
+		chiBarColors.background = specSettings.colors.comboPoints.background.color
+		local chiBarOverrides = scratch.chiBarOverrides1
+		wipe(chiBarOverrides)
+		chiBarOverrides.bar = false
+		chiBarOverrides.border = false
+		chiBarOverrides.background = false
+		local barColorMap = scratch.barColorMap3
+		wipe(barColorMap)
+		barColorMap.energyBar = energyBarColors
+		barColorMap.chiBar = chiBarColors
 
 		TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap,
 			{ chiBar = chiBarOverrides })
@@ -1438,8 +1480,10 @@ local function UpdateResourceBar()
 			end
 		end
 
-		local energyOvercapCurves = {}
-		local chiOvercapCurves = {}
+		local energyOvercapCurves = scratch.energyOvercapCurves2
+		wipe(energyOvercapCurves)
+		local chiOvercapCurves = scratch.chiOvercapCurves1
+		wipe(chiOvercapCurves)
 		if overcapIndicator and overcapIndicator.targets then
 			local energyTargets = overcapIndicator.targets.energyBar
 			if energyTargets then

--- a/ClassModules/Monk.lua
+++ b/ClassModules/Monk.lua
@@ -1085,8 +1085,16 @@ local function UpdateResourceBar()
 							thresholds = primaryNode:GetThresholds()
 						end
 						pairOffset = (thresholdId - 1) * 3
-						local resourceAmount = spell:GetPrimaryResourceCost()
-						local isUsable = spell:IsUsable()
+						-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+						-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+						local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+						local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+							or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+						local resourceAmount, isUsable = 0, false
+						if thresholdActive then
+							resourceAmount = spell:GetPrimaryResourceCost()
+							isUsable = spell:IsUsable()
+						end
 						local showThreshold = true
 						local thresholdColor = specCacheSettings.colors.threshold.over.color
 						local frameLevel = frameLevels.thresholdOver
@@ -1540,8 +1548,16 @@ local function UpdateResourceBar()
 							thresholds = primaryNode:GetThresholds()
 						end
 						pairOffset = (thresholdId - 1) * 3
-						local resourceAmount = spell:GetPrimaryResourceCost()
-						local isUsable = spell:IsUsable()
+						-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+						-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+						local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+						local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+							or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+						local resourceAmount, isUsable = 0, false
+						if thresholdActive then
+							resourceAmount = spell:GetPrimaryResourceCost()
+							isUsable = spell:IsUsable()
+						end
 						local showThreshold = true
 						local thresholdColor = specCacheSettings.colors.threshold.over.color
 						local frameLevel = frameLevels.thresholdOver

--- a/ClassModules/Paladin.lua
+++ b/ClassModules/Paladin.lua
@@ -728,6 +728,19 @@ function TRB.Functions.Class:DisableEvents()
 	spellEventFrame:UnregisterEvent("SPELL_ACTIVATION_OVERLAY_HIDE")
 end
 
+
+-- Reused per-tick scratch tables for UpdateResourceBar (see conditionMap/barColorMap sites).
+-- Held in one table so UpdateResourceBar gains a single upvalue rather than one per site.
+local scratch = {
+	overrides1 = {},
+	manaBarColors1 = {},
+	holyPowerColors1 = {},
+	manaBarColors2 = {},
+	holyPowerColors2 = {},
+	manaBarColors3 = {},
+	holyPowerColors3 = {},
+}
+
 local function UpdateResourceBar()
 	local refreshText = false
 	local classSettings = TRB.Data.settings.paladin
@@ -811,7 +824,8 @@ local function UpdateResourceBar()
 	local function ApplyFlatIndicatorColors(sharedColors, conditionMap, barColorMap)
 		-- barOverridden tells the render below to skip the resource-threshold fill curve: once an indicator
 		-- owns the fill, its flat color has to survive rather than being recomputed from the resource.
-		local overrides = {}
+		local overrides = scratch.overrides1
+		wipe(overrides)
 		for barKey in pairs(barColorMap) do
 			overrides[barKey] = {}
 		end
@@ -834,16 +848,16 @@ local function UpdateResourceBar()
 		local infusionOfLightActive = spells.flashOfLight:IsInstant()
 		local divinePurposeBuff = snapshotData.snapshots[spells.divinePurpose.id]
 		local divinePurposeActive = divinePurposeBuff ~= nil and divinePurposeBuff.buff.isActive
-		local manaBarColors = {
-			bar = specSettings.colors.bar.base,
-			border = specSettings.colors.bar.border.color,
-			background = specSettings.colors.bar.background.color,
-		}
-		local holyPowerColors = {
-			bar = specSettings.colors.comboPoints.base,
-			border = specSettings.colors.comboPoints.border.color,
-			background = specSettings.colors.comboPoints.background.color,
-		}
+		local manaBarColors = scratch.manaBarColors1
+		wipe(manaBarColors)
+		manaBarColors.bar = specSettings.colors.bar.base
+		manaBarColors.border = specSettings.colors.bar.border.color
+		manaBarColors.background = specSettings.colors.bar.background.color
+		local holyPowerColors = scratch.holyPowerColors1
+		wipe(holyPowerColors)
+		holyPowerColors.bar = specSettings.colors.comboPoints.base
+		holyPowerColors.border = specSettings.colors.comboPoints.border.color
+		holyPowerColors.background = specSettings.colors.comboPoints.background.color
 		ApplyFlatIndicatorColors(specSettings.colors.shared, { infusionOfLight = infusionOfLightActive, divinePurpose = divinePurposeActive }, {
 			manaBar = manaBarColors,
 			holyPowerBar = holyPowerColors,
@@ -890,16 +904,16 @@ local function UpdateResourceBar()
 		local infusionOfLightActive = spells.flashOfLight:IsInstant()
 		local divinePurposeBuff = snapshotData.snapshots[spells.divinePurpose.id]
 		local divinePurposeActive = divinePurposeBuff ~= nil and divinePurposeBuff.buff.isActive
-		local manaBarColors = {
-			bar = specSettings.colors.bar.base,
-			border = specSettings.colors.bar.border.color,
-			background = specSettings.colors.bar.background.color,
-		}
-		local holyPowerColors = {
-			bar = specSettings.colors.comboPoints.base,
-			border = specSettings.colors.comboPoints.border.color,
-			background = specSettings.colors.comboPoints.background.color,
-		}
+		local manaBarColors = scratch.manaBarColors2
+		wipe(manaBarColors)
+		manaBarColors.bar = specSettings.colors.bar.base
+		manaBarColors.border = specSettings.colors.bar.border.color
+		manaBarColors.background = specSettings.colors.bar.background.color
+		local holyPowerColors = scratch.holyPowerColors2
+		wipe(holyPowerColors)
+		holyPowerColors.bar = specSettings.colors.comboPoints.base
+		holyPowerColors.border = specSettings.colors.comboPoints.border.color
+		holyPowerColors.background = specSettings.colors.comboPoints.background.color
 		ApplyFlatIndicatorColors(specSettings.colors.shared, { infusionOfLight = infusionOfLightActive, divinePurpose = divinePurposeActive }, {
 			manaBar = manaBarColors,
 			holyPowerBar = holyPowerColors,
@@ -942,16 +956,16 @@ local function UpdateResourceBar()
 		local spells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Paladin.RetributionSpells]]
 		local divinePurposeBuff = snapshotData.snapshots[spells.divinePurpose.id]
 		local divinePurposeActive = divinePurposeBuff ~= nil and divinePurposeBuff.buff.isActive
-		local manaBarColors = {
-			bar = specSettings.colors.bar.base,
-			border = specSettings.colors.bar.border.color,
-			background = specSettings.colors.bar.background.color,
-		}
-		local holyPowerColors = {
-			bar = specSettings.colors.comboPoints.base,
-			border = specSettings.colors.comboPoints.border.color,
-			background = specSettings.colors.comboPoints.background.color,
-		}
+		local manaBarColors = scratch.manaBarColors3
+		wipe(manaBarColors)
+		manaBarColors.bar = specSettings.colors.bar.base
+		manaBarColors.border = specSettings.colors.bar.border.color
+		manaBarColors.background = specSettings.colors.bar.background.color
+		local holyPowerColors = scratch.holyPowerColors3
+		wipe(holyPowerColors)
+		holyPowerColors.bar = specSettings.colors.comboPoints.base
+		holyPowerColors.border = specSettings.colors.comboPoints.border.color
+		holyPowerColors.background = specSettings.colors.comboPoints.background.color
 		ApplyFlatIndicatorColors(specSettings.colors.shared, { divinePurpose = divinePurposeActive }, {
 			manaBar = manaBarColors,
 			holyPowerBar = holyPowerColors,

--- a/ClassModules/Paladin.lua
+++ b/ClassModules/Paladin.lua
@@ -733,6 +733,7 @@ end
 -- Held in one table so UpdateResourceBar gains a single upvalue rather than one per site.
 local scratch = {
 	overrides1 = {},
+	overrideFlags1 = {},
 	manaBarColors1 = {},
 	holyPowerColors1 = {},
 	manaBarColors2 = {},
@@ -824,10 +825,19 @@ local function UpdateResourceBar()
 	local function ApplyFlatIndicatorColors(sharedColors, conditionMap, barColorMap)
 		-- barOverridden tells the render below to skip the resource-threshold fill curve: once an indicator
 		-- owns the fill, its flat color has to survive rather than being recomputed from the resource.
+		-- Inner flag tables are pooled by barKey and wiped: ApplyIndicatorColors only writes true.
 		local overrides = scratch.overrides1
 		wipe(overrides)
+		local overrideFlags = scratch.overrideFlags1
 		for barKey in pairs(barColorMap) do
-			overrides[barKey] = {}
+			local flags = overrideFlags[barKey]
+			if flags == nil then
+				flags = {}
+				overrideFlags[barKey] = flags
+			else
+				wipe(flags)
+			end
+			overrides[barKey] = flags
 		end
 
 		TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap, overrides)

--- a/ClassModules/Priest.lua
+++ b/ClassModules/Priest.lua
@@ -29,14 +29,6 @@ local holyWordDefsCache = {
 	{ spell = nil --[[@as TRB.Classes.SpellBase]], key = "holyWordChastise", color = "" --[[@as string]], enabled = false },
 }
 
--- Per-tick scratch tables for the Shadow branch of UpdateResourceBar, reused instead of reallocated.
--- barColorMap only ever points at the same two tables, so it is built once and never rebuilt.
-local shadowConditionMap = {}
-local shadowInsanityBarColors = {}
-local shadowManaBarColors = {}
-local shadowBarColorMap = { insanityBar = shadowInsanityBarColors, manaBar = shadowManaBarColors }
-local shadowOvercapCurvesInsanity = {}
-local shadowOvercapCurvesMana = {}
 
 -- Reverse lookup: nodeColor key → holyWordDefsCache entry (populated once, stable)
 local holyWordKeyToDef = {
@@ -2188,6 +2180,12 @@ local scratch = {
 	holyWordsBarColors1 = {},
 	lightweaverBarColors1 = {},
 	barColorMap2 = {},
+	conditionMap3 = {},
+	insanityBarColors1 = {},
+	manaBarColors3 = {},
+	barColorMap3 = {},
+	overcapCurvesInsanity1 = {},
+	overcapCurvesMana1 = {},
 }
 
 local function UpdateResourceBar()
@@ -2733,7 +2731,7 @@ local function UpdateResourceBar()
 		local manaBarColor = specSettings.colors.bars.mana.bar.color
 		local manaBorderColor = specSettings.colors.bars.mana.border.color
 		local manaBackgroundColor = specSettings.colors.bars.mana.background.color
-		local overcapCurvesMana = shadowOvercapCurvesMana
+		local overcapCurvesMana = scratch.overcapCurvesMana1
 		wipe(overcapCurvesMana)
 
 		if snapshotData.attributes.isTracking then
@@ -2766,7 +2764,8 @@ local function UpdateResourceBar()
 
 			local swmUsable = spells.shadowWordMadness:IsFree() or spells.shadowWordMadness:IsUsable()
 
-			local conditionMap = shadowConditionMap
+			local conditionMap = scratch.conditionMap3
+			wipe(conditionMap)
 			conditionMap.instantMindBlast = snapshotData.attributes.shadowyInsightActive
 			conditionMap.voidformEnd = voidformActive and voidformEndMet
 			conditionMap.mindDevourer = spells.shadowWordMadness:IsFree()
@@ -2777,17 +2776,20 @@ local function UpdateResourceBar()
 			conditionMap.borderOvercap = affectingCombat
 
 			-- Color targets: barKey -> elementKey -> current color
-			local insanityBarColors = shadowInsanityBarColors
+			local insanityBarColors = scratch.insanityBarColors1
 			wipe(insanityBarColors)
 			insanityBarColors.bar = barColor
 			insanityBarColors.border = barBorderColor
 			insanityBarColors.background = barBackgroundColor
-			local manaBarColors = shadowManaBarColors
+			local manaBarColors = scratch.manaBarColors3
 			wipe(manaBarColors)
 			manaBarColors.bar = manaBarColor
 			manaBarColors.border = manaBorderColor
 			manaBarColors.background = manaBackgroundColor
-			local barColorMap = shadowBarColorMap
+			local barColorMap = scratch.barColorMap3
+			wipe(barColorMap)
+			barColorMap.insanityBar = insanityBarColors
+			barColorMap.manaBar = manaBarColors
 
 			-- Apply flat indicator colors (priority order, last writer wins)
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
@@ -2828,7 +2830,7 @@ local function UpdateResourceBar()
 				manaBackgroundColor = manaBarColors.background
 
 				-- Build gradient curves for targeted elements (gradient always wins over flat indicators)
-				local overcapCurvesInsanity = shadowOvercapCurvesInsanity
+				local overcapCurvesInsanity = scratch.overcapCurvesInsanity1
 				wipe(overcapCurvesInsanity)
 				if overcapIndicator and overcapIndicator.targets then
 					local insanityTargets = overcapIndicator.targets.insanityBar

--- a/ClassModules/Priest.lua
+++ b/ClassModules/Priest.lua
@@ -2867,8 +2867,16 @@ local function UpdateResourceBar()
 						thresholds = primaryNode:GetThresholds()
 					end
 					pairOffset = (thresholdId - 1) * 3
-					local resourceAmount = spell:GetPrimaryResourceCost()
-					local isUsable = spell:IsUsable()
+					-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+					-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+					local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+					local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+						or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+					local resourceAmount, isUsable = 0, false
+					if thresholdActive then
+						resourceAmount = spell:GetPrimaryResourceCost()
+						isUsable = spell:IsUsable()
+					end
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color --[[@as string?]]
 					local frameLevel = frameLevels.thresholdOver

--- a/ClassModules/Priest.lua
+++ b/ClassModules/Priest.lua
@@ -2447,14 +2447,8 @@ local function UpdateResourceBar()
 			manaBarColors.background = specSettings.colors.bar.background.color
 			local holyWordsBarColors = scratch.holyWordsBarColors1
 			wipe(holyWordsBarColors)
-			holyWordsBarColors.bar = nil
-			holyWordsBarColors.border = nil
-			holyWordsBarColors.background = nil
 			local lightweaverBarColors = scratch.lightweaverBarColors1
 			wipe(lightweaverBarColors)
-			lightweaverBarColors.bar = nil
-			lightweaverBarColors.border = nil
-			lightweaverBarColors.background = nil
 			local barColorMap = scratch.barColorMap2
 			wipe(barColorMap)
 			barColorMap.manaBar = manaBarColors

--- a/ClassModules/Priest.lua
+++ b/ClassModules/Priest.lua
@@ -1282,7 +1282,7 @@ local function RefreshLookupData_Shadow()
 		local additionalPower = snapshotData.formatted.additionalPower
 		local mana = additionalPower and additionalPower["MANA"]
 		if mana == nil or mana.dirty or mana.precision ~= manaPrecision then
-			TRB.Functions.Character:UpdateAdditionalPowerValues("MANA")
+			TRB.Functions.Character:UpdateAdditionalPowerValues("MANA", manaPrecision)
 			mana = snapshotData.formatted.additionalPower["MANA"]
 		end
 		lookupLogic["$mana"] = mana.current

--- a/ClassModules/Priest.lua
+++ b/ClassModules/Priest.lua
@@ -2175,6 +2175,21 @@ local function UpdateSnapshot_Shadow()
 	--snapshots[spells.mindBlast.id].cooldown:Refresh()
 end
 
+
+-- Reused per-tick scratch tables for UpdateResourceBar (see conditionMap/barColorMap sites).
+-- Held in one table so UpdateResourceBar gains a single upvalue rather than one per site.
+local scratch = {
+	conditionMap1 = {},
+	manaBarColors1 = {},
+	powerWordsBarColors1 = {},
+	barColorMap1 = {},
+	conditionMap2 = {},
+	manaBarColors2 = {},
+	holyWordsBarColors1 = {},
+	lightweaverBarColors1 = {},
+	barColorMap2 = {},
+}
+
 local function UpdateResourceBar()
 	local currentTime = GetTime()
 	local refreshText = false
@@ -2218,16 +2233,27 @@ local function UpdateResourceBar()
 			local indicatorColors = sharedColors and sharedColors.indicatorColors
 
 			local surgeOfLightStacks = GetSurgeOfLightStacks(snapshotData, spells)
-			local conditionMap = {
-				surgeOfLight = surgeOfLightStacks >= 1,
-				surgeOfLight2 = surgeOfLightStacks >= 2,
-				voidShield = snapshotData.snapshots[spells.masterTheDarkness.id].buff.isActive,
-			}
+			local conditionMap = scratch.conditionMap1
+			wipe(conditionMap)
+			conditionMap.surgeOfLight = surgeOfLightStacks >= 1
+			conditionMap.surgeOfLight2 = surgeOfLightStacks >= 2
+			conditionMap.voidShield = snapshotData.snapshots[spells.masterTheDarkness.id].buff.isActive
 
 			-- Color targets: barKey -> elementKey -> current color
-			local manaBarColors = { bar = specSettings.colors.bar.base, border = specSettings.colors.bar.border.color, background = specSettings.colors.bar.background.color }
-			local powerWordsBarColors = { bar = specSettings.colors.comboPoints.powerWordRadiance, border = specSettings.colors.comboPoints.border.color, background = specSettings.colors.comboPoints.background.color }
-			local barColorMap = { manaBar = manaBarColors, powerWordsBar = powerWordsBarColors }
+			local manaBarColors = scratch.manaBarColors1
+			wipe(manaBarColors)
+			manaBarColors.bar = specSettings.colors.bar.base
+			manaBarColors.border = specSettings.colors.bar.border.color
+			manaBarColors.background = specSettings.colors.bar.background.color
+			local powerWordsBarColors = scratch.powerWordsBarColors1
+			wipe(powerWordsBarColors)
+			powerWordsBarColors.bar = specSettings.colors.comboPoints.powerWordRadiance
+			powerWordsBarColors.border = specSettings.colors.comboPoints.border.color
+			powerWordsBarColors.background = specSettings.colors.comboPoints.background.color
+			local barColorMap = scratch.barColorMap1
+			wipe(barColorMap)
+			barColorMap.manaBar = manaBarColors
+			barColorMap.powerWordsBar = powerWordsBarColors
 
 			-- Apply flat indicator colors (priority order, last writer wins)
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
@@ -2403,23 +2429,39 @@ local function UpdateResourceBar()
 			end
 
 			local surgeOfLightStacks = GetSurgeOfLightStacks(snapshotData, spells)
-			local conditionMap = {
-				benediction = snapshots[spells.benediction.id].buff.isActive,
-				holyWordSerenity = holyWordCooldownCompletesKey == "holyWordSerenity",
-				holyWordSanctify = holyWordCooldownCompletesKey == "holyWordSanctify",
-				holyWordChastise = holyWordCooldownCompletesKey == "holyWordChastise",
-				apotheosisEnd = apotheosisActive and apotheosisEndMet,
-				apotheosis = apotheosisActive,
-				surgeOfLight = surgeOfLightStacks >= 1,
-				surgeOfLight2 = surgeOfLightStacks >= 2,
-				lightweaver = snapshots[spells.lightweaver.id].buff.isActive,
-			}
+			local conditionMap = scratch.conditionMap2
+			wipe(conditionMap)
+			conditionMap.benediction = snapshots[spells.benediction.id].buff.isActive
+			conditionMap.holyWordSerenity = holyWordCooldownCompletesKey == "holyWordSerenity"
+			conditionMap.holyWordSanctify = holyWordCooldownCompletesKey == "holyWordSanctify"
+			conditionMap.holyWordChastise = holyWordCooldownCompletesKey == "holyWordChastise"
+			conditionMap.apotheosisEnd = apotheosisActive and apotheosisEndMet
+			conditionMap.apotheosis = apotheosisActive
+			conditionMap.surgeOfLight = surgeOfLightStacks >= 1
+			conditionMap.surgeOfLight2 = surgeOfLightStacks >= 2
+			conditionMap.lightweaver = snapshots[spells.lightweaver.id].buff.isActive
 
 			-- Color targets: barKey -> elementKey -> current color
-			local manaBarColors = { bar = specSettings.colors.bar.base, border = specSettings.colors.bar.border.color, background = specSettings.colors.bar.background.color }
-			local holyWordsBarColors = { bar = nil, border = nil, background = nil }
-			local lightweaverBarColors = { bar = nil, border = nil, background = nil }
-			local barColorMap = { manaBar = manaBarColors, holyWordsBar = holyWordsBarColors, lightweaverBar = lightweaverBarColors }
+			local manaBarColors = scratch.manaBarColors2
+			wipe(manaBarColors)
+			manaBarColors.bar = specSettings.colors.bar.base
+			manaBarColors.border = specSettings.colors.bar.border.color
+			manaBarColors.background = specSettings.colors.bar.background.color
+			local holyWordsBarColors = scratch.holyWordsBarColors1
+			wipe(holyWordsBarColors)
+			holyWordsBarColors.bar = nil
+			holyWordsBarColors.border = nil
+			holyWordsBarColors.background = nil
+			local lightweaverBarColors = scratch.lightweaverBarColors1
+			wipe(lightweaverBarColors)
+			lightweaverBarColors.bar = nil
+			lightweaverBarColors.border = nil
+			lightweaverBarColors.background = nil
+			local barColorMap = scratch.barColorMap2
+			wipe(barColorMap)
+			barColorMap.manaBar = manaBarColors
+			barColorMap.holyWordsBar = holyWordsBarColors
+			barColorMap.lightweaverBar = lightweaverBarColors
 
 			-- Holy's own bars are resolved by the node-aware walk below, not the shared resolver: several of
 			-- its indicators apply to one node of a bar rather than the whole bar. The shared health/cast bar

--- a/ClassModules/Priest.lua
+++ b/ClassModules/Priest.lua
@@ -1276,27 +1276,26 @@ local function RefreshLookupData_Shadow()
 	-- Block F: Mana ($mana, $manaMax, $manaPercent)
 	if not activeVars or activeVars["$mana"] or activeVars["$manaMax"] or activeVars["$manaPercent"] then
 		local currentManaColor = (sharedSettings.colors.text.manaBar and sharedSettings.colors.text.manaBar.color) or sharedSettings.colors.text.current.color
-		local normalizedMana = UnitPower("player", Enum.PowerType.Mana)
-		local normalizedManaMax = UnitPowerMax("player", Enum.PowerType.Mana)
 		local manaPrecision = sharedSettings.precision.mana or 1
-		-- The percent objects and formatted strings only move when these do, so gate the expensive
-		-- derivation on them; lookupChanged degrades to always-changed if the raws come back secret.
-		local manaChanged = lookupChanged(prevState, "$manaRaw", normalizedMana, currentManaColor)
-		local manaMaxChanged = lookupChanged(prevState, "$manaMaxRaw", normalizedManaMax, currentManaColor)
-		local precisionChanged = lookupChanged(prevState, "$manaPrecisionRaw", manaPrecision)
-		if manaChanged or manaMaxChanged or precisionChanged then
-			local _manaPercent = UnitPowerPercent("player", Enum.PowerType.Mana)
-			local manaPercentRaw = UnitPowerPercent("player", Enum.PowerType.Mana, false, CurveConstants.ScaleTo100)
-
-			lookupLogic["$mana"] = normalizedMana
-			lookupLogic["$manaMax"] = normalizedManaMax
-			lookupLogic["$manaPercent"] = _manaPercent
-			local manaFormatted = TRB.Functions.String:ConvertToAbbreviatedNumber(normalizedMana)
-			lookup["$mana"] = string.format("|c%s%s|r", currentManaColor, manaFormatted)
-			local manaMaxFormatted = TRB.Functions.String:ConvertToAbbreviatedNumber(normalizedManaMax)
-			lookup["$manaMax"] = string.format("|c%s%s|r", currentManaColor, manaMaxFormatted)
-			local manaPercentFormatted = string.format("%." .. manaPrecision .. "f", manaPercentRaw)
-			lookup["$manaPercent"] = string.format("|c%s%s|r", currentManaColor, manaPercentFormatted)
+		-- Values are pre-formatted at UNIT_POWER event time; re-derive only on first read or when
+		-- the precision setting changed.
+		local additionalPower = snapshotData.formatted.additionalPower
+		local mana = additionalPower and additionalPower["MANA"]
+		if mana == nil or mana.precision ~= manaPrecision then
+			TRB.Functions.Character:UpdateAdditionalPowerValues("MANA")
+			mana = snapshotData.formatted.additionalPower["MANA"]
+		end
+		lookupLogic["$mana"] = mana.current
+		lookupLogic["$manaMax"] = mana.max
+		lookupLogic["$manaPercent"] = mana.percent
+		if lookupChanged(prevState, "$mana", mana.currentFormatted, currentManaColor) then
+			lookup["$mana"] = string.format("|c%s%s|r", currentManaColor, mana.currentFormatted)
+		end
+		if lookupChanged(prevState, "$manaMax", mana.maxFormatted, currentManaColor) then
+			lookup["$manaMax"] = string.format("|c%s%s|r", currentManaColor, mana.maxFormatted)
+		end
+		if lookupChanged(prevState, "$manaPercent", mana.percentFormatted, currentManaColor) then
+			lookup["$manaPercent"] = string.format("|c%s%s|r", currentManaColor, mana.percentFormatted)
 		end
 	end
 

--- a/ClassModules/Priest.lua
+++ b/ClassModules/Priest.lua
@@ -1277,11 +1277,11 @@ local function RefreshLookupData_Shadow()
 	if not activeVars or activeVars["$mana"] or activeVars["$manaMax"] or activeVars["$manaPercent"] then
 		local currentManaColor = (sharedSettings.colors.text.manaBar and sharedSettings.colors.text.manaBar.color) or sharedSettings.colors.text.current.color
 		local manaPrecision = sharedSettings.precision.mana or 1
-		-- Values are pre-formatted at UNIT_POWER event time; re-derive only on first read or when
-		-- the precision setting changed.
+		-- Power events only mark dirty; re-derive here at most once per tick, plus first read and
+		-- precision changes.
 		local additionalPower = snapshotData.formatted.additionalPower
 		local mana = additionalPower and additionalPower["MANA"]
-		if mana == nil or mana.precision ~= manaPrecision then
+		if mana == nil or mana.dirty or mana.precision ~= manaPrecision then
 			TRB.Functions.Character:UpdateAdditionalPowerValues("MANA")
 			mana = snapshotData.formatted.additionalPower["MANA"]
 		end

--- a/ClassModules/Priest.lua
+++ b/ClassModules/Priest.lua
@@ -1279,22 +1279,23 @@ local function RefreshLookupData_Shadow()
 		local normalizedMana = UnitPower("player", Enum.PowerType.Mana)
 		local normalizedManaMax = UnitPowerMax("player", Enum.PowerType.Mana)
 		local manaPrecision = sharedSettings.precision.mana or 1
-		local _manaPercent = UnitPowerPercent("player", Enum.PowerType.Mana)
-		local manaPercentRaw = UnitPowerPercent("player", Enum.PowerType.Mana, false, CurveConstants.ScaleTo100)
+		-- The percent objects and formatted strings only move when these do, so gate the expensive
+		-- derivation on them; lookupChanged degrades to always-changed if the raws come back secret.
+		local manaChanged = lookupChanged(prevState, "$manaRaw", normalizedMana, currentManaColor)
+		local manaMaxChanged = lookupChanged(prevState, "$manaMaxRaw", normalizedManaMax, currentManaColor)
+		local precisionChanged = lookupChanged(prevState, "$manaPrecisionRaw", manaPrecision)
+		if manaChanged or manaMaxChanged or precisionChanged then
+			local _manaPercent = UnitPowerPercent("player", Enum.PowerType.Mana)
+			local manaPercentRaw = UnitPowerPercent("player", Enum.PowerType.Mana, false, CurveConstants.ScaleTo100)
 
-		lookupLogic["$mana"] = normalizedMana
-		lookupLogic["$manaMax"] = normalizedManaMax
-		lookupLogic["$manaPercent"] = _manaPercent
-		local manaFormatted = TRB.Functions.String:ConvertToAbbreviatedNumber(normalizedMana)
-		if lookupChanged(prevState, "$mana", manaFormatted, currentManaColor) then
+			lookupLogic["$mana"] = normalizedMana
+			lookupLogic["$manaMax"] = normalizedManaMax
+			lookupLogic["$manaPercent"] = _manaPercent
+			local manaFormatted = TRB.Functions.String:ConvertToAbbreviatedNumber(normalizedMana)
 			lookup["$mana"] = string.format("|c%s%s|r", currentManaColor, manaFormatted)
-		end
-		local manaMaxFormatted = TRB.Functions.String:ConvertToAbbreviatedNumber(normalizedManaMax)
-		if lookupChanged(prevState, "$manaMax", manaMaxFormatted, currentManaColor) then
+			local manaMaxFormatted = TRB.Functions.String:ConvertToAbbreviatedNumber(normalizedManaMax)
 			lookup["$manaMax"] = string.format("|c%s%s|r", currentManaColor, manaMaxFormatted)
-		end
-		local manaPercentFormatted = string.format("%." .. manaPrecision .. "f", manaPercentRaw)
-		if lookupChanged(prevState, "$manaPercent", manaPercentFormatted, currentManaColor) then
+			local manaPercentFormatted = string.format("%." .. manaPrecision .. "f", manaPercentRaw)
 			lookup["$manaPercent"] = string.format("|c%s%s|r", currentManaColor, manaPercentFormatted)
 		end
 	end

--- a/ClassModules/Priest.lua
+++ b/ClassModules/Priest.lua
@@ -29,6 +29,15 @@ local holyWordDefsCache = {
 	{ spell = nil --[[@as TRB.Classes.SpellBase]], key = "holyWordChastise", color = "" --[[@as string]], enabled = false },
 }
 
+-- Per-tick scratch tables for the Shadow branch of UpdateResourceBar, reused instead of reallocated.
+-- barColorMap only ever points at the same two tables, so it is built once and never rebuilt.
+local shadowConditionMap = {}
+local shadowInsanityBarColors = {}
+local shadowManaBarColors = {}
+local shadowBarColorMap = { insanityBar = shadowInsanityBarColors, manaBar = shadowManaBarColors }
+local shadowOvercapCurvesInsanity = {}
+local shadowOvercapCurvesMana = {}
+
 -- Reverse lookup: nodeColor key → holyWordDefsCache entry (populated once, stable)
 local holyWordKeyToDef = {
 	holyWordSerenity = holyWordDefsCache[1],
@@ -2682,7 +2691,8 @@ local function UpdateResourceBar()
 		local manaBarColor = specSettings.colors.bars.mana.bar.color
 		local manaBorderColor = specSettings.colors.bars.mana.border.color
 		local manaBackgroundColor = specSettings.colors.bars.mana.background.color
-		local overcapCurvesMana = {}
+		local overcapCurvesMana = shadowOvercapCurvesMana
+		wipe(overcapCurvesMana)
 
 		if snapshotData.attributes.isTracking then
 			local affectingCombat = TRB.Data.character.inCombat
@@ -2714,21 +2724,28 @@ local function UpdateResourceBar()
 
 			local swmUsable = spells.shadowWordMadness:IsFree() or spells.shadowWordMadness:IsUsable()
 
-			local conditionMap = {
-				instantMindBlast = snapshotData.attributes.shadowyInsightActive,
-				voidformEnd = voidformActive and voidformEndMet,
-				mindDevourer = spells.shadowWordMadness:IsFree(),
-				entropicRift = snapshots[spells.entropicRift.id].buff.isActive,
-				borderMindFlayInsanity = snapshots[spells.mindFlayInsanity.id].buff.isActive,
-				shadowWordMadnessUsable = swmUsable,
-				voidform = voidformActive,
-				borderOvercap = affectingCombat,
-			}
+			local conditionMap = shadowConditionMap
+			conditionMap.instantMindBlast = snapshotData.attributes.shadowyInsightActive
+			conditionMap.voidformEnd = voidformActive and voidformEndMet
+			conditionMap.mindDevourer = spells.shadowWordMadness:IsFree()
+			conditionMap.entropicRift = snapshots[spells.entropicRift.id].buff.isActive
+			conditionMap.borderMindFlayInsanity = snapshots[spells.mindFlayInsanity.id].buff.isActive
+			conditionMap.shadowWordMadnessUsable = swmUsable
+			conditionMap.voidform = voidformActive
+			conditionMap.borderOvercap = affectingCombat
 
 			-- Color targets: barKey -> elementKey -> current color
-			local insanityBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
-			local manaBarColors = { bar = manaBarColor, border = manaBorderColor, background = manaBackgroundColor }
-			local barColorMap = { insanityBar = insanityBarColors, manaBar = manaBarColors }
+			local insanityBarColors = shadowInsanityBarColors
+			wipe(insanityBarColors)
+			insanityBarColors.bar = barColor
+			insanityBarColors.border = barBorderColor
+			insanityBarColors.background = barBackgroundColor
+			local manaBarColors = shadowManaBarColors
+			wipe(manaBarColors)
+			manaBarColors.bar = manaBarColor
+			manaBarColors.border = manaBorderColor
+			manaBarColors.background = manaBackgroundColor
+			local barColorMap = shadowBarColorMap
 
 			-- Apply flat indicator colors (priority order, last writer wins)
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
@@ -2769,7 +2786,8 @@ local function UpdateResourceBar()
 				manaBackgroundColor = manaBarColors.background
 
 				-- Build gradient curves for targeted elements (gradient always wins over flat indicators)
-				local overcapCurvesInsanity = {}
+				local overcapCurvesInsanity = shadowOvercapCurvesInsanity
+				wipe(overcapCurvesInsanity)
 				if overcapIndicator and overcapIndicator.targets then
 					local insanityTargets = overcapIndicator.targets.insanityBar
 					if insanityTargets then

--- a/ClassModules/Rogue.lua
+++ b/ClassModules/Rogue.lua
@@ -818,6 +818,34 @@ local function EvaluateOvercapCurve(thresholdCurve)
 	return UnitPowerPercent("player", TRB.Data.resource, true, thresholdCurve)
 end
 
+
+-- Reused per-tick scratch tables for UpdateResourceBar (see conditionMap/barColorMap sites).
+-- Held in one table so UpdateResourceBar gains a single upvalue rather than one per site.
+local scratch = {
+	comboPointsColors1 = {},
+	comboPointConditionMap1 = {},
+	comboPointBarColorMap1 = {},
+	conditionMap1 = {},
+	energyBarColors1 = {},
+	comboPointsColors2 = {},
+	barColorMap1 = {},
+	comboPointsColors3 = {},
+	comboPointConditionMap2 = {},
+	comboPointBarColorMap2 = {},
+	conditionMap2 = {},
+	energyBarColors2 = {},
+	comboPointsColors4 = {},
+	barColorMap2 = {},
+	comboPointsColors5 = {},
+	comboPointConditionMap3 = {},
+	comboPointBarColorMap3 = {},
+	thresholds1 = {},
+	conditionMap3 = {},
+	energyBarColors3 = {},
+	comboPointsColors6 = {},
+	barColorMap3 = {},
+}
+
 local function UpdateResourceBar()
 	local currentTime = GetTime()
 	local refreshText = false
@@ -847,16 +875,18 @@ local function UpdateResourceBar()
 		local comboPointSpells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Rogue.AssassinationSpells]]
 		local comboPointAffectingCombat = TRB.Data.character.inCombat
 		local comboPointStealthViaBuff = snapshots[comboPointSpells.subterfuge.id].buff.isActive
-		local comboPointsColors = {
-			bar = specSettings.colors.comboPoints.base,
-			border = specSettings.colors.comboPoints.border.color,
-			background = specSettings.colors.comboPoints.background.color,
-		}
-		local comboPointConditionMap = {
-			borderStealth = IsStealthed() or comboPointStealthViaBuff,
-			borderOvercap = comboPointAffectingCombat and not (IsStealthed() or comboPointStealthViaBuff),
-		}
-		local comboPointBarColorMap = { comboPointsBar = comboPointsColors }
+		local comboPointsColors = scratch.comboPointsColors1
+		wipe(comboPointsColors)
+		comboPointsColors.bar = specSettings.colors.comboPoints.base
+		comboPointsColors.border = specSettings.colors.comboPoints.border.color
+		comboPointsColors.background = specSettings.colors.comboPoints.background.color
+		local comboPointConditionMap = scratch.comboPointConditionMap1
+		wipe(comboPointConditionMap)
+		comboPointConditionMap.borderStealth = IsStealthed() or comboPointStealthViaBuff
+		comboPointConditionMap.borderOvercap = comboPointAffectingCombat and not (IsStealthed() or comboPointStealthViaBuff)
+		local comboPointBarColorMap = scratch.comboPointBarColorMap1
+		wipe(comboPointBarColorMap)
+		comboPointBarColorMap.comboPointsBar = comboPointsColors
 		local comboPointIndicatorTargets, comboPointOvercapIndicator = ApplyIndicatorColorsToBarMap(comboPointBarColorMap, specSettings.colors.shared, comboPointConditionMap)
 		local comboPointsOvercapCurves = BuildBarElementOvercapCurves(specSettings, comboPointOvercapIndicator, "comboPointsBar", comboPointsColors)
 		local comboPointFlatTargets = comboPointIndicatorTargets.comboPointsBar or { bar = false, border = false, background = false }
@@ -1022,17 +1052,24 @@ local function UpdateResourceBar()
 				local barBackgroundColor = specSettings.colors.bar.background.color
 				local stealthActive = IsStealthed() or stealthViaBuff
 				local sharedColors = specSettings.colors.shared
-				local conditionMap = {
-					borderStealth = stealthActive,
-					borderOvercap = affectingCombat and not stealthActive,
-				}
-				local energyBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
-				local comboPointsColors = {
-					bar = specSettings.colors.comboPoints.base,
-					border = specSettings.colors.comboPoints.border.color,
-					background = specSettings.colors.comboPoints.background.color,
-				}
-				local barColorMap = { energyBar = energyBarColors, comboPointsBar = comboPointsColors }
+				local conditionMap = scratch.conditionMap1
+				wipe(conditionMap)
+				conditionMap.borderStealth = stealthActive
+				conditionMap.borderOvercap = affectingCombat and not stealthActive
+				local energyBarColors = scratch.energyBarColors1
+				wipe(energyBarColors)
+				energyBarColors.bar = barColor
+				energyBarColors.border = barBorderColor
+				energyBarColors.background = barBackgroundColor
+				local comboPointsColors = scratch.comboPointsColors2
+				wipe(comboPointsColors)
+				comboPointsColors.bar = specSettings.colors.comboPoints.base
+				comboPointsColors.border = specSettings.colors.comboPoints.border.color
+				comboPointsColors.background = specSettings.colors.comboPoints.background.color
+				local barColorMap = scratch.barColorMap1
+				wipe(barColorMap)
+				barColorMap.energyBar = energyBarColors
+				barColorMap.comboPointsBar = comboPointsColors
 				local flatIndicatorTargets, overcapIndicator = ApplyIndicatorColorsToBarMap(barColorMap, sharedColors, conditionMap)
 				local energyBarOvercapCurves = BuildBarElementOvercapCurves(specSettings, overcapIndicator, "energyBar", energyBarColors)
 				local comboPointsOvercapCurves = BuildBarElementOvercapCurves(specSettings, overcapIndicator, "comboPointsBar", comboPointsColors)
@@ -1162,16 +1199,18 @@ local function UpdateResourceBar()
 		local comboPointSpells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Rogue.OutlawSpells]]
 		local comboPointAffectingCombat = TRB.Data.character.inCombat
 		local comboPointStealthViaBuff = snapshots[comboPointSpells.subterfuge.id].buff.isActive
-		local comboPointsColors = {
-			bar = specSettings.colors.comboPoints.base,
-			border = specSettings.colors.comboPoints.border.color,
-			background = specSettings.colors.comboPoints.background.color,
-		}
-		local comboPointConditionMap = {
-			borderStealth = IsStealthed() or comboPointStealthViaBuff,
-			borderOvercap = comboPointAffectingCombat and not (IsStealthed() or comboPointStealthViaBuff),
-		}
-		local comboPointBarColorMap = { comboPointsBar = comboPointsColors }
+		local comboPointsColors = scratch.comboPointsColors3
+		wipe(comboPointsColors)
+		comboPointsColors.bar = specSettings.colors.comboPoints.base
+		comboPointsColors.border = specSettings.colors.comboPoints.border.color
+		comboPointsColors.background = specSettings.colors.comboPoints.background.color
+		local comboPointConditionMap = scratch.comboPointConditionMap2
+		wipe(comboPointConditionMap)
+		comboPointConditionMap.borderStealth = IsStealthed() or comboPointStealthViaBuff
+		comboPointConditionMap.borderOvercap = comboPointAffectingCombat and not (IsStealthed() or comboPointStealthViaBuff)
+		local comboPointBarColorMap = scratch.comboPointBarColorMap2
+		wipe(comboPointBarColorMap)
+		comboPointBarColorMap.comboPointsBar = comboPointsColors
 		local comboPointIndicatorTargets, comboPointOvercapIndicator = ApplyIndicatorColorsToBarMap(comboPointBarColorMap, specSettings.colors.shared, comboPointConditionMap)
 		local comboPointsOvercapCurves = BuildBarElementOvercapCurves(specSettings, comboPointOvercapIndicator, "comboPointsBar", comboPointsColors)
 		local comboPointFlatTargets = comboPointIndicatorTargets.comboPointsBar or { bar = false, border = false, background = false }
@@ -1394,17 +1433,24 @@ local function UpdateResourceBar()
 				local barBackgroundColor = specSettings.colors.bar.background.color
 				local stealthActive = IsStealthed() or stealthViaBuff
 				local sharedColors = specSettings.colors.shared
-				local conditionMap = {
-					borderStealth = stealthActive,
-					borderOvercap = affectingCombat and not stealthActive,
-				}
-				local energyBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
-				local comboPointsColors = {
-					bar = specSettings.colors.comboPoints.base,
-					border = specSettings.colors.comboPoints.border.color,
-					background = specSettings.colors.comboPoints.background.color,
-				}
-				local barColorMap = { energyBar = energyBarColors, comboPointsBar = comboPointsColors }
+				local conditionMap = scratch.conditionMap2
+				wipe(conditionMap)
+				conditionMap.borderStealth = stealthActive
+				conditionMap.borderOvercap = affectingCombat and not stealthActive
+				local energyBarColors = scratch.energyBarColors2
+				wipe(energyBarColors)
+				energyBarColors.bar = barColor
+				energyBarColors.border = barBorderColor
+				energyBarColors.background = barBackgroundColor
+				local comboPointsColors = scratch.comboPointsColors4
+				wipe(comboPointsColors)
+				comboPointsColors.bar = specSettings.colors.comboPoints.base
+				comboPointsColors.border = specSettings.colors.comboPoints.border.color
+				comboPointsColors.background = specSettings.colors.comboPoints.background.color
+				local barColorMap = scratch.barColorMap2
+				wipe(barColorMap)
+				barColorMap.energyBar = energyBarColors
+				barColorMap.comboPointsBar = comboPointsColors
 				local flatIndicatorTargets, overcapIndicator = ApplyIndicatorColorsToBarMap(barColorMap, sharedColors, conditionMap)
 				local energyBarOvercapCurves = BuildBarElementOvercapCurves(specSettings, overcapIndicator, "energyBar", energyBarColors)
 				local comboPointsOvercapCurves = BuildBarElementOvercapCurves(specSettings, overcapIndicator, "comboPointsBar", comboPointsColors)
@@ -1533,16 +1579,18 @@ local function UpdateResourceBar()
 		local comboPointSpells = TRB.Data.spellsData.spells --[[@as TRB.Classes.Rogue.SubtletySpells]]
 		local comboPointAffectingCombat = TRB.Data.character.inCombat
 		local comboPointStealthViaBuff = snapshots[comboPointSpells.subterfuge.id].buff.isActive or snapshots[comboPointSpells.shadowDance.id].buff.isActive
-		local comboPointsColors = {
-			bar = specSettings.colors.comboPoints.base,
-			border = specSettings.colors.comboPoints.border.color,
-			background = specSettings.colors.comboPoints.background.color,
-		}
-		local comboPointConditionMap = {
-			borderStealth = comboPointStealthViaBuff or IsStealthed(),
-			borderOvercap = comboPointAffectingCombat and not (comboPointStealthViaBuff or IsStealthed()),
-		}
-		local comboPointBarColorMap = { comboPointsBar = comboPointsColors }
+		local comboPointsColors = scratch.comboPointsColors5
+		wipe(comboPointsColors)
+		comboPointsColors.bar = specSettings.colors.comboPoints.base
+		comboPointsColors.border = specSettings.colors.comboPoints.border.color
+		comboPointsColors.background = specSettings.colors.comboPoints.background.color
+		local comboPointConditionMap = scratch.comboPointConditionMap3
+		wipe(comboPointConditionMap)
+		comboPointConditionMap.borderStealth = comboPointStealthViaBuff or IsStealthed()
+		comboPointConditionMap.borderOvercap = comboPointAffectingCombat and not (comboPointStealthViaBuff or IsStealthed())
+		local comboPointBarColorMap = scratch.comboPointBarColorMap3
+		wipe(comboPointBarColorMap)
+		comboPointBarColorMap.comboPointsBar = comboPointsColors
 		local comboPointIndicatorTargets, comboPointOvercapIndicator = ApplyIndicatorColorsToBarMap(comboPointBarColorMap, specSettings.colors.shared, comboPointConditionMap)
 		local comboPointsOvercapCurves = BuildBarElementOvercapCurves(specSettings, comboPointOvercapIndicator, "comboPointsBar", comboPointsColors)
 		local comboPointFlatTargets = comboPointIndicatorTargets.comboPointsBar or { bar = false, border = false, background = false }
@@ -1566,7 +1614,8 @@ local function UpdateResourceBar()
 					Bar:ApplyEndCapIndicator(primaryNode, "energyBar")
 				end
 
-				local thresholds = {}
+				local thresholds = scratch.thresholds1
+				wipe(thresholds)
 				if primaryNode then
 					thresholds = primaryNode:GetThresholds()
 				end
@@ -1750,17 +1799,24 @@ local function UpdateResourceBar()
 				local barBackgroundColor = specSettings.colors.bar.background.color
 				local stealthActive = stealthViaBuff or IsStealthed()
 				local sharedColors = specSettings.colors.shared
-				local conditionMap = {
-					borderStealth = stealthActive,
-					borderOvercap = affectingCombat and not stealthActive,
-				}
-				local energyBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
-				local comboPointsColors = {
-					bar = specSettings.colors.comboPoints.base,
-					border = specSettings.colors.comboPoints.border.color,
-					background = specSettings.colors.comboPoints.background.color,
-				}
-				local barColorMap = { energyBar = energyBarColors, comboPointsBar = comboPointsColors }
+				local conditionMap = scratch.conditionMap3
+				wipe(conditionMap)
+				conditionMap.borderStealth = stealthActive
+				conditionMap.borderOvercap = affectingCombat and not stealthActive
+				local energyBarColors = scratch.energyBarColors3
+				wipe(energyBarColors)
+				energyBarColors.bar = barColor
+				energyBarColors.border = barBorderColor
+				energyBarColors.background = barBackgroundColor
+				local comboPointsColors = scratch.comboPointsColors6
+				wipe(comboPointsColors)
+				comboPointsColors.bar = specSettings.colors.comboPoints.base
+				comboPointsColors.border = specSettings.colors.comboPoints.border.color
+				comboPointsColors.background = specSettings.colors.comboPoints.background.color
+				local barColorMap = scratch.barColorMap3
+				wipe(barColorMap)
+				barColorMap.energyBar = energyBarColors
+				barColorMap.comboPointsBar = comboPointsColors
 				local flatIndicatorTargets, overcapIndicator = ApplyIndicatorColorsToBarMap(barColorMap, sharedColors, conditionMap)
 				local energyBarOvercapCurves = BuildBarElementOvercapCurves(specSettings, overcapIndicator, "energyBar", energyBarColors)
 				local comboPointsOvercapCurves = BuildBarElementOvercapCurves(specSettings, overcapIndicator, "comboPointsBar", comboPointsColors)

--- a/ClassModules/Rogue.lua
+++ b/ClassModules/Rogue.lua
@@ -839,7 +839,6 @@ local scratch = {
 	comboPointsColors5 = {},
 	comboPointConditionMap3 = {},
 	comboPointBarColorMap3 = {},
-	thresholds1 = {},
 	conditionMap3 = {},
 	energyBarColors3 = {},
 	comboPointsColors6 = {},
@@ -1614,11 +1613,7 @@ local function UpdateResourceBar()
 					Bar:ApplyEndCapIndicator(primaryNode, "energyBar")
 				end
 
-				local thresholds = scratch.thresholds1
-				wipe(thresholds)
-				if primaryNode then
-					thresholds = primaryNode:GetThresholds()
-				end
+				local thresholds = primaryNode and primaryNode:GetThresholds() or {}
 				
 				local stealthViaBuff = snapshots[spells.subterfuge.id].buff.isActive or snapshots[spells.shadowDance.id].buff.isActive
 

--- a/ClassModules/Rogue.lua
+++ b/ClassModules/Rogue.lua
@@ -767,10 +767,23 @@ local function ProcessComboPointAudioCues(specSettings)
 	TRB.Functions.AudioCues:UpdateCounter(specSettings, snapshotData, "comboPoints", snapshotData.attributes.resource2)
 end
 
-local function ApplyIndicatorColorsToBarMap(barColorMap, sharedColors, conditionMap)
-	local flatIndicatorTargets = {}
+-- Read-only stand-in for a barKey the resolver never targeted; never written to.
+local emptyIndicatorFlags = {}
+
+---Resolves indicator colors into barColorMap and records which elements an indicator claimed.
+---targets and flagPool are caller-owned: a returned flag table stays live past the caller's next
+---call, so every call site needs its own pair rather than sharing one pool.
+local function ApplyIndicatorColorsToBarMap(barColorMap, sharedColors, conditionMap, flatIndicatorTargets, flagPool)
+	wipe(flatIndicatorTargets)
 	for barKey, _ in pairs(barColorMap) do
-		flatIndicatorTargets[barKey] = { bar = false, border = false, background = false }
+		local flags = flagPool[barKey]
+		if flags == nil then
+			flags = {}
+			flagPool[barKey] = flags
+		else
+			wipe(flags)
+		end
+		flatIndicatorTargets[barKey] = flags
 	end
 
 	local indicatorColors = sharedColors and sharedColors.indicatorColors
@@ -843,6 +856,12 @@ local scratch = {
 	energyBarColors3 = {},
 	comboPointsColors6 = {},
 	barColorMap3 = {},
+	comboPointIndicatorTargets1 = {}, comboPointTargetFlags1 = {},
+	comboPointIndicatorTargets2 = {}, comboPointTargetFlags2 = {},
+	comboPointIndicatorTargets3 = {}, comboPointTargetFlags3 = {},
+	flatIndicatorTargets1 = {}, flatTargetFlags1 = {},
+	flatIndicatorTargets2 = {}, flatTargetFlags2 = {},
+	flatIndicatorTargets3 = {}, flatTargetFlags3 = {},
 }
 
 local function UpdateResourceBar()
@@ -886,9 +905,9 @@ local function UpdateResourceBar()
 		local comboPointBarColorMap = scratch.comboPointBarColorMap1
 		wipe(comboPointBarColorMap)
 		comboPointBarColorMap.comboPointsBar = comboPointsColors
-		local comboPointIndicatorTargets, comboPointOvercapIndicator = ApplyIndicatorColorsToBarMap(comboPointBarColorMap, specSettings.colors.shared, comboPointConditionMap)
+		local comboPointIndicatorTargets, comboPointOvercapIndicator = ApplyIndicatorColorsToBarMap(comboPointBarColorMap, specSettings.colors.shared, comboPointConditionMap, scratch.comboPointIndicatorTargets1, scratch.comboPointTargetFlags1)
 		local comboPointsOvercapCurves = BuildBarElementOvercapCurves(specSettings, comboPointOvercapIndicator, "comboPointsBar", comboPointsColors)
-		local comboPointFlatTargets = comboPointIndicatorTargets.comboPointsBar or { bar = false, border = false, background = false }
+		local comboPointFlatTargets = comboPointIndicatorTargets.comboPointsBar or emptyIndicatorFlags
 
 		if snapshotData.attributes.isTracking then
 			if not specSettings.displayBar.primary.neverShow then
@@ -1069,10 +1088,10 @@ local function UpdateResourceBar()
 				wipe(barColorMap)
 				barColorMap.energyBar = energyBarColors
 				barColorMap.comboPointsBar = comboPointsColors
-				local flatIndicatorTargets, overcapIndicator = ApplyIndicatorColorsToBarMap(barColorMap, sharedColors, conditionMap)
+				local flatIndicatorTargets, overcapIndicator = ApplyIndicatorColorsToBarMap(barColorMap, sharedColors, conditionMap, scratch.flatIndicatorTargets1, scratch.flatTargetFlags1)
 				local energyBarOvercapCurves = BuildBarElementOvercapCurves(specSettings, overcapIndicator, "energyBar", energyBarColors)
 				local comboPointsOvercapCurves = BuildBarElementOvercapCurves(specSettings, overcapIndicator, "comboPointsBar", comboPointsColors)
-				local comboPointFlatTargets = flatIndicatorTargets.comboPointsBar or { bar = false, border = false, background = false }
+				local comboPointFlatTargets = flatIndicatorTargets.comboPointsBar or emptyIndicatorFlags
 
 				barColor = energyBarColors.bar
 				barBorderColor = energyBarColors.border
@@ -1210,9 +1229,9 @@ local function UpdateResourceBar()
 		local comboPointBarColorMap = scratch.comboPointBarColorMap2
 		wipe(comboPointBarColorMap)
 		comboPointBarColorMap.comboPointsBar = comboPointsColors
-		local comboPointIndicatorTargets, comboPointOvercapIndicator = ApplyIndicatorColorsToBarMap(comboPointBarColorMap, specSettings.colors.shared, comboPointConditionMap)
+		local comboPointIndicatorTargets, comboPointOvercapIndicator = ApplyIndicatorColorsToBarMap(comboPointBarColorMap, specSettings.colors.shared, comboPointConditionMap, scratch.comboPointIndicatorTargets2, scratch.comboPointTargetFlags2)
 		local comboPointsOvercapCurves = BuildBarElementOvercapCurves(specSettings, comboPointOvercapIndicator, "comboPointsBar", comboPointsColors)
-		local comboPointFlatTargets = comboPointIndicatorTargets.comboPointsBar or { bar = false, border = false, background = false }
+		local comboPointFlatTargets = comboPointIndicatorTargets.comboPointsBar or emptyIndicatorFlags
 
 		if snapshotData.attributes.isTracking then
 			if not specSettings.displayBar.primary.neverShow then
@@ -1450,10 +1469,10 @@ local function UpdateResourceBar()
 				wipe(barColorMap)
 				barColorMap.energyBar = energyBarColors
 				barColorMap.comboPointsBar = comboPointsColors
-				local flatIndicatorTargets, overcapIndicator = ApplyIndicatorColorsToBarMap(barColorMap, sharedColors, conditionMap)
+				local flatIndicatorTargets, overcapIndicator = ApplyIndicatorColorsToBarMap(barColorMap, sharedColors, conditionMap, scratch.flatIndicatorTargets2, scratch.flatTargetFlags2)
 				local energyBarOvercapCurves = BuildBarElementOvercapCurves(specSettings, overcapIndicator, "energyBar", energyBarColors)
 				local comboPointsOvercapCurves = BuildBarElementOvercapCurves(specSettings, overcapIndicator, "comboPointsBar", comboPointsColors)
-				local comboPointFlatTargets = flatIndicatorTargets.comboPointsBar or { bar = false, border = false, background = false }
+				local comboPointFlatTargets = flatIndicatorTargets.comboPointsBar or emptyIndicatorFlags
 
 				barColor = energyBarColors.bar
 				barBorderColor = energyBarColors.border
@@ -1590,9 +1609,9 @@ local function UpdateResourceBar()
 		local comboPointBarColorMap = scratch.comboPointBarColorMap3
 		wipe(comboPointBarColorMap)
 		comboPointBarColorMap.comboPointsBar = comboPointsColors
-		local comboPointIndicatorTargets, comboPointOvercapIndicator = ApplyIndicatorColorsToBarMap(comboPointBarColorMap, specSettings.colors.shared, comboPointConditionMap)
+		local comboPointIndicatorTargets, comboPointOvercapIndicator = ApplyIndicatorColorsToBarMap(comboPointBarColorMap, specSettings.colors.shared, comboPointConditionMap, scratch.comboPointIndicatorTargets3, scratch.comboPointTargetFlags3)
 		local comboPointsOvercapCurves = BuildBarElementOvercapCurves(specSettings, comboPointOvercapIndicator, "comboPointsBar", comboPointsColors)
-		local comboPointFlatTargets = comboPointIndicatorTargets.comboPointsBar or { bar = false, border = false, background = false }
+		local comboPointFlatTargets = comboPointIndicatorTargets.comboPointsBar or emptyIndicatorFlags
 
 		if snapshotData.attributes.isTracking then
 			if not specSettings.displayBar.primary.neverShow then
@@ -1812,10 +1831,10 @@ local function UpdateResourceBar()
 				wipe(barColorMap)
 				barColorMap.energyBar = energyBarColors
 				barColorMap.comboPointsBar = comboPointsColors
-				local flatIndicatorTargets, overcapIndicator = ApplyIndicatorColorsToBarMap(barColorMap, sharedColors, conditionMap)
+				local flatIndicatorTargets, overcapIndicator = ApplyIndicatorColorsToBarMap(barColorMap, sharedColors, conditionMap, scratch.flatIndicatorTargets3, scratch.flatTargetFlags3)
 				local energyBarOvercapCurves = BuildBarElementOvercapCurves(specSettings, overcapIndicator, "energyBar", energyBarColors)
 				local comboPointsOvercapCurves = BuildBarElementOvercapCurves(specSettings, overcapIndicator, "comboPointsBar", comboPointsColors)
-				local comboPointFlatTargets = flatIndicatorTargets.comboPointsBar or { bar = false, border = false, background = false }
+				local comboPointFlatTargets = flatIndicatorTargets.comboPointsBar or emptyIndicatorFlags
 
 				barColor = energyBarColors.bar
 				barBorderColor = energyBarColors.border

--- a/ClassModules/Rogue.lua
+++ b/ClassModules/Rogue.lua
@@ -941,8 +941,16 @@ local function UpdateResourceBar()
 						thresholds = primaryNode:GetThresholds()
 					end
 					pairOffset = (thresholdId - 1) * 3
-					local resourceAmount = spell:GetPrimaryResourceCost()
-					local isUsable = spell:IsUsable()
+					-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+					-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+					local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+					local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+						or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+					local resourceAmount, isUsable = 0, false
+					if thresholdActive then
+						resourceAmount = spell:GetPrimaryResourceCost()
+						isUsable = spell:IsUsable()
+					end
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
 					local frameLevel = frameLevels.thresholdOver
@@ -1265,8 +1273,16 @@ local function UpdateResourceBar()
 						thresholds = primaryNode:GetThresholds()
 					end
 					pairOffset = (thresholdId - 1) * 3
-					local resourceAmount = spell:GetPrimaryResourceCost()
-					local isUsable = spell:IsUsable()
+					-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+					-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+					local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+					local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+						or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+					local resourceAmount, isUsable = 0, false
+					if thresholdActive then
+						resourceAmount = spell:GetPrimaryResourceCost()
+						isUsable = spell:IsUsable()
+					end
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
 					local frameLevel = frameLevels.thresholdOver
@@ -1642,8 +1658,16 @@ local function UpdateResourceBar()
 						thresholds[thresholdId] = primaryNode:RegisterThreshold(thresholdId)
 					end
 					pairOffset = (thresholdId - 1) * 3
-					local resourceAmount = spell:GetPrimaryResourceCost()
-					local isUsable = spell:IsUsable()
+					-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+					-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+					local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+					local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+						or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+					local resourceAmount, isUsable = 0, false
+					if thresholdActive then
+						resourceAmount = spell:GetPrimaryResourceCost()
+						isUsable = spell:IsUsable()
+					end
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
 					local frameLevel = frameLevels.thresholdOver

--- a/ClassModules/Shaman.lua
+++ b/ClassModules/Shaman.lua
@@ -352,27 +352,26 @@ local function RefreshLookupData_Elemental()
 	-- Block C: Mana ($mana, $manaMax, $manaPercent)
 	if not activeVars or activeVars["$mana"] or activeVars["$manaMax"] or activeVars["$manaPercent"] then
 		local currentManaColor = (sharedSettings.colors.text.manaBar and sharedSettings.colors.text.manaBar.color) or sharedSettings.colors.text.current.color
-		local normalizedMana = UnitPower("player", Enum.PowerType.Mana)
-		local normalizedManaMax = UnitPowerMax("player", Enum.PowerType.Mana)
 		local manaPrecision = sharedSettings.precision.mana or 1
-		local _manaPercent = UnitPowerPercent("player", Enum.PowerType.Mana)
-		local manaPercentRaw = UnitPowerPercent("player", Enum.PowerType.Mana, false, CurveConstants.ScaleTo100)
-
-		lookupLogic["$mana"] = normalizedMana
-		lookupLogic["$manaMax"] = normalizedManaMax
-		lookupLogic["$manaPercent"] = _manaPercent
-
-		local manaFormatted = TRB.Functions.String:ConvertToAbbreviatedNumber(normalizedMana)
-		if lookupChanged(prevState, "$mana", manaFormatted, currentManaColor) then
-			lookup["$mana"] = string.format("|c%s%s|r", currentManaColor, manaFormatted)
+		-- Power events only mark dirty; re-derive here at most once per tick, plus first read and
+		-- precision changes.
+		local additionalPower = snapshotData.formatted.additionalPower
+		local mana = additionalPower and additionalPower["MANA"]
+		if mana == nil or mana.dirty or mana.precision ~= manaPrecision then
+			TRB.Functions.Character:UpdateAdditionalPowerValues("MANA")
+			mana = snapshotData.formatted.additionalPower["MANA"]
 		end
-		local manaMaxFormatted = TRB.Functions.String:ConvertToAbbreviatedNumber(normalizedManaMax)
-		if lookupChanged(prevState, "$manaMax", manaMaxFormatted, currentManaColor) then
-			lookup["$manaMax"] = string.format("|c%s%s|r", currentManaColor, manaMaxFormatted)
+		lookupLogic["$mana"] = mana.current
+		lookupLogic["$manaMax"] = mana.max
+		lookupLogic["$manaPercent"] = mana.percent
+		if lookupChanged(prevState, "$mana", mana.currentFormatted, currentManaColor) then
+			lookup["$mana"] = string.format("|c%s%s|r", currentManaColor, mana.currentFormatted)
 		end
-		local manaPercentFormatted = string.format("%." .. manaPrecision .. "f", manaPercentRaw)
-		if lookupChanged(prevState, "$manaPercent", manaPercentFormatted, currentManaColor) then
-			lookup["$manaPercent"] = string.format("|c%s%s|r", currentManaColor, manaPercentFormatted)
+		if lookupChanged(prevState, "$manaMax", mana.maxFormatted, currentManaColor) then
+			lookup["$manaMax"] = string.format("|c%s%s|r", currentManaColor, mana.maxFormatted)
+		end
+		if lookupChanged(prevState, "$manaPercent", mana.percentFormatted, currentManaColor) then
+			lookup["$manaPercent"] = string.format("|c%s%s|r", currentManaColor, mana.percentFormatted)
 		end
 	end
 

--- a/ClassModules/Shaman.lua
+++ b/ClassModules/Shaman.lua
@@ -358,7 +358,7 @@ local function RefreshLookupData_Elemental()
 		local additionalPower = snapshotData.formatted.additionalPower
 		local mana = additionalPower and additionalPower["MANA"]
 		if mana == nil or mana.dirty or mana.precision ~= manaPrecision then
-			TRB.Functions.Character:UpdateAdditionalPowerValues("MANA")
+			TRB.Functions.Character:UpdateAdditionalPowerValues("MANA", manaPrecision)
 			mana = snapshotData.formatted.additionalPower["MANA"]
 		end
 		lookupLogic["$mana"] = mana.current

--- a/ClassModules/Shaman.lua
+++ b/ClassModules/Shaman.lua
@@ -673,6 +673,27 @@ local function UpdateSnapshot_Restoration()
 	UpdateSnapshot()
 end
 
+
+-- Reused per-tick scratch tables for UpdateResourceBar (see conditionMap/barColorMap sites).
+-- Held in one table so UpdateResourceBar gains a single upvalue rather than one per site.
+local scratch = {
+	conditionMap1 = {},
+	maelstromBarColors1 = {},
+	barColorMap1 = {},
+	overcapCurves1 = {},
+	conditionMap2 = {},
+	manaBarColors1 = {},
+	barColorMap2 = {},
+	manaOvercapCurves1 = {},
+	conditionMap3 = {},
+	manaBarColors2 = {},
+	barColorMap3 = {},
+	conditionMap4 = {},
+	conditionMap5 = {},
+	manaBarColors3 = {},
+	barColorMap4 = {},
+}
+
 local function UpdateResourceBar()
 	local currentTime = GetTime()
 	local refreshText = false
@@ -741,15 +762,21 @@ local function UpdateResourceBar()
 				ascendanceEndMet = timeLeft <= timeThreshold
 			end
 
-			local conditionMap = {
-				ascendanceEnd = ascendanceActive and ascendanceEndMet,
-				earthShock = earthShockUsable,
-				earthquake = earthquakeUsable,
-				ascendance = ascendanceActive,
-				borderOvercap = affectingCombat,
-			}
-			local maelstromBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
-			local barColorMap = { maelstromBar = maelstromBarColors }
+			local conditionMap = scratch.conditionMap1
+			wipe(conditionMap)
+			conditionMap.ascendanceEnd = ascendanceActive and ascendanceEndMet
+			conditionMap.earthShock = earthShockUsable
+			conditionMap.earthquake = earthquakeUsable
+			conditionMap.ascendance = ascendanceActive
+			conditionMap.borderOvercap = affectingCombat
+			local maelstromBarColors = scratch.maelstromBarColors1
+			wipe(maelstromBarColors)
+			maelstromBarColors.bar = barColor
+			maelstromBarColors.border = barBorderColor
+			maelstromBarColors.background = barBackgroundColor
+			local barColorMap = scratch.barColorMap1
+			wipe(barColorMap)
+			barColorMap.maelstromBar = maelstromBarColors
 
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
 
@@ -864,7 +891,8 @@ local function UpdateResourceBar()
 				barBorderColor = maelstromBarColors.border
 				barBackgroundColor = maelstromBarColors.background
 
-				local overcapCurves = {}
+				local overcapCurves = scratch.overcapCurves1
+				wipe(overcapCurves)
 				if overcapIndicator and overcapIndicator.targets then
 					local maelstromTargets = overcapIndicator.targets.maelstromBar
 					if maelstromTargets then
@@ -953,19 +981,21 @@ local function UpdateResourceBar()
 						ascendanceEndMet = timeLeft <= timeThreshold
 					end
 
-					local conditionMap = {
-						ascendanceEnd = ascendanceActive and ascendanceEndMet,
-						earthShock = earthShockUsable,
-						earthquake = earthquakeUsable,
-						ascendance = ascendanceActive,
-						borderOvercap = affectingCombat,
-					}
-					local manaBarColors = {
-						bar = specSettings.colors.bars.mana.bar.color,
-						border = specSettings.colors.bars.mana.border.color,
-						background = specSettings.colors.bars.mana.background.color,
-					}
-					local barColorMap = { manaBar = manaBarColors }
+					local conditionMap = scratch.conditionMap2
+					wipe(conditionMap)
+					conditionMap.ascendanceEnd = ascendanceActive and ascendanceEndMet
+					conditionMap.earthShock = earthShockUsable
+					conditionMap.earthquake = earthquakeUsable
+					conditionMap.ascendance = ascendanceActive
+					conditionMap.borderOvercap = affectingCombat
+					local manaBarColors = scratch.manaBarColors1
+					wipe(manaBarColors)
+					manaBarColors.bar = specSettings.colors.bars.mana.bar.color
+					manaBarColors.border = specSettings.colors.bars.mana.border.color
+					manaBarColors.background = specSettings.colors.bars.mana.background.color
+					local barColorMap = scratch.barColorMap2
+					wipe(barColorMap)
+					barColorMap.manaBar = manaBarColors
 
 					TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
 
@@ -985,7 +1015,8 @@ local function UpdateResourceBar()
 					manaNode:SetValue(currentMana)
 					Bar:ApplyEndCapIndicator(manaNode, "manaBar")
 
-					local manaOvercapCurves = {}
+					local manaOvercapCurves = scratch.manaOvercapCurves1
+					wipe(manaOvercapCurves)
 					if overcapIndicator and overcapIndicator.targets then
 						local manaTargets = overcapIndicator.targets.manaBar
 						if manaTargets then
@@ -1054,12 +1085,18 @@ local function UpdateResourceBar()
 				ascendanceEndMet = timeLeft <= timeThreshold
 			end
 
-			local conditionMap = {
-				ascendanceEnd = ascendanceActive and ascendanceEndMet,
-				ascendance = ascendanceActive,
-			}
-			local manaBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
-			local barColorMap = { manaBar = manaBarColors }
+			local conditionMap = scratch.conditionMap3
+			wipe(conditionMap)
+			conditionMap.ascendanceEnd = ascendanceActive and ascendanceEndMet
+			conditionMap.ascendance = ascendanceActive
+			local manaBarColors = scratch.manaBarColors2
+			wipe(manaBarColors)
+			manaBarColors.bar = barColor
+			manaBarColors.border = barBorderColor
+			manaBarColors.background = barBackgroundColor
+			local barColorMap = scratch.barColorMap3
+			wipe(barColorMap)
+			barColorMap.manaBar = manaBarColors
 
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
 
@@ -1110,10 +1147,10 @@ local function UpdateResourceBar()
 						ascendanceEndMet = timeLeft <= timeThreshold
 					end
 
-					local conditionMap = {
-						ascendanceEnd = ascendanceActive and ascendanceEndMet,
-						ascendance = ascendanceActive,
-					}
+					local conditionMap = scratch.conditionMap4
+					wipe(conditionMap)
+					conditionMap.ascendanceEnd = ascendanceActive and ascendanceEndMet
+					conditionMap.ascendance = ascendanceActive
 					local mwBarOverride = nil
 					local mwBorderOverride = nil
 					local mwBackgroundOverride = nil
@@ -1299,12 +1336,18 @@ local function UpdateResourceBar()
 				ascendanceEndMet = timeLeft <= timeThreshold
 			end
 
-			local conditionMap = {
-				ascendanceEnd = ascendanceActive and ascendanceEndMet,
-				ascendance = ascendanceActive,
-			}
-			local manaBarColors = { bar = barColor, border = barBorderColor, background = barBackgroundColor }
-			local barColorMap = { manaBar = manaBarColors }
+			local conditionMap = scratch.conditionMap5
+			wipe(conditionMap)
+			conditionMap.ascendanceEnd = ascendanceActive and ascendanceEndMet
+			conditionMap.ascendance = ascendanceActive
+			local manaBarColors = scratch.manaBarColors3
+			wipe(manaBarColors)
+			manaBarColors.bar = barColor
+			manaBarColors.border = barBorderColor
+			manaBarColors.background = barBackgroundColor
+			local barColorMap = scratch.barColorMap4
+			wipe(barColorMap)
+			barColorMap.manaBar = manaBarColors
 
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
 

--- a/ClassModules/Shaman.lua
+++ b/ClassModules/Shaman.lua
@@ -805,8 +805,16 @@ local function UpdateResourceBar()
 						thresholds = primaryNode:GetThresholds()
 					end
 					pairOffset = (thresholdId - 1) * 3
-					local resourceAmount = spell:GetPrimaryResourceCost()
-					local isUsable = spell:IsUsable()
+					-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+					-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+					local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+					local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+						or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+					local resourceAmount, isUsable = 0, false
+					if thresholdActive then
+						resourceAmount = spell:GetPrimaryResourceCost()
+						isUsable = spell:IsUsable()
+					end
 					local showThreshold = true
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
 					local frameLevel = frameLevels.thresholdOver

--- a/ClassModules/Warlock.lua
+++ b/ClassModules/Warlock.lua
@@ -1517,9 +1517,6 @@ local function UpdateResourceBar()
 			manaBarColors.background = specSettings.colors.bar.background.color
 			local soulShardsOverride = scratch.soulShardsOverride1
 			wipe(soulShardsOverride)
-			soulShardsOverride.bar = nil
-			soulShardsOverride.border = nil
-			soulShardsOverride.background = nil
 			local barColorMap = scratch.barColorMap1
 			wipe(barColorMap)
 			barColorMap.manaBar = manaBarColors
@@ -1602,9 +1599,6 @@ local function UpdateResourceBar()
 			manaBarColors.background = specSettings.colors.bar.background.color
 			local soulShardsOverride = scratch.soulShardsOverride2
 			wipe(soulShardsOverride)
-			soulShardsOverride.bar = nil
-			soulShardsOverride.border = nil
-			soulShardsOverride.background = nil
 			local barColorMap = scratch.barColorMap2
 			wipe(barColorMap)
 			barColorMap.manaBar = manaBarColors
@@ -1669,9 +1663,6 @@ local function UpdateResourceBar()
 			manaBarColors.background = specSettings.colors.bar.background.color
 			local soulShardsOverride = scratch.soulShardsOverride3
 			wipe(soulShardsOverride)
-			soulShardsOverride.bar = nil
-			soulShardsOverride.border = nil
-			soulShardsOverride.background = nil
 			local barColorMap = scratch.barColorMap3
 			wipe(barColorMap)
 			barColorMap.manaBar = manaBarColors

--- a/ClassModules/Warlock.lua
+++ b/ClassModules/Warlock.lua
@@ -1234,6 +1234,24 @@ function TRB.Functions.Class:DisableEvents()
 	spellEventFrame:UnregisterEvent("SPELL_ACTIVATION_OVERLAY_GLOW_HIDE")
 end
 
+
+-- Reused per-tick scratch tables for UpdateResourceBar (see conditionMap/barColorMap sites).
+-- Held in one table so UpdateResourceBar gains a single upvalue rather than one per site.
+local scratch = {
+	conditionMap1 = {},
+	manaBarColors1 = {},
+	soulShardsOverride1 = {},
+	barColorMap1 = {},
+	conditionMap2 = {},
+	manaBarColors2 = {},
+	soulShardsOverride2 = {},
+	barColorMap2 = {},
+	conditionMap3 = {},
+	manaBarColors3 = {},
+	soulShardsOverride3 = {},
+	barColorMap3 = {},
+}
+
 local function UpdateResourceBar()
 	local refreshText = false
 	local coreSettings = TRB.Data.settings.core
@@ -1488,13 +1506,24 @@ local function UpdateResourceBar()
 			-- No talent gate: a buff that is up is proof enough the talent is taken, and the talent
 			-- lookup keys off the spell ID, which is not guaranteed to be the tree's node ID.
 			local shardInstabilitySnapshot = snapshots[spells.shardInstability.id]
-			local conditionMap = {
-				shardInstability = shardInstabilitySnapshot ~= nil and shardInstabilitySnapshot.buff.isActive == true,
-			}
+			local conditionMap = scratch.conditionMap1
+			wipe(conditionMap)
+			conditionMap.shardInstability = shardInstabilitySnapshot ~= nil and shardInstabilitySnapshot.buff.isActive == true
 
-			local manaBarColors = { bar = specSettings.colors.bar.base, border = specSettings.colors.bar.border.color, background = specSettings.colors.bar.background.color }
-			local soulShardsOverride = { bar = nil, border = nil, background = nil }
-			local barColorMap = { manaBar = manaBarColors, soulShardsBar = soulShardsOverride }
+			local manaBarColors = scratch.manaBarColors1
+			wipe(manaBarColors)
+			manaBarColors.bar = specSettings.colors.bar.base
+			manaBarColors.border = specSettings.colors.bar.border.color
+			manaBarColors.background = specSettings.colors.bar.background.color
+			local soulShardsOverride = scratch.soulShardsOverride1
+			wipe(soulShardsOverride)
+			soulShardsOverride.bar = nil
+			soulShardsOverride.border = nil
+			soulShardsOverride.background = nil
+			local barColorMap = scratch.barColorMap1
+			wipe(barColorMap)
+			barColorMap.manaBar = manaBarColors
+			barColorMap.soulShardsBar = soulShardsOverride
 
 			-- Apply flat indicator colors (priority order, last writer wins)
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
@@ -1558,17 +1587,28 @@ local function UpdateResourceBar()
 				doaEndMet = doaSnapshot.buff.remaining <= timeThreshold
 			end
 
-			local conditionMap = {
-				dominionOfArgusEnd = doaActive and doaEndMet,
-				dominionOfArgus = doaActive,
-				demonicCore = snapshotData.snapshots[spells.demonicCore.id] ~= nil and snapshotData.snapshots[spells.demonicCore.id].buff.isActive,
-				infernalBolt = snapshotData.snapshots[spells.infernalBolt.id] ~= nil and snapshotData.snapshots[spells.infernalBolt.id].buff.isActive,
-				ruination = snapshotData.snapshots[spells.ruination.id] ~= nil and snapshotData.snapshots[spells.ruination.id].buff.isActive,
-			}
+			local conditionMap = scratch.conditionMap2
+			wipe(conditionMap)
+			conditionMap.dominionOfArgusEnd = doaActive and doaEndMet
+			conditionMap.dominionOfArgus = doaActive
+			conditionMap.demonicCore = snapshotData.snapshots[spells.demonicCore.id] ~= nil and snapshotData.snapshots[spells.demonicCore.id].buff.isActive
+			conditionMap.infernalBolt = snapshotData.snapshots[spells.infernalBolt.id] ~= nil and snapshotData.snapshots[spells.infernalBolt.id].buff.isActive
+			conditionMap.ruination = snapshotData.snapshots[spells.ruination.id] ~= nil and snapshotData.snapshots[spells.ruination.id].buff.isActive
 
-			local manaBarColors = { bar = specSettings.colors.bar.base, border = specSettings.colors.bar.border.color, background = specSettings.colors.bar.background.color }
-			local soulShardsOverride = { bar = nil, border = nil, background = nil }
-			local barColorMap = { manaBar = manaBarColors, soulShardsBar = soulShardsOverride }
+			local manaBarColors = scratch.manaBarColors2
+			wipe(manaBarColors)
+			manaBarColors.bar = specSettings.colors.bar.base
+			manaBarColors.border = specSettings.colors.bar.border.color
+			manaBarColors.background = specSettings.colors.bar.background.color
+			local soulShardsOverride = scratch.soulShardsOverride2
+			wipe(soulShardsOverride)
+			soulShardsOverride.bar = nil
+			soulShardsOverride.border = nil
+			soulShardsOverride.background = nil
+			local barColorMap = scratch.barColorMap2
+			wipe(barColorMap)
+			barColorMap.manaBar = manaBarColors
+			barColorMap.soulShardsBar = soulShardsOverride
 
 			-- Apply flat indicator colors (priority order, last writer wins)
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
@@ -1617,14 +1657,25 @@ local function UpdateResourceBar()
 			local sharedColors = specSettings.colors.shared
 			local indicatorColors = sharedColors and sharedColors.indicatorColors
 
-			local conditionMap = {
-				infernalBolt = snapshots[spells.infernalBolt.id] ~= nil and snapshots[spells.infernalBolt.id].buff.isActive,
-				ruination = snapshots[spells.ruination.id] ~= nil and snapshots[spells.ruination.id].buff.isActive,
-			}
+			local conditionMap = scratch.conditionMap3
+			wipe(conditionMap)
+			conditionMap.infernalBolt = snapshots[spells.infernalBolt.id] ~= nil and snapshots[spells.infernalBolt.id].buff.isActive
+			conditionMap.ruination = snapshots[spells.ruination.id] ~= nil and snapshots[spells.ruination.id].buff.isActive
 
-			local manaBarColors = { bar = specSettings.colors.bar.base, border = specSettings.colors.bar.border.color, background = specSettings.colors.bar.background.color }
-			local soulShardsOverride = { bar = nil, border = nil, background = nil }
-			local barColorMap = { manaBar = manaBarColors, soulShardsBar = soulShardsOverride }
+			local manaBarColors = scratch.manaBarColors3
+			wipe(manaBarColors)
+			manaBarColors.bar = specSettings.colors.bar.base
+			manaBarColors.border = specSettings.colors.bar.border.color
+			manaBarColors.background = specSettings.colors.bar.background.color
+			local soulShardsOverride = scratch.soulShardsOverride3
+			wipe(soulShardsOverride)
+			soulShardsOverride.bar = nil
+			soulShardsOverride.border = nil
+			soulShardsOverride.background = nil
+			local barColorMap = scratch.barColorMap3
+			wipe(barColorMap)
+			barColorMap.manaBar = manaBarColors
+			barColorMap.soulShardsBar = soulShardsOverride
 
 			-- Apply flat indicator colors (priority order, last writer wins)
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)

--- a/ClassModules/Warrior.lua
+++ b/ClassModules/Warrior.lua
@@ -1316,6 +1316,15 @@ local function UpdateWhirlwindCharges(specSettings, specCacheSettings)
 	end
 end
 
+
+-- Reused per-tick scratch tables for UpdateResourceBar (see conditionMap/barColorMap sites).
+-- Held in one table so UpdateResourceBar gains a single upvalue rather than one per site.
+local scratch = {
+	conditionMap1 = {},
+	conditionMap2 = {},
+	conditionMap3 = {},
+}
+
 local function UpdateResourceBar()
 	local currentTime = GetTime()
 	local refreshText = false
@@ -1365,9 +1374,9 @@ local function UpdateResourceBar()
 			local sharedColors = specSettings.colors.shared
 			local indicatorColors = sharedColors and sharedColors.indicatorColors
 			local gradientOrder = sharedColors and sharedColors.gradientOrder
-			local conditionMap = {
-				borderOvercap = affectingCombat,
-			}
+			local conditionMap = scratch.conditionMap1
+			wipe(conditionMap)
+			conditionMap.borderOvercap = affectingCombat
 			-- The rage bar is colored bespoke below; the resolver is here for the shared health/cast bar.
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, nil)
 
@@ -1607,11 +1616,11 @@ local function UpdateResourceBar()
 					end
 				end
 			end
-			local conditionMap = {
-				borderOvercap = affectingCombat,
-				zeroStackBackground = zeroStackActive,
-				enrage = enrageActive,
-			}
+			local conditionMap = scratch.conditionMap2
+			wipe(conditionMap)
+			conditionMap.borderOvercap = affectingCombat
+			conditionMap.zeroStackBackground = zeroStackActive
+			conditionMap.enrage = enrageActive
 
 			local enrageBarColors = specSettings.colors.bars and specSettings.colors.bars.enrage
 			local enrageColors = {
@@ -1841,10 +1850,10 @@ local function UpdateResourceBar()
 			local sharedColors = specSettings.colors.shared
 			local indicatorColors = sharedColors and sharedColors.indicatorColors
 			local gradientOrder = sharedColors and sharedColors.gradientOrder
-			local conditionMap = {
-				borderOvercap = affectingCombat,
-				violentOutburst = snapshotData.snapshots[spells.violentOutburst.id] ~= nil and snapshotData.snapshots[spells.violentOutburst.id].buff.isActive,
-			}
+			local conditionMap = scratch.conditionMap3
+			wipe(conditionMap)
+			conditionMap.borderOvercap = affectingCombat
+			conditionMap.violentOutburst = snapshotData.snapshots[spells.violentOutburst.id] ~= nil and snapshotData.snapshots[spells.violentOutburst.id].buff.isActive
 			-- The rage bar is colored bespoke below; the resolver is here for the shared health/cast bar.
 			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, nil)
 

--- a/ClassModules/Warrior.lua
+++ b/ClassModules/Warrior.lua
@@ -1323,6 +1323,8 @@ local scratch = {
 	conditionMap1 = {},
 	conditionMap2 = {},
 	conditionMap3 = {},
+	enrageColors1 = {},
+	barColorMap1 = {},
 }
 
 local function UpdateResourceBar()
@@ -1623,16 +1625,19 @@ local function UpdateResourceBar()
 			conditionMap.enrage = enrageActive
 
 			local enrageBarColors = specSettings.colors.bars and specSettings.colors.bars.enrage
-			local enrageColors = {
-				-- The whole entry, not just its string: ApplyFillColor only reaches its gradient branch
-				-- for a table, the same way the primary bar's base color is passed.
-				bar = enrageBarColors and enrageBarColors.bar,
-				border = enrageBarColors and enrageBarColors.border.color,
-				background = enrageBarColors and enrageBarColors.background.color,
-			}
+			-- The whole entry, not just its string: ApplyFillColor only reaches its gradient branch
+			-- for a table, the same way the primary bar's base color is passed.
+			local enrageColors = scratch.enrageColors1
+			wipe(enrageColors)
+			enrageColors.bar = enrageBarColors and enrageBarColors.bar
+			enrageColors.border = enrageBarColors and enrageBarColors.border.color
+			enrageColors.background = enrageBarColors and enrageBarColors.background.color
 			-- The rage and Whirlwind bars are colored bespoke above; the resolver covers the Enrage bar
 			-- along with the shared health/cast bar.
-			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, { enrageBar = enrageColors })
+			local barColorMap = scratch.barColorMap1
+			wipe(barColorMap)
+			barColorMap.enrageBar = enrageColors
+			TRB.Functions.Color:ApplyIndicatorColors(sharedColors, conditionMap, barColorMap)
 
 			if not specSettings.displayBar.primary.neverShow then
 				refreshText = true

--- a/ClassModules/Warrior.lua
+++ b/ClassModules/Warrior.lua
@@ -1406,8 +1406,16 @@ local function UpdateResourceBar()
 						thresholds = primaryNode:GetThresholds()
 					end
 					pairOffset = (thresholdId - 1) * 3
-					local resourceAmount = spell:GetPrimaryResourceCost()
-					local isUsable = spell:IsUsable()
+					-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+					-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+					local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+					local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+						or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+					local resourceAmount, isUsable = 0, false
+					if thresholdActive then
+						resourceAmount = spell:GetPrimaryResourceCost()
+						isUsable = spell:IsUsable()
+					end
 					local showThreshold = true
 							---@type string?
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
@@ -1662,8 +1670,16 @@ local function UpdateResourceBar()
 						thresholds = primaryNode:GetThresholds()
 					end
 					pairOffset = (thresholdId - 1) * 3
-					local resourceAmount = spell:GetPrimaryResourceCost()
-					local isUsable = spell:IsUsable()
+					-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+					-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+					local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+					local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+						or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+					local resourceAmount, isUsable = 0, false
+					if thresholdActive then
+						resourceAmount = spell:GetPrimaryResourceCost()
+						isUsable = spell:IsUsable()
+					end
 					local showThreshold = true
 					---@type string?
 					local thresholdColor = specCacheSettings.colors.threshold.over.color
@@ -1885,8 +1901,16 @@ local function UpdateResourceBar()
 						thresholds = primaryNode:GetThresholds()
 					end
 					pairOffset = (thresholdId - 1) * 3
-					local resourceAmount = spell:GetPrimaryResourceCost()
-					local isUsable = spell:IsUsable()
+					-- Nothing below reads these unless the line draws or its own audio cue fires, and both
+					-- calls can reach the WoW API. A missing dictionary entry stays active, as before.
+					local thresholdSettings = specCacheSettings.thresholds.thresholdDictionary[spell.settingKey]
+					local thresholdActive = thresholdSettings == nil or thresholdSettings.enabled == true
+						or (thresholdSettings.audio ~= nil and thresholdSettings.audio.enabled == true and thresholdSettings.audio.sound ~= nil)
+					local resourceAmount, isUsable = 0, false
+					if thresholdActive then
+						resourceAmount = spell:GetPrimaryResourceCost()
+						isUsable = spell:IsUsable()
+					end
 					local showThreshold = true
 					---@type string?
 					local thresholdColor = specCacheSettings.colors.threshold.over.color

--- a/Classes/Spell.lua
+++ b/Classes/Spell.lua
@@ -322,7 +322,8 @@ function TRB.Classes.SpellBase:GetPrimaryResourceCost(dontReturnLastNonZero, ind
 		    self:GetCacheKey()
         end
 
-		if TRB.Data.cache.values.resource[self._cacheKey] == nil then
+		local cachedCost = TRB.Data.cache.values.resource[self._cacheKey]
+		if cachedCost == nil then
 			local spc = C_Spell.GetSpellPowerCost(self.id)
 			if spc ~= nil then
 				for x = 1, #spc do
@@ -340,12 +341,15 @@ function TRB.Classes.SpellBase:GetPrimaryResourceCost(dontReturnLastNonZero, ind
 					end
 				end
 			end
-		else
-			if TRB.Data.cache.values.resource[self._cacheKey] == 0 then
-				self._isFreeCurrently = true
-			else
-				return TRB.Data.cache.values.resource[self._cacheKey]
+			-- Remember a lookup that matched nothing, or this spell re-queries the API on every
+			-- call until the next aura-driven wipe while costed spells only query once.
+			if TRB.Data.cache.values.resource[self._cacheKey] == nil then
+				TRB.Data.cache.values.resource[self._cacheKey] = false
 			end
+		elseif cachedCost == 0 then
+			self._isFreeCurrently = true
+		elseif cachedCost ~= false then
+			return cachedCost
 		end
 	elseif self.primaryResourceTypeProperty == "custom" then
 		return self.primaryResourceTypePropertyValue

--- a/Classes/Spell.lua
+++ b/Classes/Spell.lua
@@ -465,12 +465,11 @@ function TRB.Classes.SpellBase:InsufficientPower()
 end
 
 ---Updates IsSpellUsable cache.
----@param force boolean? # Force the update even if within embargo timespan
-function TRB.Classes.SpellBase:UpdateIsSpellUsable(force)
+function TRB.Classes.SpellBase:UpdateIsSpellUsable()
 	local currentTime = GetTime()
+	-- A cache hit must not re-stamp _lastSpellUsableCheck, or frequent callers starve the real check.
 	if (self._lastSpellUsableCheck or 0) + spellUsableEmbargoTimespan > currentTime then
-		self._lastSpellUsableCheck = currentTime
-		return self._isUsable
+		return
 	end
 
 	local isUsable, insufficientPower = C_Spell.IsSpellUsable(self.id)

--- a/Classes/Spell.lua
+++ b/Classes/Spell.lua
@@ -111,6 +111,7 @@ end
 ---@field private _lastPrimaryResourceValueCheck number? # Timestamp of the last time a check was done
 ---@field private _isFreeCurrently boolean # Is this ability free now when it usually has a resource cost?
 ---@field private _lastSpellUsableCheck number? # Timestamp of the last time a spell usability check was done
+---@field private _spellUsableGeneration number? # SPELL_UPDATE_USABLE generation the cached usability was read at
 ---@field private _isUsable boolean # Is the spell usable currently
 ---@field private _insufficientPower boolean # Is there insufficient power to cast the spell currently
 ---@field private _cacheKey string # Key used to cache the primary resource cost of the spell
@@ -448,7 +449,15 @@ function TRB.Classes.SpellBase:ResetCastTime()
 	self._isInstantCurrently = false
 end
 
-local spellUsableEmbargoTimespan = 0.05
+-- Usability only moves when SPELL_UPDATE_USABLE fires, so spells re-poll on generation change
+-- rather than on a timer. The floor is a backstop for a missed event, not the primary mechanism.
+local spellUsableGeneration = 0
+local spellUsableFloorTimespan = 1.0
+
+---Marks every spell's cached usability stale. Called from the SPELL_UPDATE_USABLE handler.
+function TRB.Classes.SpellBase.InvalidateSpellUsable()
+	spellUsableGeneration = spellUsableGeneration + 1
+end
 
 ---Gets whether the spell is currently usable.
 ---@return boolean # Is the spell usable
@@ -467,8 +476,9 @@ end
 ---Updates IsSpellUsable cache.
 function TRB.Classes.SpellBase:UpdateIsSpellUsable()
 	local currentTime = GetTime()
-	-- A cache hit must not re-stamp _lastSpellUsableCheck, or frequent callers starve the real check.
-	if (self._lastSpellUsableCheck or 0) + spellUsableEmbargoTimespan > currentTime then
+	-- A cache hit must not re-stamp _lastSpellUsableCheck, or the floor never expires.
+	if self._spellUsableGeneration == spellUsableGeneration
+		and (self._lastSpellUsableCheck or 0) + spellUsableFloorTimespan > currentTime then
 		return
 	end
 
@@ -477,6 +487,7 @@ function TRB.Classes.SpellBase:UpdateIsSpellUsable()
 	self._isUsable = isUsable
 	self._insufficientPower = insufficientPower
 	self._lastSpellUsableCheck = currentTime
+	self._spellUsableGeneration = spellUsableGeneration
 end
 
 ---Determines if the current SpellBase is also another type, such as SpellThreshold.

--- a/Functions/BarText.lua
+++ b/Functions/BarText.lua
@@ -261,6 +261,7 @@ local barTextCacheHash = {}
 -- last plan, color and argument values for the unchanged-skip.
 local barTextRenderPlans = {}
 local barTextEntryStates = {}
+local barTextSignatureFns = {}
 
 ---Returns true if the value or color has changed for this key, indicating the
 ---formatted lookup string needs updating. Reuses existing prevState entries to
@@ -314,6 +315,7 @@ function TRB.Functions.BarText:ClearBarTextCacheHash()
 	for k in pairs(barTextCacheHash) do barTextCacheHash[k] = nil end
 	wipe(barTextRenderPlans)
 	wipe(barTextEntryStates)
+	wipe(barTextSignatureFns)
 end
 
 ---Scans all enabled bar text entries and builds a set of which $variable and #icon
@@ -1139,12 +1141,13 @@ local function GetFromBarTextTreeCache(input)
 end
 
 
----Compiles a conditional expression node into a reusable Lua function.
----The compiled function accepts variable values as positional arguments, eliminating
----the need to rebuild the expression string and call loadstring() every frame.
+---Builds the normalized Lua expression template and positional variable bindings for a
+---conditional node. Shared by the interpreted compiler and the entry codegen.
 ---@param node table A conditional node from the bar text tree
----@return table compiledExpression { fn, varCount, varInfos } or { invalid = true }
-local function CompileConditionalExpression(node)
+---@return string templateString
+---@return table varInfos
+---@return integer varCount
+local function BuildConditionalTemplate(node)
 	local templateParts = {}
 	local varInfos = {}
 	local varCount = 0
@@ -1208,15 +1211,30 @@ local function CompileConditionalExpression(node)
 	templateString = string.gsub(templateString, "&", " and ")
 	templateString = string.gsub(templateString, "||", " or ")
 
-	-- Build the compiled function with positional parameters
+	return templateString, varInfos, varCount
+end
+
+---Builds "function(v1,...) return ( <template> ) end" source for a conditional template.
+---@param templateString string
+---@param varCount integer
+---@return string
+local function BuildConditionalFunctionSource(templateString, varCount)
 	local paramList = {}
 	for i = 1, varCount do
 		paramList[i] = "v" .. i
 	end
 	local paramString = table.concat(paramList, ",")
-	local funcSource = "return function(" .. paramString .. ") return (" .. templateString .. ") end"
+	return "function(" .. paramString .. ") return (" .. templateString .. ") end"
+end
 
-	local chunk = loadstring(funcSource)
+---Compiles a conditional expression node into a reusable Lua function.
+---The compiled function accepts variable values as positional arguments, eliminating
+---the need to rebuild the expression string and call loadstring() every frame.
+---@param node table A conditional node from the bar text tree
+---@return table compiledExpression { fn, varCount, varInfos } or { invalid = true }
+local function CompileConditionalExpression(node)
+	local templateString, varInfos, varCount = BuildConditionalTemplate(node)
+	local chunk = loadstring("return " .. BuildConditionalFunctionSource(templateString, varCount))
 	if chunk then
 		local ok, evalFn = pcall(chunk)
 		if ok and type(evalFn) == "function" then
@@ -1608,6 +1626,122 @@ local function AppendTreeSignature(tree, len)
 	return len
 end
 
+-- Conditionals per entry are capped so numeric signatures (2 bits each) stay exact integers.
+local maxSignatureNodes = 26
+
+---Emits signature-walk source for one tree level: inline arg fetch, secret sanitize, expression
+---eval (pcall only when the expression can raise) and branch dispatch accumulating a base-4 sig.
+---@param tree table
+---@param out table Body lines
+---@param preamble table Hoisted expression function definitions
+---@param indent string
+---@param k integer Next node index
+---@return integer|nil k Next node index, or nil when the entry cannot be compiled
+local function EmitTreeSignatureSource(tree, out, preamble, indent, k)
+	if tree == nil or tree.barText == nil then
+		return k
+	end
+	local barText = tree.barText
+	for idx = 1, #barText do
+		local v = barText[idx]
+		if type(v) ~= "string" then
+			if k >= maxSignatureNodes then
+				return nil
+			end
+			local addT = string.format("%.0f", 1 * 4 ^ k)
+			local addF = string.format("%.0f", 2 * 4 ^ k)
+			local addI = string.format("%.0f", 3 * 4 ^ k)
+			local templateString, varInfos, varCount = BuildConditionalTemplate(v)
+			local exprSource = BuildConditionalFunctionSource(templateString, varCount)
+			if loadstring("return " .. exprSource) == nil then
+				-- Statically invalid logic always resolves to the INVALID outcome.
+				out[#out + 1] = indent .. "sig = sig + " .. addI
+				k = k + 1
+			else
+				local argNames = {}
+				for i = 1, varCount do
+					local info = varInfos[i]
+					local an = "a" .. k .. "_" .. i
+					argNames[i] = an
+					out[#out + 1] = indent .. "local " .. an .. " = Class:IsValidVariableForSpec(" .. string.format("%q", info.variable) .. ")"
+					if info.useLookupLogic then
+						local ln = "l" .. k .. "_" .. i
+						out[#out + 1] = indent .. "local " .. ln .. " = logic[" .. string.format("%q", info.variable) .. "]"
+						out[#out + 1] = indent .. "if " .. ln .. " then " .. an .. " = " .. ln .. " if issecretvalue(" .. an .. ") then " .. an .. " = false end end"
+					end
+				end
+				-- Pure boolean expressions cannot raise, so they inline without pcall.
+				local safe = true
+				for token in string.gmatch(templateString, "[^%s%(%)]+") do
+					if token ~= "and" and token ~= "or" and token ~= "not" and string.match(token, "^v%d+$") == nil then
+						safe = false
+						break
+					end
+				end
+				local nextIndent = indent .. "\t"
+				local rName = "r" .. k
+				if safe then
+					local inlined = string.gsub(templateString, "v(%d+)", "a" .. k .. "_%1")
+					out[#out + 1] = indent .. "local " .. rName .. " = (" .. inlined .. ")"
+					out[#out + 1] = indent .. "if " .. rName .. " then"
+				else
+					preamble[#preamble + 1] = "local e" .. k .. " = " .. exprSource
+					local callArgs = varCount > 0 and (", " .. table.concat(argNames, ", ")) or ""
+					out[#out + 1] = indent .. "local ok" .. k .. ", " .. rName .. " = pcall(e" .. k .. callArgs .. ")"
+					out[#out + 1] = indent .. "if not ok" .. k .. " then"
+					out[#out + 1] = nextIndent .. "sig = sig + " .. addI
+					out[#out + 1] = indent .. "elseif " .. rName .. " then"
+				end
+				out[#out + 1] = nextIndent .. "sig = sig + " .. addT
+				k = EmitTreeSignatureSource(v.trueResult, out, preamble, nextIndent, k + 1)
+				if k == nil then
+					return nil
+				end
+				out[#out + 1] = indent .. "else"
+				out[#out + 1] = nextIndent .. "sig = sig + " .. addF
+				if v.falseResult ~= nil then
+					k = EmitTreeSignatureSource(v.falseResult, out, preamble, nextIndent, k)
+					if k == nil then
+						return nil
+					end
+				end
+				out[#out + 1] = indent .. "end"
+			end
+		end
+	end
+	return k
+end
+
+---Compiles an entry's tree into a signature closure. Returns 0 for trees with no conditionals,
+---or nil when codegen is not possible (the interpreted walk handles those).
+---@param tree table
+---@return function|integer|nil
+local function CompileEntrySignatureFn(tree)
+	local out = {}
+	local preamble = {}
+	local count = EmitTreeSignatureSource(tree, out, preamble, "\t", 0)
+	if count == nil then
+		return nil
+	end
+	if count == 0 then
+		return 0
+	end
+	local src = "local issecretvalue, pcall = issecretvalue, pcall\n"
+		.. table.concat(preamble, "\n") .. (#preamble > 0 and "\n" or "")
+		.. "return function(Class, logic)\nlocal sig = 0\n"
+		.. table.concat(out, "\n")
+		.. "\nreturn sig\nend"
+	local chunk = loadstring(src)
+	if chunk == nil then
+		return nil
+	end
+	local ok, fn = pcall(chunk)
+	if ok and type(fn) == "function" then
+		return fn
+	end
+	return nil
+end
+
 ---Renders one bar text entry via the signature-keyed plan cache. Plans are built once by the
 ---legacy resolver so their skeletons match it exactly; after that a tick only re-reads the
 ---plan's variable values and skips the format entirely when nothing changed.
@@ -1617,9 +1751,28 @@ end
 ---@param force boolean True bypasses the unchanged-skip
 ---@return string|nil output The formatted text, or nil when unchanged and not forced
 local function RenderBarTextEntry(state, text, colorCode, force)
-	local tree = GetFromBarTextTreeCache(text)
-	local len = AppendTreeSignature(tree, 0)
-	local signature = len == 0 and "" or table.concat(signatureBuffer, "", 1, len)
+	local signature
+	local sigFn = state.sigFn
+	if sigFn == nil then
+		sigFn = barTextSignatureFns[text]
+		if sigFn == nil then
+			sigFn = CompileEntrySignatureFn(GetFromBarTextTreeCache(text))
+			if sigFn == nil then
+				sigFn = false
+			end
+			barTextSignatureFns[text] = sigFn
+		end
+		state.sigFn = sigFn
+	end
+	if sigFn == 0 then
+		signature = 0
+	elseif sigFn ~= false then
+		signature = sigFn(TRB.Functions.Class, TRB.Data.lookupLogic)
+	else
+		-- Interpreted fallback for entries codegen cannot handle.
+		local len = AppendTreeSignature(GetFromBarTextTreeCache(text), 0)
+		signature = len == 0 and "" or table.concat(signatureBuffer, "", 1, len)
+	end
 
 	local plans = barTextRenderPlans[text]
 	if plans == nil then
@@ -1628,7 +1781,7 @@ local function RenderBarTextEntry(state, text, colorCode, force)
 	end
 	local plan = plans[signature]
 	if plan == nil then
-		plan = GetFromBarTextCache(RemoveInvalidVariablesFromBarText(tree))
+		plan = GetFromBarTextCache(RemoveInvalidVariablesFromBarText(GetFromBarTextTreeCache(text)))
 		plans[signature] = plan
 	end
 

--- a/Functions/BarText.lua
+++ b/Functions/BarText.lua
@@ -1574,6 +1574,30 @@ local function AreSecondaryRatingsNil()
 	return false
 end
 
+-- "%.Nf" strings memoized by precision so per-tick refreshes skip rebuilding them.
+local precisionFormatCache = {}
+local function GetPrecisionFormat(precision)
+	local fmt = precisionFormatCache[precision]
+	if fmt == nil then
+		fmt = "%." .. precision .. "f"
+		precisionFormatCache[precision] = fmt
+	end
+	return fmt
+end
+
+-- Unit descriptors for RefreshTargetCastbarLookupData, hoisted with precomputed variable names so
+-- the per-tick refresh allocates nothing.
+local targetCastbarLookupUnits = {
+	{ modelKey = "targetCastbar", nameVar = "$targetCastingSpellName", timeVar = "$targetCastTime", remVar = "$targetCastTimeRemaining", iconVar = "#targetCasting" },
+	{ modelKey = "focusCastbar", nameVar = "$focusCastingSpellName", timeVar = "$focusCastTime", remVar = "$focusCastTimeRemaining", iconVar = "#focusCasting" },
+}
+
+-- Idle short-circuit state for the castbar/other-bars refreshers: their idle writes are constants,
+-- so an idle refresher runs one final blanking pass (or the initial one) and then skips entirely.
+local castbarLookupWasActive = true
+local targetCastbarLookupWasActive = true
+local otherBarsLookupWasActive = true
+
 ---Refreshes ONLY the castbar bar text lookup variables (cast/channel/empower) from the dedicated
 ---castbar model (TRB.Data.castbar) — deliberately independent of snapshotData.casting, which is the
 ---resource-prediction path. Values default to empty/zero when nothing is casting. Called from
@@ -1583,21 +1607,26 @@ end
 ---use latencyPrecision. All values are seconds ($castLatencyMs is always whole milliseconds).
 ---@param settings TRB.Classes.Settings.SpecializationSettingsBase? # Active spec settings (for bars.castbar precision fields)
 function TRB.Functions.BarText:RefreshCastbarLookupData(settings)
+	local castbar = TRB.Data.castbar
+	local isActive = castbar ~= nil and castbar:IsActive()
+	if not isActive and not castbarLookupWasActive then
+		return
+	end
+	castbarLookupWasActive = isActive
 	TRB.Data.lookup = TRB.Data.lookup or {}
 	TRB.Data.lookupLogic = TRB.Data.lookupLogic or {}
 	local lookup = TRB.Data.lookup
 	local lookupLogic = TRB.Data.lookupLogic
 	---@diagnostic disable-next-line: undefined-field
 	local castbarSettings = settings and settings.bars and settings.bars.castbar
-	local castTimeFormat = "%." .. ((castbarSettings and castbarSettings.castTimePrecision) or 1) .. "f"
-	local durationFormat = "%." .. ((castbarSettings and castbarSettings.durationPrecision) or 1) .. "f"
-	local latencyFormat = "%." .. ((castbarSettings and castbarSettings.latencyPrecision) or 1) .. "f"
+	local castTimeFormat = GetPrecisionFormat((castbarSettings and castbarSettings.castTimePrecision) or 1)
+	local durationFormat = GetPrecisionFormat((castbarSettings and castbarSettings.durationPrecision) or 1)
+	local latencyFormat = GetPrecisionFormat((castbarSettings and castbarSettings.latencyPrecision) or 1)
 
-	local castbar = TRB.Data.castbar
 	local castTime, castRemaining, castLatency, castPushback = 0, 0, 0, 0
 	local castSpellName, castSpellId = "", 0
 	local isCasting, notInterruptible = false, false
-	if castbar and castbar:IsActive() then
+	if isActive then
 		local _, remaining, duration = castbar:GetProgress()
 		isCasting = true
 		notInterruptible = castbar.notInterruptible == true
@@ -1652,17 +1681,24 @@ end
 ---arithmetic/comparison conditional engine.
 ---@param settings TRB.Classes.Settings.SpecializationSettingsBase?
 function TRB.Functions.BarText:RefreshTargetCastbarLookupData(settings)
+	local targetModel = TRB.Data.targetCastbar
+	local focusModel = TRB.Data.focusCastbar
+	local isActive = (targetModel ~= nil and targetModel:IsActive()) or (focusModel ~= nil and focusModel:IsActive())
+	if not isActive and not targetCastbarLookupWasActive then
+		return
+	end
+	targetCastbarLookupWasActive = isActive
 	TRB.Data.lookup = TRB.Data.lookup or {}
 	local lookup = TRB.Data.lookup
-	for _, u in ipairs({ { prefix = "target", modelKey = "targetCastbar" }, { prefix = "focus", modelKey = "focusCastbar" } }) do
+	for _, u in ipairs(targetCastbarLookupUnits) do
 		local model = TRB.Data[u.modelKey]
 		local barSettings = settings and settings.bars and settings.bars[u.modelKey] --[[@as TRB.Classes.Settings.CastbarBar?]]
-		local remFmt = "%." .. ((barSettings and barSettings.castTimePrecision) or 1) .. "f"
-		local durFmt = "%." .. ((barSettings and barSettings.durationPrecision) or 1) .. "f"
-		local nameVar = "$" .. u.prefix .. "CastingSpellName"
-		local timeVar = "$" .. u.prefix .. "CastTime"
-		local remVar = "$" .. u.prefix .. "CastTimeRemaining"
-		local iconVar = "#" .. u.prefix .. "Casting"
+		local remFmt = GetPrecisionFormat((barSettings and barSettings.castTimePrecision) or 1)
+		local durFmt = GetPrecisionFormat((barSettings and barSettings.durationPrecision) or 1)
+		local nameVar = u.nameVar
+		local timeVar = u.timeVar
+		local remVar = u.remVar
+		local iconVar = u.iconVar
 
 		-- Default to empty, then fill. Never use `secret or ""` -- that tests the secret's truthiness,
 		-- which is blocked; only nil-checks (==/~= nil) and string.format are allowed on secrets.
@@ -1883,6 +1919,31 @@ local otherBarsSecretVars = {
 	["$gcdDuration"] = true, ["$gcdDurationRemaining"] = true,
 }
 
+---Renders a mirror timer's seconds as mm:ss. Minutes are not capped -- no mirror timer runs an hour,
+---but a longer one would read 61:xx rather than wrap silently.
+---@param seconds number
+---@return string
+local function FormatMinutesSeconds(seconds)
+	if seconds < 0 then
+		seconds = 0
+	end
+	local wholeSeconds = math.floor(seconds)
+	local minutes = math.floor(wholeSeconds / 60)
+	return string.format("%02d:%02d", minutes, wholeSeconds - (minutes * 60))
+end
+
+-- Per-bar "$<key>Duration"/"$<key>DurationRemaining" names, built once (the bar key set is static).
+local otherBarsVarNamesByKey = {}
+local function GetOtherBarsVarNames(barKey)
+	local names = otherBarsVarNamesByKey[barKey]
+	if names == nil then
+		local totalVar = "$" .. barKey .. "Duration"
+		names = { total = totalVar, remaining = totalVar .. "Remaining" }
+		otherBarsVarNamesByKey[barKey] = names
+	end
+	return names
+end
+
 ---Refreshes the Other Bars timer variables ($gcdDuration, $fatigueDurationRemaining, ...). An idle bar
 ---renders as an empty string, so a bare {$fatigueDurationRemaining}[...] gate shows nothing while the
 ---timer is down. Values are formatted with string.format, which is safe on a secret.
@@ -1894,23 +1955,15 @@ local otherBarsSecretVars = {
 ---conditionals still compare against a number rather than the display string.
 ---@param settings TRB.Classes.Settings.SpecializationSettingsBase?
 function TRB.Functions.BarText:RefreshOtherBarsLookupData(settings)
+	local isActive = TRB.Functions.OtherBars:HasActiveTimer()
+	if not isActive and not otherBarsLookupWasActive then
+		return
+	end
+	otherBarsLookupWasActive = isActive
 	TRB.Data.lookup = TRB.Data.lookup or {}
 	TRB.Data.lookupLogic = TRB.Data.lookupLogic or {}
 	local lookup = TRB.Data.lookup
 	local lookupLogic = TRB.Data.lookupLogic
-
-	---Renders a mirror timer's seconds as mm:ss. Minutes are not capped -- no mirror timer runs an hour,
-	---but a longer one would read 61:xx rather than wrap silently.
-	---@param seconds number
-	---@return string
-	local function FormatMinutesSeconds(seconds)
-		if seconds < 0 then
-			seconds = 0
-		end
-		local wholeSeconds = math.floor(seconds)
-		local minutes = math.floor(wholeSeconds / 60)
-		return string.format("%02d:%02d", minutes, wholeSeconds - (minutes * 60))
-	end
 
 	for _, entry in ipairs(TRB.Functions.OtherBars:GetBars()) do
 		local barKey = entry.key
@@ -1922,10 +1975,11 @@ function TRB.Functions.BarText:RefreshOtherBarsLookupData(settings)
 			-- Only the GCD carries durationPrecision; the mirror timers have no decimals to configure.
 			local fmt
 			if not isMirror then
-				fmt = "%." .. barSettings.durationPrecision .. "f"
+				fmt = GetPrecisionFormat(barSettings.durationPrecision)
 			end
-			local totalVar = "$" .. barKey .. "Duration"
-			local remVar = totalVar .. "Remaining"
+			local names = GetOtherBarsVarNames(barKey)
+			local totalVar = names.total
+			local remVar = names.remaining
 			local isSecret = otherBarsSecretVars[totalVar] == true
 
 			-- Default to empty, then fill. Never use `secret or ""` -- that tests the secret's truthiness,
@@ -2084,8 +2138,10 @@ end
 -- Previous tick's HasActiveSelfDrivenBarVariableInUse result, for detecting the tick a cast/timer ends on.
 local selfDrivenBarWasInUse = false
 
--- Reused per-call cache for GetBarTextFrame results (avoids redundant frame lookups)
-local showFrameCache = {}
+-- Reused per-call caches for GetBarTextFrame results, split into parallel maps so caching a
+-- frame's state allocates nothing. Presence is keyed on showFrameEnabled.
+local showFrameEnabled = {}
+local showFrameVisible = {}
 
 -- Reusable table for passing to GetReturnText (avoids per-entry table allocation)
 local barTextBuffer = { text = "", color = "" }
@@ -2151,7 +2207,8 @@ function TRB.Functions.BarText:UpdateResourceBarText(settings, refreshText)
 	--Only parse bar text if we need to refresh the text (or if there are Screen-bound entries)
 	if settings ~= nil and settings.displayText ~= nil then
 		-- Clear the per-call frame cache so entries get fresh visibility data
-		for k in pairs(showFrameCache) do showFrameCache[k] = nil end
+		wipe(showFrameEnabled)
+		wipe(showFrameVisible)
 
 		---@type Frame[]
 		local textFrames = TRB.Frames.textFrames
@@ -2188,16 +2245,16 @@ function TRB.Functions.BarText:UpdateResourceBarText(settings, refreshText)
 					-- Use per-call cache to avoid redundant GetBarTextFrame calls for entries sharing a frame
 					local frameKey = e.position.relativeToFrame
 					local isEnabled, isVisible
-					local cached = showFrameCache[frameKey]
-					if cached then
-						isEnabled = cached[1]
-						isVisible = cached[2]
+					if showFrameEnabled[frameKey] ~= nil then
+						isEnabled = showFrameEnabled[frameKey]
+						isVisible = showFrameVisible[frameKey]
 					else
 						_, isEnabled, isVisible = TRB.Functions.BarText:GetAnchorFrame(frameKey)
 						if isScreenText then
 							isVisible = true
 						end
-						showFrameCache[frameKey] = { isEnabled, isVisible }
+						showFrameEnabled[frameKey] = isEnabled == true
+						showFrameVisible[frameKey] = isVisible == true
 					end
 
 					local tfKey = GetTextFrameKey(i)
@@ -2591,8 +2648,8 @@ function TRB.Functions.BarText:Show(settings)
 	local entries = #displayText.barText
 	if entries > 0 then
 		-- Per-call cache: entries sharing the same relativeToFrame skip redundant GetBarTextFrame calls
-		local fCache = showFrameCache
-		for k in pairs(fCache) do fCache[k] = nil end
+		wipe(showFrameEnabled)
+		wipe(showFrameVisible)
 
 		local anyBecameVisible = false
 		local isTransition = TRB.Functions.Bar:IsRenderTransitionActive()
@@ -2600,16 +2657,16 @@ function TRB.Functions.BarText:Show(settings)
 			local e = displayText.barText[i]
 			local key = e.position.relativeToFrame
 			local isEnabled, isVisible
-			local cached = fCache[key]
-			if cached then
-				isEnabled = cached[1]
-				isVisible = cached[2]
+			if showFrameEnabled[key] ~= nil then
+				isEnabled = showFrameEnabled[key]
+				isVisible = showFrameVisible[key]
 			else
 				_, isEnabled, isVisible = TRB.Functions.BarText:GetAnchorFrame(key)
 				if key == "UIParent" then
 					isVisible = true
 				end
-				fCache[key] = { isEnabled, isVisible }
+				showFrameEnabled[key] = isEnabled == true
+				showFrameVisible[key] = isVisible == true
 			end
 
 			if e.enabled and isEnabled and isVisible and textFrames[i] ~= nil then

--- a/Functions/BarText.lua
+++ b/Functions/BarText.lua
@@ -2404,8 +2404,10 @@ function TRB.Functions.BarText:UpdateResourceBarText(settings, refreshText)
 							barTextEntryStates[i] = entryState
 						end
 						-- Empty frameCache.text means the frame was hidden or never written; the font
-						-- string may hold stale text, so bypass the unchanged-skip.
-						local forceWrite = visibilityRefresh or frameCache.text == nil or frameCache.text == ""
+						-- string may hold stale text, so bypass the unchanged-skip. Secret text cannot be
+						-- compared but is never empty (it carries the color prefix), so it never forces.
+						local prevText = frameCache.text
+						local forceWrite = visibilityRefresh or (not issecretvalue(prevText) and (prevText == nil or prevText == ""))
 						local renderOk, returnText = pcall(RenderBarTextEntry, entryState, e.text, colorCode, forceWrite)
 						if not renderOk then
 							-- Engine failure: fall back to the legacy resolver for this pass.
@@ -2414,7 +2416,7 @@ function TRB.Functions.BarText:UpdateResourceBarText(settings, refreshText)
 							returnText = GetReturnText(barTextBuffer)
 						end
 
-						if returnText ~= nil then
+						if issecretvalue(returnText) or returnText ~= nil then
 							if textFrames ~= nil and textFrames[i] ~= nil then
 								pcall(TryUpdateText, textFrames[i],  returnText)
 							else

--- a/Functions/BarText.lua
+++ b/Functions/BarText.lua
@@ -256,6 +256,12 @@ end
 -- Declared at file scope so ClearBarTextCacheHash and GetFromBarTextCache share the same upvalue.
 local barTextCacheHash = {}
 
+-- Branch-signature render engine state, declared here so ClearBarTextCacheHash can wipe it.
+-- Plans are keyed [entry text][conditional-outcome signature]; entry states hold each entry's
+-- last plan, color and argument values for the unchanged-skip.
+local barTextRenderPlans = {}
+local barTextEntryStates = {}
+
 ---Returns true if the value or color has changed for this key, indicating the
 ---formatted lookup string needs updating. Reuses existing prevState entries to
 ---avoid table allocation after initial warm-up.
@@ -306,6 +312,8 @@ end
 function TRB.Functions.BarText:ClearBarTextCacheHash()
 	-- The hash is a local upvalue; wipe it here where it's in scope
 	for k in pairs(barTextCacheHash) do barTextCacheHash[k] = nil end
+	wipe(barTextRenderPlans)
+	wipe(barTextEntryStates)
 end
 
 ---Scans all enabled bar text entries and builds a set of which $variable and #icon
@@ -1554,6 +1562,113 @@ local function GetReturnText(inputText)
 	return inputText.color .. inputText.text
 end
 
+-- Reusable buffer for building conditional-outcome signatures without allocation.
+local signatureBuffer = {}
+
+---Walks the tree evaluating only taken conditionals, appending one outcome char per node
+---("T"/"F"/"I") so the branch combination can key a cached render plan.
+---@param tree table
+---@param len integer Current signature buffer length
+---@return integer len
+local function AppendTreeSignature(tree, len)
+	if tree == nil or tree.barText == nil then
+		return len
+	end
+	local barText = tree.barText
+	for idx = 1, #barText do
+		local v = barText[idx]
+		if type(v) ~= "string" then
+			if v.compiledExpression == nil then
+				v.compiledExpression = CompileConditionalExpression(v)
+			end
+			local ce = v.compiledExpression
+			local outcome
+			if ce.invalid then
+				outcome = "I"
+			else
+				local args = ResolveConditionalValues(ce)
+				local ok, result = pcall(ce.fn, unpack(args, 1, ce.varCount))
+				if not ok then
+					outcome = "I"
+				elseif result == true or result then
+					outcome = "T"
+				else
+					outcome = "F"
+				end
+			end
+			len = len + 1
+			signatureBuffer[len] = outcome
+			if outcome == "T" then
+				len = AppendTreeSignature(v.trueResult, len)
+			elseif outcome == "F" and v.falseResult ~= nil then
+				len = AppendTreeSignature(v.falseResult, len)
+			end
+		end
+	end
+	return len
+end
+
+---Renders one bar text entry via the signature-keyed plan cache. Plans are built once by the
+---legacy resolver so their skeletons match it exactly; after that a tick only re-reads the
+---plan's variable values and skips the format entirely when nothing changed.
+---@param state table Per-entry state holding the last plan, color and argument values
+---@param text string The entry's raw bar text
+---@param colorCode string The "|cAARRGGBB" default color prefix
+---@param force boolean True bypasses the unchanged-skip
+---@return string|nil output The formatted text, or nil when unchanged and not forced
+local function RenderBarTextEntry(state, text, colorCode, force)
+	local tree = GetFromBarTextTreeCache(text)
+	local len = AppendTreeSignature(tree, 0)
+	local signature = len == 0 and "" or table.concat(signatureBuffer, "", 1, len)
+
+	local plans = barTextRenderPlans[text]
+	if plans == nil then
+		plans = {}
+		barTextRenderPlans[text] = plans
+	end
+	local plan = plans[signature]
+	if plan == nil then
+		plan = GetFromBarTextCache(RemoveInvalidVariablesFromBarText(tree))
+		plans[signature] = plan
+	end
+
+	local lookup = TRB.Data.lookup
+	lookup["color"] = colorCode
+
+	local vars = plan.variables
+	local varCount = #vars
+	local lastArgs = state.args
+	if lastArgs == nil then
+		lastArgs = {}
+		state.args = lastArgs
+	end
+
+	local changed = force or state.plan ~= plan or state.colorCode ~= colorCode
+	for i = 1, varCount do
+		local value = lookup[vars[i]]
+		if not changed and (issecretvalue(value) or issecretvalue(lastArgs[i]) or lastArgs[i] ~= value) then
+			changed = true
+		end
+		lastArgs[i] = value
+	end
+	if not changed then
+		return nil
+	end
+	state.plan = plan
+	state.colorCode = colorCode
+
+	local _
+	local outputText
+	if varCount > 0 then
+		_, outputText = pcall(string.format, plan.stringFormat, unpack(lastArgs, 1, varCount))
+	elseif string.len(plan.stringFormat) > 0 then
+		outputText = plan.stringFormat
+	else
+		outputText = ""
+	end
+	return colorCode .. outputText
+end
+
 ---Checks if any primary stat ratings are nil
 ---@return boolean
 local function ArePrimaryRatingsNil()
@@ -2282,22 +2397,36 @@ function TRB.Functions.BarText:UpdateResourceBarText(settings, refreshText)
 
 						color = color or "FFFFFFFF"
 
-						barTextBuffer.text = e.text
-						barTextBuffer.color = "|c" .. color
+						local colorCode = "|c" .. color
+						local entryState = barTextEntryStates[i]
+						if entryState == nil then
+							entryState = {}
+							barTextEntryStates[i] = entryState
+						end
+						-- Empty frameCache.text means the frame was hidden or never written; the font
+						-- string may hold stale text, so bypass the unchanged-skip.
+						local forceWrite = visibilityRefresh or frameCache.text == nil or frameCache.text == ""
+						local renderOk, returnText = pcall(RenderBarTextEntry, entryState, e.text, colorCode, forceWrite)
+						if not renderOk then
+							-- Engine failure: fall back to the legacy resolver for this pass.
+							barTextBuffer.text = e.text
+							barTextBuffer.color = colorCode
+							returnText = GetReturnText(barTextBuffer)
+						end
 
-						local returnText = GetReturnText(barTextBuffer)
-
-						if textFrames ~= nil and textFrames[i] ~= nil then
-							pcall(TryUpdateText, textFrames[i],  returnText)
-						else
-							-- Frame list is out of sync; rebuild and try once.
-							TRB.Functions.BarText:CreateBarTextFrames()
-							textFrames = TRB.Frames.textFrames
+						if returnText ~= nil then
 							if textFrames ~= nil and textFrames[i] ~= nil then
 								pcall(TryUpdateText, textFrames[i],  returnText)
+							else
+								-- Frame list is out of sync; rebuild and try once.
+								TRB.Functions.BarText:CreateBarTextFrames()
+								textFrames = TRB.Frames.textFrames
+								if textFrames ~= nil and textFrames[i] ~= nil then
+									pcall(TryUpdateText, textFrames[i],  returnText)
+								end
 							end
+							frameCache.text = returnText
 						end
-						frameCache.text = returnText
 					end
 					
 					if frameCache.level ~= TRB.Data.settings.core.strata.level then
@@ -2411,6 +2540,9 @@ function TRB.Functions.BarText:CreateBarTextFrames(classId, specId)
 	if classId ~= TRB.Data.character.classId or specId ~= TRB.Data.character.specId then
 		return
 	end
+
+	-- New font strings start empty; drop the unchanged-skip states so every entry rewrites.
+	wipe(barTextEntryStates)
 	
 	local className, specName = TRB.Functions.Character:GetClassAndSpecializationNames(classId, specId, true)
 	local compositeKey = TRB.Functions.Character:GetCompositeKey(className, specName)

--- a/Functions/BarText.lua
+++ b/Functions/BarText.lua
@@ -1584,7 +1584,8 @@ end
 local signatureBuffer = {}
 
 ---Walks the tree evaluating only taken conditionals, appending one outcome char per node
----("T"/"F"/"I") so the branch combination can key a cached render plan.
+---("T"/"F"/"I") so the branch combination can key a cached render plan. Outcomes must stay identical to
+---EmitTreeSignatureSource; "F" absorbs a missing falseResult because that is a static property of a node.
 ---@param tree table
 ---@param len integer Current signature buffer length
 ---@return integer len
@@ -1685,27 +1686,34 @@ local function EmitTreeSignatureSource(tree, out, preamble, indent, k)
 					out[#out + 1] = indent .. "local " .. rName .. " = (" .. inlined .. ")"
 					out[#out + 1] = indent .. "if " .. rName .. " then"
 				else
-					preamble[#preamble + 1] = "local e" .. k .. " = " .. exprSource
+					-- Hoisted names are indexed by preamble position, not by k: true/false subtrees
+					-- share slot numbers, and these all land in the same chunk-level scope.
+					local eName = "e" .. (#preamble + 1)
+					preamble[#preamble + 1] = "local " .. eName .. " = " .. exprSource
 					local callArgs = varCount > 0 and (", " .. table.concat(argNames, ", ")) or ""
-					out[#out + 1] = indent .. "local ok" .. k .. ", " .. rName .. " = pcall(e" .. k .. callArgs .. ")"
+					out[#out + 1] = indent .. "local ok" .. k .. ", " .. rName .. " = pcall(" .. eName .. callArgs .. ")"
 					out[#out + 1] = indent .. "if not ok" .. k .. " then"
 					out[#out + 1] = nextIndent .. "sig = sig + " .. addI
 					out[#out + 1] = indent .. "elseif " .. rName .. " then"
 				end
 				out[#out + 1] = nextIndent .. "sig = sig + " .. addT
-				k = EmitTreeSignatureSource(v.trueResult, out, preamble, nextIndent, k + 1)
-				if k == nil then
+				-- Branches are mutually exclusive and slot k already records which one ran, so both
+				-- subtrees start at k + 1 and the parent resumes past the deeper of the two.
+				local kTrue = EmitTreeSignatureSource(v.trueResult, out, preamble, nextIndent, k + 1)
+				if kTrue == nil then
 					return nil
 				end
 				out[#out + 1] = indent .. "else"
 				out[#out + 1] = nextIndent .. "sig = sig + " .. addF
+				local kFalse = k + 1
 				if v.falseResult ~= nil then
-					k = EmitTreeSignatureSource(v.falseResult, out, preamble, nextIndent, k)
-					if k == nil then
+					kFalse = EmitTreeSignatureSource(v.falseResult, out, preamble, nextIndent, k + 1)
+					if kFalse == nil then
 						return nil
 					end
 				end
 				out[#out + 1] = indent .. "end"
+				k = kTrue > kFalse and kTrue or kFalse
 			end
 		end
 	end

--- a/Functions/BarText.lua
+++ b/Functions/BarText.lua
@@ -1752,6 +1752,13 @@ end
 ---@return string|nil output The formatted text, or nil when unchanged and not forced
 local function RenderBarTextEntry(state, text, colorCode, force)
 	local signature
+	-- State is keyed by entry index but sigFn/plan are compiled from the text. Drop them when the
+	-- index changes text so the caches stay an optimization, not a correctness requirement.
+	if state.sigText ~= text then
+		state.sigFn = nil
+		state.plan = nil
+		state.sigText = text
+	end
 	local sigFn = state.sigFn
 	if sigFn == nil then
 		sigFn = barTextSignatureFns[text]
@@ -1865,6 +1872,9 @@ local targetCastbarLookupUnits = {
 local castbarLookupWasActive = true
 local targetCastbarLookupWasActive = true
 local otherBarsLookupWasActive = true
+-- The latches assume their idle writes are still present, but SwitchSpec replaces lookupLogic
+-- wholesale. Tracked here so RefreshLookupDataBase can re-arm them on a rebuild.
+local lastLookupLogicTable = nil
 
 ---Refreshes ONLY the castbar bar text lookup variables (cast/channel/empower) from the dedicated
 ---castbar model (TRB.Data.castbar) — deliberately independent of snapshotData.casting, which is the
@@ -2158,6 +2168,15 @@ function TRB.Functions.BarText:RefreshLookupDataBase(settings)
 	lookup["#casting"] = castingIcon
 
 	lookupLogic["$inCombat"] = tostring(TRB.Data.character.inCombat)
+
+	-- A spec change replaces lookupLogic wholesale, stranding the idle latches. Re-arm on identity
+	-- change rather than depending on SwitchSpec call order.
+	if TRB.Data.lookupLogic ~= lastLookupLogicTable then
+		lastLookupLogicTable = TRB.Data.lookupLogic
+		castbarLookupWasActive = true
+		targetCastbarLookupWasActive = true
+		otherBarsLookupWasActive = true
+	end
 
 	-- Castbar variables live in their own function so the isolated castbar bar text path can refresh
 	-- them independently of this class-driven (combat/isTracking-gated) refresh.

--- a/Functions/BarText.lua
+++ b/Functions/BarText.lua
@@ -262,6 +262,8 @@ local barTextCacheHash = {}
 local barTextRenderPlans = {}
 local barTextEntryStates = {}
 local barTextSignatureFns = {}
+-- Consecutive render throws before an entry gives up and stays on the legacy resolver.
+local maxEngineFailures = 3
 
 ---Returns true if the value or color has changed for this key, indicating the
 ---formatted lookup string needs updating. Reuses existing prevState entries to
@@ -2588,9 +2590,22 @@ function TRB.Functions.BarText:UpdateResourceBarText(settings, refreshText)
 						-- compared but is never empty (it carries the color prefix), so it never forces.
 						local prevText = frameCache.text
 						local forceWrite = visibilityRefresh or (not issecretvalue(prevText) and (prevText == nil or prevText == ""))
-						local renderOk, returnText = pcall(RenderBarTextEntry, entryState, e.text, colorCode, forceWrite)
+						-- An entry that keeps throwing latches to legacy so it stops paying for both paths
+						-- every tick; the latch clears whenever entry state is wiped.
+						local engineFailures = entryState.engineFailures or 0
+						if engineFailures > 0 and entryState.sigText ~= e.text then
+							engineFailures = 0
+						end
+						local renderOk, returnText = false, nil
+						if engineFailures < maxEngineFailures then
+							renderOk, returnText = pcall(RenderBarTextEntry, entryState, e.text, colorCode, forceWrite)
+							if not renderOk then
+								entryState.engineFailures = engineFailures + 1
+							elseif engineFailures > 0 then
+								entryState.engineFailures = nil
+							end
+						end
 						if not renderOk then
-							-- Engine failure: fall back to the legacy resolver for this pass.
 							barTextBuffer.text = e.text
 							barTextBuffer.color = colorCode
 							returnText = GetReturnText(barTextBuffer)

--- a/Functions/Character.lua
+++ b/Functions/Character.lua
@@ -24,6 +24,12 @@ local PowerTypeToToken = {
 	[Enum.PowerType.Essence] = "ESSENCE",
 }
 
+-- Reverse of PowerTypeToToken, for resolving event power tokens back to Enum values.
+local TokenToPowerType = {}
+for powerType, token in pairs(PowerTypeToToken) do
+	TokenToPowerType[token] = powerType
+end
+
 -- Cached format strings for resource/health percent formatting.
 -- Rebuilt only when the precision setting changes (spec switch / options edit).
 local cachedResourcePercentFmt = nil
@@ -157,6 +163,41 @@ function TRB.Functions.Character:UpdateResourceValues()
 	if TRB.Functions.BarVisibility.hasResourceCurve then
 		TRB.Functions.BarVisibility:MarkDirty()
 	end
+end
+
+---Reads and pre-formats an additional power's values (e.g. Shadow's mana) at event time,
+---so per-tick refreshers only read cached strings.
+---@param powerToken string # UNIT_POWER_UPDATE power token, e.g. "MANA"
+function TRB.Functions.Character:UpdateAdditionalPowerValues(powerToken)
+	local powerType = TokenToPowerType[powerToken]
+	if powerType == nil then
+		return
+	end
+	local formatted = TRB.Data.snapshotData.formatted
+	local store = formatted.additionalPower
+	if store == nil then
+		store = {}
+		formatted.additionalPower = store
+	end
+	local entry = store[powerToken]
+	if entry == nil then
+		entry = {}
+		store[powerToken] = entry
+	end
+
+	local precision = 1
+	local specEntry = TRB.Data.specCache and TRB.Data.character and TRB.Data.specCache[TRB.Data.character.compositeKey]
+	if specEntry and specEntry.settings and specEntry.settings.precision then
+		precision = specEntry.settings.precision.mana or 1
+	end
+
+	entry.current = UnitPower("player", powerType)
+	entry.max = UnitPowerMax("player", powerType)
+	entry.percent = UnitPowerPercent("player", powerType)
+	entry.currentFormatted = TRB.Functions.String:ConvertToAbbreviatedNumber(entry.current)
+	entry.maxFormatted = TRB.Functions.String:ConvertToAbbreviatedNumber(entry.max)
+	entry.percentFormatted = string.format("%." .. precision .. "f", UnitPowerPercent("player", powerType, false, CurveConstants.ScaleTo100))
+	entry.precision = precision
 end
 
 ---Reads the player's current health, max health, absorbs, and incoming heals from the WoW API, updates snapshotData.attributes, pre-formats display strings, and recalculates the health color curve.
@@ -374,12 +415,13 @@ local function CharacterChange(self, event, ...)
 		end
 	end
 
-	if event == "UNIT_POWER_UPDATE" or event == "UNIT_POWER_FREQUENT" then
+	if event == "UNIT_POWER_UPDATE" or event == "UNIT_POWER_FREQUENT" or event == "UNIT_MAXPOWER" then
 		local unitTarget, powerType = ...
 		if unitTarget == "player" and (powerType == TRB.Data.resourceToken or powerType == TRB.Data.resource2Token) then
 			TRB.Functions.Character:UpdateResourceValues()
 			TRB.Data.lookupDirty = true
 		elseif unitTarget == "player" and TRB.Data.additionalPowerTokens and TRB.Data.additionalPowerTokens[powerType] then
+			TRB.Functions.Character:UpdateAdditionalPowerValues(powerType)
 			if TRB.Functions.BarVisibility.hasResourceCurve then
 				TRB.Functions.BarVisibility:MarkDirty()
 			end
@@ -510,6 +552,7 @@ end
 function TRB.Functions.Character:EnableCharacterChange()
 	characterChangeFrame:RegisterUnitEvent("UNIT_POWER_UPDATE", "player")
 	characterChangeFrame:RegisterUnitEvent("UNIT_POWER_FREQUENT", "player")
+	characterChangeFrame:RegisterUnitEvent("UNIT_MAXPOWER", "player")
 	characterChangeFrame:RegisterUnitEvent("UNIT_HEALTH", "player")
 	characterChangeFrame:RegisterUnitEvent("UNIT_MAXHEALTH", "player")
 	characterChangeFrame:RegisterUnitEvent("UNIT_ABSORB_AMOUNT_CHANGED", "player")
@@ -542,6 +585,7 @@ end
 function TRB.Functions.Character:DisableCharacterChange()
 	characterChangeFrame:UnregisterEvent("UNIT_POWER_UPDATE")
 	characterChangeFrame:UnregisterEvent("UNIT_POWER_FREQUENT")
+	characterChangeFrame:UnregisterEvent("UNIT_MAXPOWER")
 	characterChangeFrame:UnregisterEvent("UNIT_HEALTH")
 	characterChangeFrame:UnregisterEvent("UNIT_MAXHEALTH")
 	characterChangeFrame:UnregisterEvent("UNIT_ABSORB_AMOUNT_CHANGED")

--- a/Functions/Character.lua
+++ b/Functions/Character.lua
@@ -165,10 +165,14 @@ function TRB.Functions.Character:UpdateResourceValues()
 	end
 end
 
+-- "%.Nf" strings memoized by precision so repeated reformats skip rebuilding them.
+local precisionFormatCache = {}
+
 ---Reads and pre-formats an additional power's values (e.g. Shadow's mana), so per-tick
 ---refreshers only read cached strings. Power events mark the entry dirty; the refresher pulls.
 ---@param powerToken string # UNIT_POWER_UPDATE power token, e.g. "MANA"
-function TRB.Functions.Character:UpdateAdditionalPowerValues(powerToken)
+---@param precision integer? # Decimal places for the percent string, defaults to 1
+function TRB.Functions.Character:UpdateAdditionalPowerValues(powerToken, precision)
 	local powerType = TokenToPowerType[powerToken]
 	if powerType == nil then
 		return
@@ -185,20 +189,35 @@ function TRB.Functions.Character:UpdateAdditionalPowerValues(powerToken)
 		store[powerToken] = entry
 	end
 
-	local precision = 1
-	local specEntry = TRB.Data.specCache and TRB.Data.character and TRB.Data.specCache[TRB.Data.character.compositeKey]
-	if specEntry and specEntry.settings and specEntry.settings.precision then
-		precision = specEntry.settings.precision.mana or 1
+	precision = precision or 1
+	local percentFormat = precisionFormatCache[precision]
+	if percentFormat == nil then
+		percentFormat = "%." .. precision .. "f"
+		precisionFormatCache[precision] = percentFormat
 	end
 
 	entry.current = UnitPower("player", powerType)
 	entry.max = UnitPowerMax("player", powerType)
+	-- The raw fraction feeds bar text conditionals; the display string wants it scaled to 100.
 	entry.percent = UnitPowerPercent("player", powerType)
 	entry.currentFormatted = TRB.Functions.String:ConvertToAbbreviatedNumber(entry.current)
 	entry.maxFormatted = TRB.Functions.String:ConvertToAbbreviatedNumber(entry.max)
-	entry.percentFormatted = string.format("%." .. precision .. "f", UnitPowerPercent("player", powerType, false, CurveConstants.ScaleTo100))
+	entry.percentFormatted = string.format(percentFormat, UnitPowerPercent("player", powerType, false, CurveConstants.ScaleTo100))
 	entry.precision = precision
 	entry.dirty = false
+end
+
+---Marks every cached additional power entry stale. Spec changes stop the events that would
+---otherwise mark them, so the next refresher pull must re-read rather than serve pre-swap values.
+function TRB.Functions.Character:InvalidateAdditionalPowerValues()
+	local store = TRB.Data.snapshotData and TRB.Data.snapshotData.formatted and TRB.Data.snapshotData.formatted.additionalPower
+	if store == nil then
+		return
+	end
+	---@diagnostic disable-next-line: param-type-mismatch
+	for _, entry in pairs(store) do
+		entry.dirty = true
+	end
 end
 
 ---Reads the player's current health, max health, absorbs, and incoming heals from the WoW API, updates snapshotData.attributes, pre-formats display strings, and recalculates the health color curve.
@@ -1988,6 +2007,9 @@ function TRB.Functions.Character:EventRegistration()
 	local timerFrame = TRB.Frames.timerFrame
 	local combatFrame = TRB.Frames.combatFrame
 	local barGroups = TRB.Frames.barGroups --[[@as { [string]: TRB.Classes.BarGroup }]]
+
+	-- Runs on every spec change, after the class module has set additionalPowerTokens.
+	TRB.Functions.Character:InvalidateAdditionalPowerValues()
 
 	if TRB.Data.specSupported then
 		local snapshotData = TRB.Data.snapshotData --[[@as TRB.Classes.SnapshotData]]

--- a/Functions/Character.lua
+++ b/Functions/Character.lua
@@ -452,6 +452,8 @@ local function CharacterChange(self, event, ...)
 			end
 			TRB.Data.lookupDirty = true
 		end
+	elseif event == "SPELL_UPDATE_USABLE" then
+		TRB.Classes.SpellBase.InvalidateSpellUsable()
 	elseif event == "UNIT_HEALTH" or event == "UNIT_MAXHEALTH" or event == "UNIT_ABSORB_AMOUNT_CHANGED" or event == "UNIT_HEAL_PREDICTION" or event == "UNIT_HEAL_ABSORB_AMOUNT_CHANGED" then
 		local unitTarget = ...
 		if unitTarget == "player" then
@@ -604,6 +606,7 @@ function TRB.Functions.Character:EnableCharacterChange()
 	characterChangeFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
 	characterChangeFrame:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
 	characterChangeFrame:RegisterEvent("TRAIT_CONFIG_UPDATED")
+	characterChangeFrame:RegisterEvent("SPELL_UPDATE_USABLE")
 end
 
 ---Unregisters all character-change events from the characterChangeFrame and stops flight polling.
@@ -637,6 +640,7 @@ function TRB.Functions.Character:DisableCharacterChange()
 	characterChangeFrame:UnregisterEvent("PLAYER_ENTERING_WORLD")
 	characterChangeFrame:UnregisterEvent("PLAYER_SPECIALIZATION_CHANGED")
 	characterChangeFrame:UnregisterEvent("TRAIT_CONFIG_UPDATED")
+	characterChangeFrame:UnregisterEvent("SPELL_UPDATE_USABLE")
 	TRB.Functions.Character:StopFlightPolling()
 end
 

--- a/Functions/Character.lua
+++ b/Functions/Character.lua
@@ -165,8 +165,8 @@ function TRB.Functions.Character:UpdateResourceValues()
 	end
 end
 
----Reads and pre-formats an additional power's values (e.g. Shadow's mana) at event time,
----so per-tick refreshers only read cached strings.
+---Reads and pre-formats an additional power's values (e.g. Shadow's mana), so per-tick
+---refreshers only read cached strings. Power events mark the entry dirty; the refresher pulls.
 ---@param powerToken string # UNIT_POWER_UPDATE power token, e.g. "MANA"
 function TRB.Functions.Character:UpdateAdditionalPowerValues(powerToken)
 	local powerType = TokenToPowerType[powerToken]
@@ -198,6 +198,7 @@ function TRB.Functions.Character:UpdateAdditionalPowerValues(powerToken)
 	entry.maxFormatted = TRB.Functions.String:ConvertToAbbreviatedNumber(entry.max)
 	entry.percentFormatted = string.format("%." .. precision .. "f", UnitPowerPercent("player", powerType, false, CurveConstants.ScaleTo100))
 	entry.precision = precision
+	entry.dirty = false
 end
 
 ---Reads the player's current health, max health, absorbs, and incoming heals from the WoW API, updates snapshotData.attributes, pre-formats display strings, and recalculates the health color curve.
@@ -421,7 +422,12 @@ local function CharacterChange(self, event, ...)
 			TRB.Functions.Character:UpdateResourceValues()
 			TRB.Data.lookupDirty = true
 		elseif unitTarget == "player" and TRB.Data.additionalPowerTokens and TRB.Data.additionalPowerTokens[powerType] then
-			TRB.Functions.Character:UpdateAdditionalPowerValues(powerType)
+			-- Mark only; the 20Hz refresher pulls the reformat, coalescing bursts and UPDATE/FREQUENT pairs.
+			local additionalPower = TRB.Data.snapshotData.formatted.additionalPower
+			local powerEntry = additionalPower and additionalPower[powerType]
+			if powerEntry ~= nil then
+				powerEntry.dirty = true
+			end
 			if TRB.Functions.BarVisibility.hasResourceCurve then
 				TRB.Functions.BarVisibility:MarkDirty()
 			end

--- a/Functions/News.lua
+++ b/Functions/News.lua
@@ -14,6 +14,9 @@ local content = [====[
 
 # 12.1.0.6-release (2026-08-24)
 ## General
+
+- Improve bar update performance, primarily around threshold lines and bar text.
+
 ### Cast Bars
 
 - Fix bar text blanking the moment a cast ended, leaving the Player, Target and Focus cast bars on screen with no text while they faded out. The bar text when the cast finishes now persists until the bar is gone.

--- a/Functions/News.lua
+++ b/Functions/News.lua
@@ -12,11 +12,15 @@ local content = [====[
 
 ---
 
-# 12.1.0.6-release (2026-08-24)
+# 12.1.0.7-release (2026-08-26)
 ## General
 
 - Improve bar update performance, primarily around threshold lines and bar text.
 
+---
+
+# 12.1.0.6-release (2026-08-24)
+## General
 ### Cast Bars
 
 - Fix bar text blanking the moment a cast ended, leaving the Player, Target and Focus cast bars on screen with no text while they faded out. The bar text when the cast finishes now persists until the bar is gone.

--- a/Functions/Threshold.lua
+++ b/Functions/Threshold.lua
@@ -2001,17 +2001,28 @@ function TRB.Functions.Threshold:HideInactiveCustomThresholdFrames(activeFrameKe
 	end
 end
 
+-- Reused per-tick scratch (HideInactiveCustomThresholdFrames only reads it) and the guid ->
+-- namespaced dictionary key memo (guids are stable strings).
+local activeFrameKeysScratch = {}
+local customThresholdKeyByGuid = {}
+
 ---@param settings TRB.Classes.Settings.SpecializationSettingsBase
 ---@param barGroups table<string, TRB.Classes.BarGroup>?
 function TRB.Functions.Threshold:UpdateCustomThresholdLines(settings, barGroups)
-	local activeFrameKeys = {}
+	local activeFrameKeys = activeFrameKeysScratch
+	wipe(activeFrameKeys)
 	if settings == nil or settings.thresholds == nil or settings.thresholds.customThresholds == nil or barGroups == nil then
 		TRB.Functions.Threshold:HideInactiveCustomThresholdFrames(activeFrameKeys)
 		return
 	end
 
 	for guid, customThreshold in pairs(settings.thresholds.customThresholds) do
-		local customThresholdKey = TRB.Functions.Settings:GetCustomThresholdDictionaryKey(customThreshold.guid or guid)
+		local rawGuid = customThreshold.guid or guid
+		local customThresholdKey = customThresholdKeyByGuid[rawGuid]
+		if customThresholdKey == nil then
+			customThresholdKey = TRB.Functions.Settings:GetCustomThresholdDictionaryKey(rawGuid)
+			customThresholdKeyByGuid[rawGuid] = customThresholdKey
+		end
 		local thresholdOverrides = settings.thresholds.thresholdDictionary and settings.thresholds.thresholdDictionary[customThresholdKey]
 		if thresholdOverrides ~= nil and thresholdOverrides.enabled == true then
 			local targetInfo = TRB.Functions.Threshold:GetCustomThresholdTargetInfo(settings, barGroups, customThreshold.barTarget or "primary")

--- a/TwintopInsanityBar.toc
+++ b/TwintopInsanityBar.toc
@@ -15,9 +15,9 @@
 ## Title-zhTW: Twintop 的資源欄
 ## Author: Twintop
 ## X-AuthorServer: Frostmourne-US/OCE
-## Version: 12.1.0.6
+## Version: 12.1.0.7
 ## X-ReleaseType: release
-## X-ReleaseDate: 2026-08-24
+## X-ReleaseDate: 2026-08-26
 ## SavedVariables: TwintopInsanityBarSettings
 ## IconTexture: 1386550
 ## DefaultState: enabled


### PR DESCRIPTION
Measured over 120s as Shadow while in combat (via Perfy): 
- CPU: -7.9% (2,083 → 1,919 ms)
- Memory: -26% (36.3 → 27.1 MB)

**Bar text render engine**
- Entry text now compiles once into a signature closure (inlined variable fetch, secret sanitize, branch dispatch)
- Render plans cache per branch combination, and unchanged entries skip formatting and SetText entirely. The interpreted path remains as fallback.

**Value production**
- Shadow, Balance, Elemental and Druid Unified mana strings move to power-event time with a dirty-flag pull, capped at the existing 20Hz tick.

**Table Allocations**
- Per-tick scratch tables reused across all class modules, bar text refreshers, and threshold lines.

**Other Fixes**
- `UpdateIsSpellUsable` no longer re-stamps its timestamp on cache hits (off-tick callers could starve the 20Hz check indefinitely)
- Bar text skip compares guard against secret strings
- `UNIT_MAXPOWER` now registered.